### PR TITLE
Use different task type to prevent extension conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "views": {
       "explorer": [
         {
-          "id": "gradle",
+          "id": "gradle-tree-view",
           "name": "Gradle Tasks",
           "when": "gradle:showTasksExplorer"
         }
@@ -140,7 +140,6 @@
         "gradle.explorerNestedSubProjects": {
           "type": "boolean",
           "default": true,
-          "scope": "resource",
           "description": "Show nested sub-projects in the explorer"
         }
       }
@@ -153,9 +152,10 @@
     ],
     "taskDefinitions": [
       {
-        "type": "gradle",
+        "type": "richardwillis.gradle",
         "required": [
-          "task"
+          "task",
+          "buildFile"
         ],
         "properties": {
           "task": {

--- a/package.json
+++ b/package.json
@@ -94,14 +94,14 @@
       "view/title": [
         {
           "command": "gradle.refresh",
-          "when": "view == gradle",
+          "when": "view == gradle-tree-view",
           "group": "navigation"
         }
       ],
       "view/item/context": [
         {
           "command": "gradle.runTask",
-          "when": "view == gradle && viewItem == task"
+          "when": "view == gradle-tree-view && viewItem == task"
         }
       ]
     },

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,35 +1,37 @@
-import { workspace, WorkspaceFolder, Uri } from 'vscode';
+import * as vscode from 'vscode';
 
 type AutoDetect = 'on' | 'off';
 
-export function getCustomBuildFile(uri: Uri): string {
-  return workspace
+export function getCustomBuildFile(uri: vscode.Uri): string {
+  return vscode.workspace
     .getConfiguration('gradle', uri)
     .get<string>('customBuildFile', '');
 }
 
-export function getIsAutoDetectionEnabled(folder: WorkspaceFolder): boolean {
+export function getIsAutoDetectionEnabled(
+  folder: vscode.WorkspaceFolder
+): boolean {
   return (
-    workspace
+    vscode.workspace
       .getConfiguration('gradle', folder.uri)
       .get<AutoDetect>('autoDetect', 'on') === 'on'
   );
 }
 
-export function getTasksArgs(folder: WorkspaceFolder): string {
-  return workspace
+export function getTasksArgs(folder: vscode.WorkspaceFolder): string {
+  return vscode.workspace
     .getConfiguration('gradle', folder.uri)
     .get<string>('tasksArgs', '--all');
 }
 
 export function getIsTasksExplorerEnabled(): boolean {
-  return workspace
+  return vscode.workspace
     .getConfiguration('gradle')
     .get<boolean>('enableTasksExplorer', true);
 }
 
 export function getHasExplorerNestedSubProjects(): boolean {
-  return workspace
+  return vscode.workspace
     .getConfiguration('gradle')
     .get<boolean>('explorerNestedSubProjects', true);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,4 @@
-import {
-  window,
-  workspace,
-  commands,
-  ExtensionContext,
-  Disposable,
-  TaskProvider,
-  StatusBarAlignment,
-  OutputChannel
-} from 'vscode';
+import * as vscode from 'vscode';
 import { GradleTasksTreeDataProvider } from './gradleView';
 import {
   invalidateTasksCache,
@@ -20,9 +11,9 @@ import { getCustomBuildFile, getIsTasksExplorerEnabled } from './config';
 let treeDataProvider: GradleTasksTreeDataProvider | undefined;
 
 function registerTaskProvider(
-  context: ExtensionContext,
-  outputChannel: OutputChannel
-): Disposable | undefined {
+  context: vscode.ExtensionContext,
+  outputChannel: vscode.OutputChannel
+): vscode.Disposable | undefined {
   function invalidateTaskCaches() {
     invalidateTasksCache();
     if (treeDataProvider) {
@@ -30,11 +21,11 @@ function registerTaskProvider(
     }
   }
 
-  if (workspace.workspaceFolders) {
+  if (vscode.workspace.workspaceFolders) {
     const defaultGroovyBuildFile = 'build.gradle';
     const defaultKotlinBuildFile = 'build.gradle.kts';
     const buildFiles = new Set<string>();
-    for (const folder of workspace.workspaceFolders) {
+    for (const folder of vscode.workspace.workspaceFolders) {
       const customBuildFile = getCustomBuildFile(folder.uri);
       if (customBuildFile) {
         buildFiles.add(customBuildFile);
@@ -45,25 +36,28 @@ function registerTaskProvider(
     }
 
     const buildFileGlob = `**/{${Array.from(buildFiles).join(',')}}`;
-    const watcher = workspace.createFileSystemWatcher(buildFileGlob);
+    const watcher = vscode.workspace.createFileSystemWatcher(buildFileGlob);
     watcher.onDidChange(() => invalidateTaskCaches());
     watcher.onDidDelete(() => invalidateTaskCaches());
     watcher.onDidCreate(() => invalidateTaskCaches());
 
-    const workspaceWatcher = workspace.onDidChangeWorkspaceFolders(() =>
+    const workspaceWatcher = vscode.workspace.onDidChangeWorkspaceFolders(() =>
       invalidateTaskCaches()
     );
 
-    const statusBarItem = window.createStatusBarItem(
-      StatusBarAlignment.Left,
+    const statusBarItem = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left,
       1
     );
 
-    const provider: TaskProvider = new GradleTaskProvider(
+    const provider: vscode.TaskProvider = new GradleTaskProvider(
       statusBarItem,
       outputChannel
     );
-    const taskProvider = workspace.registerTaskProvider('gradle', provider);
+    const taskProvider = vscode.tasks.registerTaskProvider(
+      'richardwillis.gradle',
+      provider
+    );
 
     context.subscriptions.push(watcher);
     context.subscriptions.push(workspaceWatcher);
@@ -75,12 +69,12 @@ function registerTaskProvider(
 }
 
 function registerExplorer(
-  context: ExtensionContext
+  context: vscode.ExtensionContext
 ): GradleTasksTreeDataProvider | undefined {
-  if (workspace.workspaceFolders) {
+  if (vscode.workspace.workspaceFolders) {
     const treeDataProvider = new GradleTasksTreeDataProvider(context);
     context.subscriptions.push(
-      window.createTreeView('gradle-tree-view', {
+      vscode.window.createTreeView('gradle-tree-view', {
         treeDataProvider: treeDataProvider,
         showCollapseAll: true
       })
@@ -91,19 +85,19 @@ function registerExplorer(
 }
 
 function registerCommands(
-  context: ExtensionContext,
+  context: vscode.ExtensionContext,
   treeDataProvider: GradleTasksTreeDataProvider | undefined
 ) {
   if (treeDataProvider) {
     context.subscriptions.push(
-      commands.registerCommand(
+      vscode.commands.registerCommand(
         'gradle.runTask',
         treeDataProvider.runTask,
         treeDataProvider
       )
     );
     context.subscriptions.push(
-      commands.registerCommand(
+      vscode.commands.registerCommand(
         'gradle.refresh',
         treeDataProvider.refresh,
         treeDataProvider
@@ -113,23 +107,27 @@ function registerCommands(
 }
 
 export interface ExtensionApi {
-  outputChannel: OutputChannel;
+  outputChannel: vscode.OutputChannel;
 }
 
 export async function activate(
-  context: ExtensionContext
+  context: vscode.ExtensionContext
 ): Promise<ExtensionApi> {
-  const outputChannel = window.createOutputChannel('Gradle Tasks');
+  const outputChannel = vscode.window.createOutputChannel('Gradle Tasks');
   context.subscriptions.push(outputChannel);
+  registerTaskProvider(context, outputChannel);
   if (await hasGradleBuildFile()) {
-    registerTaskProvider(context, outputChannel);
     treeDataProvider = registerExplorer(context);
     registerCommands(context, treeDataProvider);
     if (treeDataProvider) {
       treeDataProvider.refresh();
     }
     if (getIsTasksExplorerEnabled()) {
-      commands.executeCommand('setContext', 'gradle:showTasksExplorer', true);
+      vscode.commands.executeCommand(
+        'setContext',
+        'gradle:showTasksExplorer',
+        true
+      );
     }
   }
   return { outputChannel };

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -145,7 +145,7 @@ class NoTasksTreeItem extends TreeItem {
 }
 
 export class GradleTasksTreeDataProvider implements TreeDataProvider<TreeItem> {
-  private taskItemsPromise: Thenable<Task[]> | undefined = undefined;
+  private taskItemsPromise: Thenable<Task[]> = Promise.resolve([]);
   private taskTree:
     | WorkspaceTreeItem[]
     | GradleBuildFileTreeItem[]
@@ -163,14 +163,16 @@ export class GradleTasksTreeDataProvider implements TreeDataProvider<TreeItem> {
     }
   }
 
-  refresh() {
+  refresh(): Thenable<Task[]> {
     invalidateTasksCache();
     enableTaskDetection();
     this.taskTree = null;
-    this.taskItemsPromise = tasks
-      .fetchTasks({ type: 'gradle' })
-      .then((tasks = []) => tasks.filter(task => task.source === 'gradle'));
-    this._onDidChangeTreeData.fire();
+    this.taskItemsPromise = tasks.fetchTasks().then((tasks = []) => {
+      this._onDidChangeTreeData.fire();
+      return tasks.filter(
+        task => task.definition.type === 'richardwillis.gradle'
+      );
+    });
     return this.taskItemsPromise;
   }
 

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -1,17 +1,5 @@
 import * as path from 'path';
-import {
-  Event,
-  EventEmitter,
-  ExtensionContext,
-  ThemeIcon,
-  TreeDataProvider,
-  TreeItem,
-  Task,
-  TreeItemCollapsibleState,
-  Uri,
-  WorkspaceFolder,
-  tasks
-} from 'vscode';
+import * as vscode from 'vscode';
 
 import {
   GradleTaskDefinition,
@@ -22,16 +10,16 @@ import {
 
 import { getHasExplorerNestedSubProjects } from './config';
 
-class WorkspaceTreeItem extends TreeItem {
+class WorkspaceTreeItem extends vscode.TreeItem {
   buildFileTreeItems: GradleBuildFileTreeItem[] = [];
-  workspaceFolder: WorkspaceFolder;
+  workspaceFolder: vscode.WorkspaceFolder;
 
-  constructor(name: string, folder: WorkspaceFolder) {
-    super(name, TreeItemCollapsibleState.Expanded);
+  constructor(name: string, folder: vscode.WorkspaceFolder) {
+    super(name, vscode.TreeItemCollapsibleState.Expanded);
     this.contextValue = 'folder';
     this.resourceUri = folder.uri;
     this.workspaceFolder = folder;
-    this.iconPath = ThemeIcon.Folder;
+    this.iconPath = vscode.ThemeIcon.Folder;
   }
 
   addGradleBuildFileTreeItem(buildGradle: GradleBuildFileTreeItem) {
@@ -39,7 +27,7 @@ class WorkspaceTreeItem extends TreeItem {
   }
 }
 
-class GradleTasksFolderTreeItem extends TreeItem {
+class GradleTasksFolderTreeItem extends vscode.TreeItem {
   tasks: GradleTaskTreeItem[] = [];
   workspaceTreeItem: WorkspaceTreeItem;
   path: string;
@@ -49,7 +37,7 @@ class GradleTasksFolderTreeItem extends TreeItem {
     relativePath: string,
     name: string
   ) {
-    super(name, TreeItemCollapsibleState.Expanded);
+    super(name, vscode.TreeItemCollapsibleState.Expanded);
     this.workspaceTreeItem = workspaceTreeItem;
     this.path = relativePath;
     this.contextValue = name;
@@ -81,13 +69,15 @@ class GradleBuildFileTreeItem extends GradleTasksFolderTreeItem {
       GradleBuildFileTreeItem.getLabel(folder.label!, relativePath, name)
     );
     if (relativePath) {
-      this.resourceUri = Uri.file(
+      this.resourceUri = vscode.Uri.file(
         path.join(folder!.resourceUri!.fsPath, relativePath, name)
       );
     } else {
-      this.resourceUri = Uri.file(path.join(folder!.resourceUri!.fsPath, name));
+      this.resourceUri = vscode.Uri.file(
+        path.join(folder!.resourceUri!.fsPath, name)
+      );
     }
-    this.iconPath = ThemeIcon.File;
+    this.iconPath = vscode.ThemeIcon.File;
   }
 
   addSubProjectTreeItem(subProject: SubProjectTreeItem) {
@@ -99,17 +89,17 @@ class SubProjectTreeItem extends WorkspaceTreeItem {}
 
 type ExplorerCommands = 'run';
 
-class GradleTaskTreeItem extends TreeItem {
-  task: Task;
+class GradleTaskTreeItem extends vscode.TreeItem {
+  task: vscode.Task;
   folderTreeItem: GradleTasksFolderTreeItem;
 
   constructor(
-    context: ExtensionContext,
+    context: vscode.ExtensionContext,
     folderTreeItem: GradleTasksFolderTreeItem,
-    task: Task,
+    task: vscode.Task,
     label: string
   ) {
-    super(label, TreeItemCollapsibleState.None);
+    super(label, vscode.TreeItemCollapsibleState.None);
     const command: ExplorerCommands = 'run';
 
     const commandList = {
@@ -132,55 +122,56 @@ class GradleTaskTreeItem extends TreeItem {
     };
   }
 
-  getFolder(): WorkspaceFolder {
+  getFolder(): vscode.WorkspaceFolder {
     return this.folderTreeItem.workspaceTreeItem.workspaceFolder;
   }
 }
 
-class NoTasksTreeItem extends TreeItem {
+class NoTasksTreeItem extends vscode.TreeItem {
   constructor() {
-    super('No tasks found', TreeItemCollapsibleState.None);
+    super('No tasks found', vscode.TreeItemCollapsibleState.None);
     this.contextValue = 'notasks';
   }
 }
 
-export class GradleTasksTreeDataProvider implements TreeDataProvider<TreeItem> {
-  private taskItemsPromise: Thenable<Task[]> = Promise.resolve([]);
+export class GradleTasksTreeDataProvider
+  implements vscode.TreeDataProvider<vscode.TreeItem> {
+  private taskItemsPromise: Thenable<vscode.Task[]> = Promise.resolve([]);
   private taskTree:
     | WorkspaceTreeItem[]
     | GradleBuildFileTreeItem[]
     | NoTasksTreeItem[]
     | null = null;
-  private _onDidChangeTreeData: EventEmitter<TreeItem | null> = new EventEmitter<TreeItem | null>();
-  readonly onDidChangeTreeData: Event<TreeItem | null> = this
+  private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | null> = new vscode.EventEmitter<vscode.TreeItem | null>();
+  readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | null> = this
     ._onDidChangeTreeData.event;
 
-  constructor(private readonly extensionContext: ExtensionContext) {}
+  constructor(private readonly extensionContext: vscode.ExtensionContext) {}
 
   runTask(taskItem: GradleTaskTreeItem) {
     if (taskItem && taskItem.task) {
-      tasks.executeTask(taskItem.task);
+      vscode.tasks.executeTask(taskItem.task);
     }
   }
 
-  refresh(): Thenable<Task[]> {
+  refresh(): Thenable<vscode.Task[]> {
     invalidateTasksCache();
     enableTaskDetection();
     this.taskTree = null;
-    this.taskItemsPromise = tasks.fetchTasks().then((tasks = []) => {
-      this._onDidChangeTreeData.fire();
-      return tasks.filter(
-        task => task.definition.type === 'richardwillis.gradle'
-      );
-    });
+    this.taskItemsPromise = vscode.tasks
+      .fetchTasks({ type: 'richardwillis.gradle' })
+      .then((tasks = []) => {
+        this._onDidChangeTreeData.fire();
+        return tasks;
+      });
     return this.taskItemsPromise;
   }
 
-  getTreeItem(element: TreeItem): TreeItem {
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
     return element;
   }
 
-  getParent(element: TreeItem): TreeItem | null {
+  getParent(element: vscode.TreeItem): vscode.TreeItem | null {
     if (element instanceof WorkspaceTreeItem) {
       return null;
     }
@@ -196,7 +187,7 @@ export class GradleTasksTreeDataProvider implements TreeDataProvider<TreeItem> {
     return null;
   }
 
-  async getChildren(element?: TreeItem): Promise<TreeItem[]> {
+  async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
     if (!this.taskTree) {
       const taskItems = await this.taskItemsPromise;
       if (taskItems) {
@@ -230,7 +221,7 @@ export class GradleTasksTreeDataProvider implements TreeDataProvider<TreeItem> {
   }
 
   private buildTaskTree(
-    tasks: Task[]
+    tasks: vscode.Task[]
   ): WorkspaceTreeItem[] | GradleBuildFileTreeItem[] | NoTasksTreeItem[] {
     const workspaceTreeItems: Map<String, WorkspaceTreeItem> = new Map();
     const subProjectTreeItems: Map<String, SubProjectTreeItem> = new Map();

--- a/src/test/gradle/extension.test.ts
+++ b/src/test/gradle/extension.test.ts
@@ -38,10 +38,10 @@ describe(fixtureName, () => {
     let tasks: vscode.Task[];
 
     beforeEach(async () => {
-      tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
+      tasks = await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' });
     });
 
-    it('should load tasks', async () => {
+    it('should load tasks', () => {
       assert.equal(tasks.length > 0, true);
     });
 
@@ -57,9 +57,9 @@ describe(fixtureName, () => {
 
     it('should refresh tasks', async () => {
       await vscode.commands.executeCommand('gradle.refresh');
-      const task = (await vscode.tasks.fetchTasks({ type: 'gradle' })).find(
-        task => task.name === 'hello'
-      );
+      const task = (
+        await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' })
+      ).find(task => task.name === 'hello');
       assert.ok(task);
     });
   });

--- a/src/test/multi-project/extension.test.ts
+++ b/src/test/multi-project/extension.test.ts
@@ -28,7 +28,7 @@ describe(fixtureName, () => {
     let tasks: vscode.Task[];
 
     beforeEach(async () => {
-      tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
+      tasks = await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' });
     });
 
     it('should load tasks', async () => {

--- a/src/test/multi-root/extension.test.ts
+++ b/src/test/multi-root/extension.test.ts
@@ -23,7 +23,7 @@ describe(fixtureName, () => {
       let tasks: vscode.Task[];
 
       beforeEach(async () => {
-        tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
+        tasks = await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' });
       });
 
       it('should load groovy default build file tasks', () => {
@@ -71,9 +71,9 @@ describe(fixtureName, () => {
 
       it('should refresh tasks', async () => {
         await vscode.commands.executeCommand('gradle.refresh');
-        const task = (await vscode.tasks.fetchTasks({ type: 'gradle' })).find(
-          task => task.name === 'hello'
-        );
+        const task = (
+          await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' })
+        ).find(task => task.name === 'hello');
         assert.ok(task);
       });
     });

--- a/src/test/no-gradle/extension.test.ts
+++ b/src/test/no-gradle/extension.test.ts
@@ -12,7 +12,9 @@ describe('without any build file or local gradle wrapper', () => {
     );
     if (extension) {
       assert.equal(extension.isActive, false);
-      const tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
+      const tasks = await vscode.tasks.fetchTasks({
+        type: 'richardwillis.gradle'
+      });
       assert.equal(tasks.length === 0, true);
     }
   });


### PR DESCRIPTION
In addition, prevent multiple refresh processes and improve code readability.

Problem:

If I keep the task type "gradle", then the extension will successfully provide the tasks, but the task definitions will be the ones defined by the [`Tasks Explorer`](https://github.com/spmeesseman/vscode-taskexplorer/blob/1a9491797a8be1eae29519b041320c96c2573684/package.json#L772) extension, and will only contain default fields. I assume this is because both extensions [provide tasks for the "gradle" task type](https://github.com/spmeesseman/vscode-taskexplorer/blob/d059ae9320c5180a8efc810327bc8e2f770b5be1/src/extension.ts#L328) and there's some form of conflict.

The changes in this PR provide compatibility between the extensions by namespacing this extension to provide tasks for the "richardwillis.gradle" task type. It's not ideal, i'm thinking it might be better if the `Tasks Explorer` extensions fixes this, as I want this extension to provide tasks for the "gradle" task type.

----

Fixes #37 

I am undecided if I like this approach, as the provider is now called `richardwillis.gradle` and it looks a little weird in the UI when it says "the richardwillis.gradle tasks provider".

## Screenshots

As you can see below, the `Gradle Tasks` extension will now work with the `Tasks Explorer` extension. You will also see the `Task Explorer` is showing duplicated `Gradle` groups. This is because both the `Gradle Tasks` and `Tasks Explorer` extensions provide tasks of source `gradle`. 

It is up to the author of `Task Explorer` to improve this. 

<img width="429" alt="Screenshot 2019-11-13 at 13 51 29" src="https://user-images.githubusercontent.com/102141/68765500-328ad900-061d-11ea-90d4-8770ddd73b32.png">
