### PR TITLE
Better gradle and extension conflict error handling. Refs #99

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,21 @@ Check your dotfiles (eg `~/.bashrc`, `~/.bash_profile`, `~/.zshrc`) and fix any 
 
 You might see an error like:
 
-```
+```shell
 ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 ```
 
 The start script [should find](https://gist.github.com/badsyntax/d71d38b1700325f31c19912ac3428042#file-gradle-tasks-server-sh-L85-L105) the path to Java in the usual locations. If you get this error it suggests an issues with your `$PATH` or you simply haven't installed Java. Run the gradle wrapper script (eg `./gradlew tasks`) to debug further.
+
+</details>
+
+<details><summary>Incompatibility with other extensions</summary>
+
+This extension is incompatible with the following extensions:
+
+- [spmeesseman.vscode-taskexplorer](https://marketplace.visualstudio.com/items?itemName=spmeesseman.vscode-taskexplorer)
+
+The reason for the incompatibility is due to the extensions providing the same tasks types (`gradle`) with different task definitions.
 
 </details>
 

--- a/java-gradle-tasks/src/main/java/com/github/badsyntax/gradletasks/server/Server.java
+++ b/java-gradle-tasks/src/main/java/com/github/badsyntax/gradletasks/server/Server.java
@@ -87,13 +87,13 @@ public class Server extends WebSocketServer {
 
     @Override
     public void onStart() {
-        logger.info("Server started, waiting for clients");
+        logger.info("Gradle tasks server started");
         setConnectionLostTimeout(0);
         setConnectionLostTimeout(100);
     }
 
     @Override
     public void onMessage(WebSocket conn, String message) {
-        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException();
     }
 }

--- a/java-gradle-tasks/src/main/java/com/github/badsyntax/gradletasks/server/actions/Action.java
+++ b/java-gradle-tasks/src/main/java/com/github/badsyntax/gradletasks/server/actions/Action.java
@@ -28,8 +28,9 @@ class Action {
     protected void logError(WebSocket connection, String error) {
         logger.warning(error);
         if (connection.isOpen()) {
-            connection
-                    .send(ServerMessage.Error.newBuilder().setMessage(error).build().toByteArray());
+            connection.send(ServerMessage.Message.newBuilder()
+                    .setError(ServerMessage.Error.newBuilder().setMessage(error)).build()
+                    .toByteArray());
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5805,6 +5805,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/ts-protoc-gen/-/ts-protoc-gen-0.12.0.tgz",
       "integrity": "sha512-V7jnICJxKqalBrnJSMTW5tB9sGi48gOC325bfcM7TDNUItVOlaMM//rQmuo49ybipk/SyJTnWXgtJnhHCevNJw==",
+      "dev": true,
       "requires": {
         "google-protobuf": "^3.6.1"
       }

--- a/src/client.ts
+++ b/src/client.ts
@@ -158,6 +158,7 @@ export class GradleTasksClient implements vscode.Disposable {
   ) {
     this.onGradleProgress(this.handleProgressMessage);
     this.onGradleOutput(this.handleOutputMessage);
+    this.onGradleError(this.handleGradleError);
     this.server.onStart(this.connect);
     this.server.onStop(this.handleServerStopped);
   }
@@ -383,6 +384,13 @@ export class GradleTasksClient implements vscode.Disposable {
     const logMessage = stripAnsi(message.getMessage()).trim();
     if (logMessage) {
       logger.info(logMessage);
+    }
+  };
+
+  private handleGradleError = (message: ServerMessage.Error): void => {
+    const logMessage = message.getMessage().trim();
+    if (logMessage) {
+      logger.error(logMessage);
     }
   };
 

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -297,7 +297,7 @@ export class GradleTasksTreeDataProvider
     let workspaceTreeItem = null;
 
     tasks.forEach(task => {
-      if (isWorkspaceFolder(task.scope)) {
+      if (isWorkspaceFolder(task.scope) && task.definition.buildFile) {
         workspaceTreeItem = workspaceTreeItems.get(task.scope.name);
         if (!workspaceTreeItem) {
           workspaceTreeItem = new WorkspaceTreeItem(


### PR DESCRIPTION
See #99 . 

[This change](https://github.com/badsyntax/vscode-gradle/pull/188/files#diff-a6b67fd6ad3f7c5b6fd832b05806ca60R300) prevents that error from occurring, but tasks-explorer plugin then throws some errors. So I added a note to the README about incompatibility with this extension.