### PR TITLE
Gradle server output logs

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,10 +6,13 @@ src/**
 .gitignore
 **/tsconfig.json
 **/.eslintignore
-**/.eslintrc.js
-**/.prettierrc.js
+**/.eslintrc.json
+**/.prettierrc.json
+**/.prettierignore
 **/*.map
 **/*.ts
 test-fixtures/**
 images/**
 java-gradle-tasks/**
+sonar-project.properties
+

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -384,9 +384,10 @@ export function buildGradleServerTask(
   );
   task.isBackground = true;
   task.presentationOptions = {
-    reveal: vscode.TaskRevealKind.Never,
+    reveal: vscode.TaskRevealKind.Silent,
     focus: false,
     echo: false,
+    clear: false,
     panel: vscode.TaskPanelKind.Shared
   };
   return task;

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -386,7 +386,7 @@ export function buildGradleServerTask(
   task.presentationOptions = {
     reveal: vscode.TaskRevealKind.Silent,
     focus: false,
-    echo: false,
+    echo: true,
     clear: false,
     panel: vscode.TaskPanelKind.Shared
   };


### PR DESCRIPTION
Refs #137

If there's an error starting the gradle server (which is done via a custom vscode task), then the output will now be shown by default. 

This will help with debugging errors starting the gradle server.

<img width="899" alt="Screenshot 2020-01-02 at 13 33 04" src="https://user-images.githubusercontent.com/102141/71667366-17a72c00-2d65-11ea-97b5-902731c869bd.png">
