### PR TITLE
Add namespace to task name

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     ],
     "taskDefinitions": [
       {
-        "type": "gradle",
+        "type": "richardwillis.gradle",
         "required": [
           "task",
           "buildFile"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,10 @@ function registerTaskProvider(
       statusBarItem,
       outputChannel
     );
-    const taskProvider = vscode.tasks.registerTaskProvider('gradle', provider);
+    const taskProvider = vscode.tasks.registerTaskProvider(
+      'richardwillis.gradle',
+      provider
+    );
 
     context.subscriptions.push(watcher);
     context.subscriptions.push(workspaceWatcher);

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -159,7 +159,7 @@ export class GradleTasksTreeDataProvider
     enableTaskDetection();
     this.taskTree = null;
     this.taskItemsPromise = vscode.tasks
-      .fetchTasks({ type: 'gradle' })
+      .fetchTasks({ type: 'richardwillis.gradle' })
       .then((tasks = []) => {
         this._onDidChangeTreeData.fire();
         return tasks;

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -226,7 +226,7 @@ export async function createTask(
     }
 
     definition = {
-      type: 'gradle',
+      type: 'richardwillis.gradle',
       task: taskDefinitionOrTaskName,
       buildFile: path.basename(gradleBuildFileUri.fsPath),
       subProjectBuildFile

--- a/src/test/gradle/extension.test.ts
+++ b/src/test/gradle/extension.test.ts
@@ -38,7 +38,7 @@ describe(fixtureName, () => {
     let tasks: vscode.Task[];
 
     beforeEach(async () => {
-      tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
+      tasks = await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' });
     });
 
     it('should load tasks', () => {
@@ -57,9 +57,9 @@ describe(fixtureName, () => {
 
     it('should refresh tasks', async () => {
       await vscode.commands.executeCommand('gradle.refresh');
-      const task = (await vscode.tasks.fetchTasks({ type: 'gradle' })).find(
-        task => task.name === 'hello'
-      );
+      const task = (
+        await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' })
+      ).find(task => task.name === 'hello');
       assert.ok(task);
     });
   });

--- a/src/test/multi-project/extension.test.ts
+++ b/src/test/multi-project/extension.test.ts
@@ -28,7 +28,7 @@ describe(fixtureName, () => {
     let tasks: vscode.Task[];
 
     beforeEach(async () => {
-      tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
+      tasks = await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' });
     });
 
     it('should load tasks', async () => {

--- a/src/test/multi-root/extension.test.ts
+++ b/src/test/multi-root/extension.test.ts
@@ -23,7 +23,7 @@ describe(fixtureName, () => {
       let tasks: vscode.Task[];
 
       beforeEach(async () => {
-        tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
+        tasks = await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' });
       });
 
       it('should load groovy default build file tasks', () => {
@@ -71,9 +71,9 @@ describe(fixtureName, () => {
 
       it('should refresh tasks', async () => {
         await vscode.commands.executeCommand('gradle.refresh');
-        const task = (await vscode.tasks.fetchTasks({ type: 'gradle' })).find(
-          task => task.name === 'hello'
-        );
+        const task = (
+          await vscode.tasks.fetchTasks({ type: 'richardwillis.gradle' })
+        ).find(task => task.name === 'hello');
         assert.ok(task);
       });
     });

--- a/src/test/no-gradle/extension.test.ts
+++ b/src/test/no-gradle/extension.test.ts
@@ -13,7 +13,7 @@ describe('without any build file or local gradle wrapper', () => {
     if (extension) {
       assert.equal(extension.isActive, false);
       const tasks = await vscode.tasks.fetchTasks({
-        type: 'gradle'
+        type: 'richardwillis.gradle'
       });
       assert.equal(tasks.length === 0, true);
     }


### PR DESCRIPTION
Problem:

If I keep the task type "gradle", then the extension will successfully provide the tasks, but the task definitions will be the ones defined by the [`Tasks Explorer`](https://github.com/spmeesseman/vscode-taskexplorer/blob/1a9491797a8be1eae29519b041320c96c2573684/package.json#L772) extension, and will only contain default fields. I assume this is because both extensions [provide tasks for the "gradle" task type](https://github.com/spmeesseman/vscode-taskexplorer/blob/d059ae9320c5180a8efc810327bc8e2f770b5be1/src/extension.ts#L328) and there's some form of conflict.

The changes in this PR provide compatibility between the extensions by namespacing this extension to provide tasks for the "richardwillis.gradle" task type. It's not ideal, i'm thinking it might be better if the `Tasks Explorer` extensions fixes this, as I want this extension to provide tasks for the "gradle" task type.

----

Fixes #37 

I am undecided if I like this approach, as the provider is now called `richardwillis.gradle` and it looks a little weird in the UI when it says "the richardwillis.gradle tasks provider".

## Screenshots

As you can see below, the `Gradle Tasks` extension will now work with the `Tasks Explorer` extension. You will also see the `Task Explorer` is showing duplicated `Gradle` groups. This is because both the `Gradle Tasks` and `Tasks Explorer` extensions provide tasks of source `gradle`. 

It is up to the author of `Task Explorer` to improve this. 

<img width="429" alt="Screenshot 2019-11-13 at 13 51 29" src="https://user-images.githubusercontent.com/102141/68765500-328ad900-061d-11ea-90d4-8770ddd73b32.png">
