### PR TITLE
Fix for refreshing tasks

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,11 +80,27 @@ function registerExplorer(
 ): GradleTasksTreeDataProvider | undefined {
   if (workspace.workspaceFolders) {
     const treeDataProvider = new GradleTasksTreeDataProvider(context);
-    const view = window.createTreeView('gradle', {
-      treeDataProvider: treeDataProvider,
-      showCollapseAll: true
-    });
-    context.subscriptions.push(view);
+    treeDataProvider.refresh();
+    context.subscriptions.push(
+      window.createTreeView('gradle', {
+        treeDataProvider: treeDataProvider,
+        showCollapseAll: true
+      })
+    );
+    context.subscriptions.push(
+      commands.registerCommand(
+        'gradle.runTask',
+        treeDataProvider.runTask,
+        treeDataProvider
+      )
+    );
+    context.subscriptions.push(
+      commands.registerCommand(
+        'gradle.refresh',
+        treeDataProvider.refresh,
+        treeDataProvider
+      )
+    );
     return treeDataProvider;
   }
   return undefined;

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -153,12 +153,9 @@ export class GradleTasksTreeDataProvider implements TreeDataProvider<TreeItem> {
     invalidateTasksCache();
     enableTaskDetection();
     this.taskTree = null;
-    this.taskItemsPromise = tasks
-      .fetchTasks({ type: 'gradle' })
-      .then(taskItems => {
-        this._onDidChangeTreeData.fire();
-        return taskItems;
-      });
+    this.taskItemsPromise = tasks.fetchTasks({ type: 'gradle' });
+    this._onDidChangeTreeData.fire();
+    return this.taskItemsPromise;
   }
 
   getTreeItem(element: TreeItem): TreeItem {

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -131,38 +131,34 @@ class NoTasksTreeItem extends TreeItem {
 }
 
 export class GradleTasksTreeDataProvider implements TreeDataProvider<TreeItem> {
+  private taskItemsPromise: Thenable<Task[]> | undefined = undefined;
   private taskTree:
     | Folder[]
     | GradleTreeItem[]
     | NoTasksTreeItem[]
     | null = null;
-  private extensionContext: ExtensionContext;
   private _onDidChangeTreeData: EventEmitter<TreeItem | null> = new EventEmitter<TreeItem | null>();
   readonly onDidChangeTreeData: Event<TreeItem | null> = this
     ._onDidChangeTreeData.event;
 
-  constructor(context: ExtensionContext) {
-    this.extensionContext = context;
-    const subscriptions = context.subscriptions;
-    subscriptions.push(
-      commands.registerCommand('gradle.runTask', this.runTask, this)
-    );
-    subscriptions.push(
-      commands.registerCommand('gradle.refresh', this.refresh, this)
-    );
-  }
+  constructor(private readonly extensionContext: ExtensionContext) {}
 
-  private async runTask(taskItem: GradleTaskItem) {
+  runTask(taskItem: GradleTaskItem) {
     if (taskItem && taskItem.task) {
       tasks.executeTask(taskItem.task);
     }
   }
 
-  public refresh() {
+  refresh() {
     invalidateTasksCache();
     enableTaskDetection();
     this.taskTree = null;
-    this._onDidChangeTreeData.fire();
+    this.taskItemsPromise = tasks
+      .fetchTasks({ type: 'gradle' })
+      .then(taskItems => {
+        this._onDidChangeTreeData.fire();
+        return taskItems;
+      });
   }
 
   getTreeItem(element: TreeItem): TreeItem {
@@ -187,7 +183,7 @@ export class GradleTasksTreeDataProvider implements TreeDataProvider<TreeItem> {
 
   async getChildren(element?: TreeItem): Promise<TreeItem[]> {
     if (!this.taskTree) {
-      const taskItems = await tasks.fetchTasks({ type: 'gradle' });
+      const taskItems = await this.taskItemsPromise;
       if (taskItems) {
         this.taskTree = this.buildTaskTree(taskItems);
         if (this.taskTree.length === 0) {


### PR DESCRIPTION
Fixes https://github.com/badsyntax/vscode-gradle/issues/12

Previously we'd only get the tasks once the treeview was rendered. Now we explicitly refresh the tasks when the extension is activated.