### PR TITLE
Task presentation options & focus settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This extension contributes the following settings:
 
 - `gradle.autoDetect`: Automatically detect Gradle tasks
 - `gradle.enableTasksExplorer`: Enable an explorer view for Gradle tasks
+- `gradle.taskPresentationOptions`: Task presentation options. See [tasks output behaviour](https://code.visualstudio.com/docs/editor/tasks#_output-behavior).
 - `gradle.debug`: Show extra debug info in the output panel
 
 ## Snippets

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This extension contributes the following settings:
 
 - `gradle.autoDetect`: Automatically detect Gradle tasks
 - `gradle.enableTasksExplorer`: Enable an explorer view for Gradle tasks
-- `gradle.taskPresentationOptions`: Task presentation options. See [tasks output behaviour](https://code.visualstudio.com/docs/editor/tasks#_output-behavior).
+- `gradle.taskPresentationOptions`: Task presentation options, see [tasks output behaviour](https://code.visualstudio.com/docs/editor/tasks#_output-behavior)
+- `gradle.focusTaskInExplorer`: Focus the task in the explorer when running a task
 - `gradle.debug`: Show extra debug info in the output panel
 
 ## Snippets

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -15,6 +15,7 @@
   "extension.config.autoDetect.description": "Controla si las tareas de Gradle deben detectarse automáticamente",
   "extension.config.enableTasksExplorer.description": "Habilitar una vista de explorador para tareas de Gradle",
   "extension.config.debug.description": "Mostrar información adicional de depuración en el panel de salida",
+  "extension.config.focusTaskInExplorer.description": "Enfoca la tarea en el explorador cuando ejecutas una tarea",
   "extension.config.taskPresentationOptions.description": "Opciones de terminal para ejecutar una tarea",
   "extension.config.taskPresentationOptions.reveal.description": "Controla si el panel Terminal integrado se lleva al frente",
   "extension.config.taskPresentationOptions.focus.description": "Controla si el terminal está tomando el foco de entrada o no",

--- a/i18n/es/package.i18n.json
+++ b/i18n/es/package.i18n.json
@@ -14,5 +14,12 @@
   "extension.command.stoppingTreeItemTaskShow.title": "Tarea de detención",
   "extension.config.autoDetect.description": "Controla si las tareas de Gradle deben detectarse automáticamente",
   "extension.config.enableTasksExplorer.description": "Habilitar una vista de explorador para tareas de Gradle",
-  "extension.config.debug.description": "Mostrar información adicional de depuración en el panel de salida"
+  "extension.config.debug.description": "Mostrar información adicional de depuración en el panel de salida",
+  "extension.config.taskPresentationOptions.description": "Opciones de terminal para ejecutar una tarea",
+  "extension.config.taskPresentationOptions.reveal.description": "Controla si el panel Terminal integrado se lleva al frente",
+  "extension.config.taskPresentationOptions.focus.description": "Controla si el terminal está tomando el foco de entrada o no",
+  "extension.config.taskPresentationOptions.echo.description": "Controla si el comando ejecutado se repite en el terminal",
+  "extension.config.taskPresentationOptions.showReuseMessage.description": "Controla si mostrar el \"Terminal será reutilizado por tareas, presione cualquier tecla para cerrarlo \" mensaje",
+  "extension.config.taskPresentationOptions.panel.description": "Controla si la instancia de terminal se comparte entre ejecuciones de tareas",
+  "extension.config.taskPresentationOptions.clear.description": "Controla si el terminal se borra antes de ejecutar esta tarea"
 }

--- a/package.json
+++ b/package.json
@@ -292,13 +292,22 @@
           "default": false,
           "description": "%extension.config.debug.description%"
         },
+        "gradle.focusTaskInExplorer": {
+          "type": "boolean",
+          "default": true,
+          "description": "%extension.config.focusTaskInExplorer.description%"
+        },
         "gradle.taskPresentationOptions": {
           "type": "object",
           "description": "%extension.config.taskPresentationOptions.description%",
           "properties": {
             "reveal": {
               "type": "string",
-              "enum": ["always", "never", "silent"],
+              "enum": [
+                "always",
+                "never",
+                "silent"
+              ],
               "default": "always",
               "description": "%extension.config.taskPresentationOptions.reveal.description%"
             },
@@ -319,7 +328,11 @@
             },
             "panel": {
               "type": "string",
-              "enum": ["shared", "dedicated", "new"],
+              "enum": [
+                "shared",
+                "dedicated",
+                "new"
+              ],
               "default": "shared",
               "description": "%extension.config.taskPresentationOptions.panel.description%"
             },
@@ -328,6 +341,14 @@
               "default": true,
               "description": "%extension.config.taskPresentationOptions.clear.description%"
             }
+          },
+          "default": {
+            "reveal": "always",
+            "focus": true,
+            "echo": true,
+            "showReuseMessage": false,
+            "panel": "shared",
+            "clear": true
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -291,6 +291,44 @@
           "type": "boolean",
           "default": false,
           "description": "%extension.config.debug.description%"
+        },
+        "gradle.taskPresentationOptions": {
+          "type": "object",
+          "description": "%extension.config.taskPresentationOptions.description%",
+          "properties": {
+            "reveal": {
+              "type": "string",
+              "enum": ["always", "never", "silent"],
+              "default": "always",
+              "description": "%extension.config.taskPresentationOptions.reveal.description%"
+            },
+            "focus": {
+              "type": "boolean",
+              "default": true,
+              "description": "%extension.config.taskPresentationOptions.focus.description%"
+            },
+            "echo": {
+              "type": "boolean",
+              "default": true,
+              "description": "%extension.config.taskPresentationOptions.echo.description%"
+            },
+            "showReuseMessage": {
+              "type": "boolean",
+              "default": false,
+              "description": "%extension.config.taskPresentationOptions.showReuseMessage.description%"
+            },
+            "panel": {
+              "type": "string",
+              "enum": ["shared", "dedicated", "new"],
+              "default": "shared",
+              "description": "%extension.config.taskPresentationOptions.panel.description%"
+            },
+            "clear": {
+              "type": "boolean",
+              "default": true,
+              "description": "%extension.config.taskPresentationOptions.clear.description%"
+            }
+          }
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,5 +14,12 @@
   "extension.command.stoppingTreeItemTaskShow.title": "Stopping Task",
   "extension.config.autoDetect.description": "Controls whether Gradle tasks should be automatically detected",
   "extension.config.enableTasksExplorer.description": "Enable an explorer view for Gradle tasks",
-  "extension.config.debug.description": "Show extra debug information in the output panel"
+  "extension.config.debug.description": "Show extra debug information in the output panel",
+  "extension.config.taskPresentationOptions.description": "Terminal options for running a task",
+  "extension.config.taskPresentationOptions.reveal.description": "Controls whether the Integrated Terminal panel is brought to front",
+  "extension.config.taskPresentationOptions.focus.description": "Controls whether the terminal is taking input focus or not",
+  "extension.config.taskPresentationOptions.echo.description": "Controls whether the executed command is echoed in the terminal",
+  "extension.config.taskPresentationOptions.showReuseMessage.description": "Controls whether to show the \"Terminal will be reused by tasks, press any key to close it\" message",
+  "extension.config.taskPresentationOptions.panel.description": "Controls whether the terminal instance is shared between task runs",
+  "extension.config.taskPresentationOptions.clear.description": "Controls whether the terminal is cleared before this task is run"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -15,6 +15,7 @@
   "extension.config.autoDetect.description": "Controls whether Gradle tasks should be automatically detected",
   "extension.config.enableTasksExplorer.description": "Enable an explorer view for Gradle tasks",
   "extension.config.debug.description": "Show extra debug information in the output panel",
+  "extension.config.focusTaskInExplorer.description": "Focus the task in the explorer when running a task",
   "extension.config.taskPresentationOptions.description": "Terminal options for running a task",
   "extension.config.taskPresentationOptions.reveal.description": "Controls whether the Integrated Terminal panel is brought to front",
   "extension.config.taskPresentationOptions.focus.description": "Controls whether the terminal is taking input focus or not",

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,3 +23,32 @@ export function getIsDebugEnabled(): boolean {
     .getConfiguration('gradle')
     .get<boolean>('debug', false);
 }
+
+export type ConfigTaskPresentationOptionsRevealKind =
+  | 'always'
+  | 'never'
+  | 'silent';
+
+export type ConfigTaskPresentationOptionsPanelKind =
+  | 'shared'
+  | 'dedicated'
+  | 'new';
+
+export interface ConfigTaskPresentationOptions
+  extends Omit<vscode.TaskPresentationOptions, 'reveal' | 'panel'> {
+  reveal: 'always' | 'never' | 'silent';
+  panel: 'shared' | 'dedicated' | 'new';
+}
+
+export function getTaskPresentationOptions(): ConfigTaskPresentationOptions {
+  return vscode.workspace
+    .getConfiguration('gradle')
+    .get<ConfigTaskPresentationOptions>('taskPresentationOptions', {
+      reveal: 'always',
+      focus: true,
+      echo: true,
+      showReuseMessage: false,
+      panel: 'shared',
+      clear: true
+    });
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,12 @@ export function getIsDebugEnabled(): boolean {
     .get<boolean>('debug', false);
 }
 
+export function getFocusTaskInExplorer(): boolean {
+  return vscode.workspace
+    .getConfiguration('gradle')
+    .get<boolean>('focusTaskInExplorer', true);
+}
+
 export type ConfigTaskPresentationOptionsRevealKind =
   | 'always'
   | 'never'
@@ -36,8 +42,8 @@ export type ConfigTaskPresentationOptionsPanelKind =
 
 export interface ConfigTaskPresentationOptions
   extends Omit<vscode.TaskPresentationOptions, 'reveal' | 'panel'> {
-  reveal: 'always' | 'never' | 'silent';
-  panel: 'shared' | 'dedicated' | 'new';
+  reveal: ConfigTaskPresentationOptionsRevealKind;
+  panel: ConfigTaskPresentationOptionsPanelKind;
 }
 
 export function getTaskPresentationOptions(): ConfigTaskPresentationOptions {

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -365,6 +365,9 @@ export function registerExplorer(
         if (event.affectsConfiguration('gradle.enableTasksExplorer')) {
           vscode.commands.executeCommand('gradle.refresh', false, false);
         }
+        if (event.affectsConfiguration('gradle.taskPresentationOptions')) {
+          vscode.commands.executeCommand('gradle.refresh', false, true);
+        }
       }
     ),
     vscode.tasks.onDidStartTask((event: vscode.TaskStartEvent) => {

--- a/src/gradleView.ts
+++ b/src/gradleView.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import * as nls from 'vscode-nls';
 
 import { isWorkspaceFolder, isTaskStopping, isTaskRunning } from './tasks';
+import { getFocusTaskInExplorer } from './config';
 
 const localize = nls.loadMessageBundle();
 
@@ -374,7 +375,7 @@ export function registerExplorer(
       const { type } = event.execution.task.definition;
       if (type === 'gradle') {
         const treeItem = treeDataProvider.findTreeItem(event.execution.task);
-        const shouldFocus = treeView.visible;
+        const shouldFocus = treeView.visible && getFocusTaskInExplorer();
         if (treeItem && shouldFocus) {
           treeView.reveal(treeItem, {
             focus: true,

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -147,6 +147,7 @@ export class GradleTaskProvider implements vscode.TaskProvider {
       }
       cachedTasks = allTasks;
     } catch (e) {
+      logger.error(`Unable to refresh tasks: ${e.message}`);
       cachedTasks = emptyTasks;
     }
   }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -2,7 +2,14 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as nls from 'vscode-nls';
 import * as ServerMessage from '../lib/proto/com/github/badsyntax/gradletasks/ServerMessage_pb';
-import { getIsAutoDetectionEnabled, getIsDebugEnabled } from './config';
+import {
+  getIsAutoDetectionEnabled,
+  getIsDebugEnabled,
+  getTaskPresentationOptions,
+  ConfigTaskPresentationOptions,
+  ConfigTaskPresentationOptionsRevealKind,
+  ConfigTaskPresentationOptionsPanelKind
+} from './config';
 import { GradleTasksClient } from './client';
 import { logger } from './logger';
 
@@ -296,6 +303,22 @@ class CustomBuildTaskTerminal implements vscode.Pseudoterminal {
   }
 }
 
+function getTaskPanelKind(
+  panel: ConfigTaskPresentationOptionsPanelKind
+): vscode.TaskPanelKind {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  return vscode.TaskPanelKind[panel[0].toUpperCase() + panel.substring(1)];
+}
+
+function getTaskRevealKind(
+  reveal: ConfigTaskPresentationOptionsRevealKind
+): vscode.TaskRevealKind {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+  // @ts-ignore
+  return vscode.TaskRevealKind[reveal[0].toUpperCase() + reveal.substring(1)];
+}
+
 export function createTaskFromDefinition(
   definition: GradleTaskDefinition,
   workspaceFolder: vscode.WorkspaceFolder,
@@ -322,12 +345,13 @@ export function createTaskFromDefinition(
     ),
     ['$gradle']
   );
+  const configTaskPresentationOptions: ConfigTaskPresentationOptions = getTaskPresentationOptions();
   task.presentationOptions = {
-    clear: true,
-    showReuseMessage: false,
-    focus: true,
-    panel: vscode.TaskPanelKind.Shared,
-    reveal: vscode.TaskRevealKind.Always
+    ...configTaskPresentationOptions,
+    ...{
+      panel: getTaskPanelKind(configTaskPresentationOptions.panel),
+      reveal: getTaskRevealKind(configTaskPresentationOptions.reveal)
+    }
   };
   if (isTaskOfType(definition, 'build')) {
     task.group = vscode.TaskGroup.Build;


### PR DESCRIPTION
Now you can customise the terminal options for running gradle tasks. Also the scroll/focus behaviour is optional.