### PR TITLE
Add support for git bash on Windows. Fixes #24

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         },
         "gradle.enableTasksExplorer": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable an explorer view for gradle tasks"
         },
         "gradle.tasksArgs": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,14 +12,14 @@ export function getIsAutoDetectionEnabled(folder: WorkspaceFolder): boolean {
   return (
     workspace
       .getConfiguration('gradle', folder.uri)
-      .get<AutoDetect>('autoDetect') === 'on'
+      .get<AutoDetect>('autoDetect', 'on') === 'on'
   );
 }
 
 export function getTasksArgs(folder: WorkspaceFolder): string {
   return workspace
     .getConfiguration('gradle', folder.uri)
-    .get<string>('tasksArgs', '');
+    .get<string>('tasksArgs', '--all');
 }
 
 export function getIsTasksExplorerEnabled(): boolean {

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -112,12 +112,12 @@ async function getGradleWrapperCommandFromFolder(
     platform === 'win32' &&
     (await exists(path.join(folder.uri.fsPath!, 'gradlew.bat')))
   ) {
-    return path.join(folder.uri.fsPath!, 'gradlew.bat');
+    return '.\\gradlew.bat';
   } else if (
     (platform === 'linux' || platform === 'darwin') &&
     (await exists(path.join(folder.uri.fsPath!, 'gradlew')))
   ) {
-    return path.join(folder.uri.fsPath!, 'gradlew');
+    return './gradlew';
   } else {
     throw new Error('Gradle wrapper executable not found');
   }
@@ -252,7 +252,7 @@ export function createTask(
     if (customBuildFile) {
       args.push('--build-file', customBuildFile);
     }
-    return `${command} ${args.join(' ')}`;
+    return `"${command}" ${args.join(' ')}`;
   }
 
   function getRelativePath(


### PR DESCRIPTION
See https://github.com/badsyntax/vscode-gradle/issues/24

I tested this on Windows 7 with the following vscode settings:

```json
{
    "terminal.integrated.shell.windows": "C:\\Program Files\\Git\\bin\\bash.exe"
}
```

I also tested on MacOS. Seems like a good change.