### PR TITLE
Snippets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: badsyntax
-
 ---
 
 **Describe the bug**
@@ -20,7 +19,8 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
- - OS: [e.g. iOS]
+
+- OS: [e.g. iOS]
 
 **Output from "Gradle Tasks"**
 You can find this by clicking on the "Output" panel, then selecting the "Gradle Tasks" channel from the dropdown.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: enhancement
 assignees: badsyntax
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Run gradle tasks in VS Code.
 
 ## Features
 
-- Run gradle tasks as [VS Code tasks](https://code.visualstudio.com/docs/editor/tasks)
+- Run [Gradle tasks](https://gradle.org/) as [VS Code tasks](https://code.visualstudio.com/docs/editor/tasks)
 - List & run gradle tasks in the Explorer
 - Multi-root workspace folders supported
 - Default Groovy/Kotlin & custom build files supported
@@ -26,6 +26,12 @@ This extension contributes the following settings:
 - `gradle.enableTasksExplorer`: Enable an explorer view for gradle tasks
 - `gradle.customBuildFile`: Custom gradle build filename
 - `gradle.explorerNestedSubProjects`: Show nested subprojects in the explorer
+
+## Snippets
+
+This extensions provides snippets for the groovy and kotlin build files:
+
+- `cgt`: Create a new gradle task
 
 ## Slow Task Provider Warning
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "vscode": "^1.39.0"
   },
   "categories": [
-    "Other"
+    "Other",
+    "Snippets"
   ],
   "keywords": [
     "java",
@@ -42,6 +43,16 @@
   ],
   "main": "./out/extension",
   "contributes": {
+    "snippets": [
+      {
+        "language": "groovy",
+        "path": "./snippets/build.gradle.json"
+      },
+      {
+        "language": "kotlinscript",
+        "path": "./snippets/build.gradle.kts.json"
+      }
+    ],
     "problemMatchers": [
       {
         "owner": "gradle",
@@ -88,6 +99,14 @@
         "title": "Open Build File"
       },
       {
+        "command": "gradle.addTask",
+        "title": "Add Task",
+        "icon": {
+          "light": "resources/light/add.svg",
+          "dark": "resources/dark/add.svg"
+        }
+      },
+      {
         "command": "gradle.refresh",
         "title": "Gradle: Refresh Tasks",
         "icon": {
@@ -100,6 +119,10 @@
       "commandPalette": [
         {
           "command": "gradle.runTask",
+          "when": "false"
+        },
+        {
+          "command": "gradle.addTask",
           "when": "false"
         },
         {
@@ -126,6 +149,15 @@
         {
           "command": "gradle.openBuildFile",
           "when": "view == gradle-tree-view && viewItem == buildFile"
+        },
+        {
+          "command": "gradle.addTask",
+          "when": "view == gradle-tree-view && viewItem == buildFile"
+        },
+        {
+          "command": "gradle.addTask",
+          "when": "view == gradle-tree-view && viewItem == buildFile",
+          "group": "inline"
         },
         {
           "command": "gradle.runTask",
@@ -199,6 +231,10 @@
           "fileName": {
             "type": "string",
             "description": "The filename of the build file that provides the tasks"
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the task"
           }
         }
       }
@@ -211,9 +247,9 @@
     "test": "node ./out/test/runTest.js",
     "pretest": "npm run compile",
     "lint": "npm run lint:prettier && npm run lint:tslint",
-    "lint:prettier": "prettier --check \"**/*.{ts,js,json,svg}\"",
+    "lint:prettier": "prettier --check \"**/*.{ts,js,json,svg,md,yml}\"",
     "lint:tslint": "tslint -c tslint.json 'src/**/*.ts'",
-    "format": "prettier --write '**/*.{ts,js,json,svg}'"
+    "format": "prettier --write '**/*.{ts,js,json,svg,md,yml}'"
   },
   "dependencies": {},
   "devDependencies": {

--- a/resources/dark/add.svg
+++ b/resources/dark/add.svg
@@ -1,0 +1,9 @@
+<svg
+  width="16"
+  height="16"
+  viewBox="0 0 16 16"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path d="M14 7V8H8V14H7V8H1V7H7V1H8V7H14Z" fill="#C5C5C5" />
+</svg>

--- a/resources/light/add.svg
+++ b/resources/light/add.svg
@@ -1,0 +1,9 @@
+<svg
+  width="16"
+  height="16"
+  viewBox="0 0 16 16"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <path d="M14 7V8H8V14H7V8H1V7H7V1H8V7H14Z" fill="#424242" />
+</svg>

--- a/snippets/build.gradle.json
+++ b/snippets/build.gradle.json
@@ -1,0 +1,15 @@
+{
+  "createGradleTask": {
+    "prefix": "cgt",
+    "body": [
+      "tasks.register(\"$1\") {",
+      "\tgroup='$2'",
+      "\tdescription='$3'",
+      "\tdoLast {",
+      "\t\tprintln 'Hello, World'",
+      "\t}",
+      "}"
+    ],
+    "description": "Create a new Gradle task"
+  }
+}

--- a/snippets/build.gradle.kts.json
+++ b/snippets/build.gradle.kts.json
@@ -1,0 +1,15 @@
+{
+  "createGradleTask": {
+    "prefix": "cgt",
+    "body": [
+      "tasks.register(\"$1\") {",
+      "\tgroup=\"$2\"",
+      "\tdescription=\"$3\"",
+      "\tdoLast {",
+      "\t\tprintln(\"Hello, World\")",
+      "\t}",
+      "}"
+    ],
+    "description": "Create a new Gradle task"
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,6 +114,13 @@ function registerCommands(
         treeDataProvider
       )
     );
+    context.subscriptions.push(
+      vscode.commands.registerCommand(
+        'gradle.addTask',
+        treeDataProvider.addTask,
+        treeDataProvider
+      )
+    );
   }
 }
 

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -96,7 +96,8 @@ class GradleTaskTreeItem extends vscode.TreeItem {
     context: vscode.ExtensionContext,
     folderTreeItem: GradleBuildFileTreeItem,
     task: vscode.Task,
-    label: string
+    label: string,
+    description?: string
   ) {
     super(label, vscode.TreeItemCollapsibleState.None);
     this.command = {
@@ -104,6 +105,7 @@ class GradleTaskTreeItem extends vscode.TreeItem {
       command: 'gradle.runTask',
       arguments: [this]
     };
+    this.tooltip = description || label;
     this.folderTreeItem = folderTreeItem;
     this.task = task;
     this.execution = getTaskExecution(task);
@@ -189,6 +191,22 @@ export class GradleTasksTreeDataProvider
       await vscode.window.showTextDocument(
         await vscode.workspace.openTextDocument(uri)
       );
+    }
+  }
+
+  async addTask(buildFileTreeItem: GradleBuildFileTreeItem) {
+    const uri = buildFileTreeItem.resourceUri;
+    if (uri) {
+      const textEditor = await vscode.window.showTextDocument(
+        await vscode.workspace.openTextDocument(uri)
+      );
+
+      const position = new vscode.Position(textEditor.document.lineCount, 0);
+      textEditor.selection = new vscode.Selection(position, position);
+
+      vscode.commands.executeCommand('editor.action.insertSnippet', {
+        name: 'createGradleTask'
+      });
     }
   }
 
@@ -333,7 +351,8 @@ export class GradleTasksTreeDataProvider
             this.extensionContext,
             subProjectBuildFileTreeItem,
             task,
-            task.name.replace(/[^:]+:/, '')
+            task.name.replace(/[^:]+:/, ''),
+            task.definition.description
           );
           subProjectBuildFileTreeItem.addTask(gradleTask);
         } else {
@@ -341,7 +360,8 @@ export class GradleTasksTreeDataProvider
             this.extensionContext,
             buildFileTreeItem,
             task,
-            task.name
+            task.name,
+            task.definition.description
           );
           buildFileTreeItem.addTask(gradleTask);
         }


### PR DESCRIPTION
Fixes #53 

Adds snippets and basic support for adding new gradle tasks.

## Screenshots 

Snippet shows up in intellisense:

<img width="655" alt="Screenshot 2019-11-18 at 13 26 58" src="https://user-images.githubusercontent.com/102141/69052376-30eb5780-0a07-11ea-8300-f2728941284c.png">


New explorer action (add task) is shown on build files:

<img width="427" alt="Screenshot 2019-11-18 at 13 24 48" src="https://user-images.githubusercontent.com/102141/69052259-e8339e80-0a06-11ea-8b48-b687287ad6a7.png">

Clicking on that action will execute the "cgt" snippet:

<img width="755" alt="Screenshot 2019-11-18 at 13 24 57" src="https://user-images.githubusercontent.com/102141/69052271-ed90e900-0a06-11ea-96c4-26651deb1c9b.png">

