### PR TITLE
Change task definition for better extension support

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,21 +162,17 @@
       {
         "type": "gradle",
         "required": [
-          "task",
-          "buildFile"
+          "script",
+          "fileName"
         ],
         "properties": {
-          "task": {
+          "script": {
             "type": "string",
-            "description": "Gradle task name"
+            "description": "The task script name"
           },
-          "buildFile": {
+          "fileName": {
             "type": "string",
-            "description": "The build file that provides the task"
-          },
-          "subProjectBuildFile": {
-            "type": "string",
-            "description": "The subproject build file that provides the task"
+            "description": "The filename of the build file that provides the tasks"
           }
         }
       }

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -248,13 +248,13 @@ export class GradleTasksTreeDataProvider
           buildFileTreeItem = new GradleBuildFileTreeItem(
             workspaceTreeItem,
             relativePath,
-            definition.buildFile
+            definition.fileName
           );
           workspaceTreeItem.addGradleBuildFileTreeItem(buildFileTreeItem);
           buildFileTreeItems.set(fullPath, buildFileTreeItem);
         }
-        if (showNestedSubProjects && definition.subProjectBuildFile) {
-          const [subProjectName] = task.definition.task.split(':');
+        if (showNestedSubProjects && definition.script.includes(':')) {
+          const [subProjectName] = definition.script.split(':');
           let subProjectTreeItem = subProjectTreeItems.get(subProjectName);
           if (!subProjectTreeItem) {
             subProjectTreeItem = new SubProjectTreeItem(
@@ -272,7 +272,7 @@ export class GradleTasksTreeDataProvider
             subProjectBuildFileTreeItem = new GradleBuildFileTreeItem(
               workspaceTreeItem,
               relativePath,
-              path.basename(definition.subProjectBuildFile)
+              definition.fileName
             );
             subProjectTreeItem.addGradleBuildFileTreeItem(
               subProjectBuildFileTreeItem

--- a/src/test/multi-root/extension.test.ts
+++ b/src/test/multi-root/extension.test.ts
@@ -32,7 +32,7 @@ describe(fixtureName, () => {
         );
         assert.ok(groovyDefaultTask);
         if (groovyDefaultTask) {
-          assert.equal(groovyDefaultTask.definition.buildFile, 'build.gradle');
+          assert.equal(groovyDefaultTask.definition.fileName, 'build.gradle');
         }
       });
 
@@ -42,7 +42,7 @@ describe(fixtureName, () => {
         );
         assert.ok(kotlinTask);
         if (kotlinTask) {
-          assert.equal(kotlinTask.definition.buildFile, 'build.gradle.kts');
+          assert.equal(kotlinTask.definition.fileName, 'build.gradle.kts');
         }
       });
 
@@ -53,7 +53,7 @@ describe(fixtureName, () => {
         assert.ok(groovyCustomTask);
         if (groovyCustomTask) {
           assert.equal(
-            groovyCustomTask.definition.buildFile,
+            groovyCustomTask.definition.fileName,
             'my-custom-build.gradle'
           );
         }


### PR DESCRIPTION
Fixes #37

Now both extensions work together. There are some duplicated UI elements in the "Task Explorer" extension but it's no longer showing an error and you can run the gradle tasks from either explorer view.


## Default gradle build file:

<img width="426" alt="Screenshot 2019-11-14 at 18 04 50" src="https://user-images.githubusercontent.com/102141/68879264-65aa9680-0709-11ea-82b9-ba8467ad043a.png">

## Multi-projects:

<img width="427" alt="Screenshot 2019-11-14 at 18 04 14" src="https://user-images.githubusercontent.com/102141/68879296-765b0c80-0709-11ea-97fa-54e70088dcd3.png">


