### PR TITLE
Use latest macOS version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,7 @@ jobs:
           npm test
 
   build-test-macos:
-    runs-on: macOS-10.14
+    runs-on: macOS-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
From email from GitHub: 

> Any jobs in your workflows that run on the `macos-10.14` virtual environment must migrate to `macos-latest`. Going forward, we will only support the `macos-latest` environment which will run Catalina (10.15). Once the migration to Catalina is complete, jobs using `macos-10.14` will no longer run.