### PR TITLE
Add support for custom java home setting. Refs #249

### DIFF
--- a/java-gradle-tasks/build.gradle
+++ b/java-gradle-tasks/build.gradle
@@ -56,10 +56,12 @@ task createStartScripts(type: CreateStartScripts) {
     mainClassName = 'com.github.badsyntax.gradletasks.Application'
     applicationName = project.name
     classpath = files(shadowJar.outputs.files)
+    unixStartScriptGenerator.template = resources.text.fromFile('startScriptTemplates/unixStartScript.txt')
+    windowsStartScriptGenerator.template = resources.text.fromFile('startScriptTemplates/windowsStartScript.txt')
 }
 
 task generateLib(type: Copy) {
-    dependsOn build, createStartScripts
+    dependsOn createStartScripts
 
     from file("$buildDir/lib/${project.name}-all.jar")
     into file("$buildDir/../../lib/${project.name}-all.jar")

--- a/java-gradle-tasks/startScriptTemplates/unixStartScript.txt
+++ b/java-gradle-tasks/startScriptTemplates/unixStartScript.txt
@@ -1,0 +1,174 @@
+#!/usr/bin/env sh
+
+##############################################################################
+##
+##  ${applicationName} start up script for UN*X
+##
+##############################################################################
+
+# Attempt to set APP_HOME
+# Resolve links: \$0 may be a link
+PRG="\$0"
+# Need this for relative symlinks.
+while [ -h "\$PRG" ] ; do
+    ls=`ls -ld "\$PRG"`
+    link=`expr "\$ls" : '.*-> \\(.*\\)\$'`
+    if expr "\$link" : '/.*' > /dev/null; then
+        PRG="\$link"
+    else
+        PRG=`dirname "\$PRG"`"/\$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"\$PRG\"`/${appHomeRelativePath}" >/dev/null
+APP_HOME="`pwd -P`"
+cd "\$SAVED" >/dev/null
+
+APP_NAME="${applicationName}"
+APP_BASE_NAME=`basename "\$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+# Use the maximum available, or set MAX_FD != -1 to use that value.
+MAX_FD="maximum"
+
+warn ( ) {
+    echo "\$*"
+}
+
+die ( ) {
+    echo
+    echo "\$*"
+    echo
+    exit 1
+}
+
+# OS specific support (must be 'true' or 'false').
+cygwin=false
+msys=false
+darwin=false
+nonstop=false
+case "`uname`" in
+  CYGWIN* )
+    cygwin=true
+    ;;
+  Darwin* )
+    darwin=true
+    ;;
+  MINGW* )
+    msys=true
+    ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
+esac
+
+CLASSPATH=$classpath
+
+_JAVA_HOME=\${VSCODE_JAVA_HOME:-\$JAVA_HOME}
+
+# Determine the Java command to use to start the JVM.
+if [ -n "\$_JAVA_HOME" ] ; then
+    if [ -x "\$_JAVA_HOME/jre/sh/java" ] ; then
+        # IBM's JDK on AIX uses strange locations for the executables
+        JAVACMD="\$_JAVA_HOME/jre/sh/java"
+    else
+        JAVACMD="\$_JAVA_HOME/bin/java"
+    fi
+    if [ ! -x "\$JAVACMD" ] ; then
+        die "ERROR: JAVA_HOME is set to an invalid directory: \$_JAVA_HOME
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+    fi
+else
+    JAVACMD="java"
+    which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+
+Please set the JAVA_HOME variable in your environment to match the
+location of your Java installation."
+fi
+
+# Increase the maximum file descriptors if we can.
+if [ "\$cygwin" = "false" -a "\$darwin" = "false" -a "\$nonstop" = "false" ] ; then
+    MAX_FD_LIMIT=`ulimit -H -n`
+    if [ \$? -eq 0 ] ; then
+        if [ "\$MAX_FD" = "maximum" -o "\$MAX_FD" = "max" ] ; then
+            MAX_FD="\$MAX_FD_LIMIT"
+        fi
+        ulimit -n \$MAX_FD
+        if [ \$? -ne 0 ] ; then
+            warn "Could not set maximum file descriptor limit: \$MAX_FD"
+        fi
+    else
+        warn "Could not query maximum file descriptor limit: \$MAX_FD_LIMIT"
+    fi
+fi
+
+# For Darwin, add options to specify how the application appears in the dock
+if \$darwin; then
+    GRADLE_OPTS="\$GRADLE_OPTS \\"-Xdock:name=\$APP_NAME\\" \\"-Xdock:icon=\$APP_HOME/media/gradle.icns\\""
+fi
+
+# For Cygwin, switch paths to Windows format before running java
+if \$cygwin ; then
+    APP_HOME=`cygpath --path --mixed "\$APP_HOME"`
+    CLASSPATH=`cygpath --path --mixed "\$CLASSPATH"`
+    JAVACMD=`cygpath --unix "\$JAVACMD"`
+
+    # We build the pattern for arguments to be converted via cygpath
+    ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`
+    SEP=""
+    for dir in \$ROOTDIRSRAW ; do
+        ROOTDIRS="\$ROOTDIRS\$SEP\$dir"
+        SEP="|"
+    done
+    OURCYGPATTERN="(^(\$ROOTDIRS))"
+    # Add a user-defined pattern to the cygpath arguments
+    if [ "\$GRADLE_CYGPATTERN" != "" ] ; then
+        OURCYGPATTERN="\$OURCYGPATTERN|(\$GRADLE_CYGPATTERN)"
+    fi
+    # Now convert the arguments - kludge to limit ourselves to /bin/sh
+    i=0
+    for arg in "\$@" ; do
+        CHECK=`echo "\$arg"|egrep -c "\$OURCYGPATTERN" -`
+        CHECK2=`echo "\$arg"|egrep -c "^-"`                                 ### Determine if an option
+
+        if [ \$CHECK -ne 0 ] && [ \$CHECK2 -eq 0 ] ; then                    ### Added a condition
+            eval `echo args\$i`=`cygpath --path --ignore --mixed "\$arg"`
+        else
+            eval `echo args\$i`="\"\$arg\""
+        fi
+        i=\$((i+1))
+    done
+    case \$i in
+        (0) set -- ;;
+        (1) set -- "\$args0" ;;
+        (2) set -- "\$args0" "\$args1" ;;
+        (3) set -- "\$args0" "\$args1" "\$args2" ;;
+        (4) set -- "\$args0" "\$args1" "\$args2" "\$args3" ;;
+        (5) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" ;;
+        (6) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" ;;
+        (7) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" ;;
+        (8) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" "\$args7" ;;
+        (9) set -- "\$args0" "\$args1" "\$args2" "\$args3" "\$args4" "\$args5" "\$args6" "\$args7" "\$args8" ;;
+    esac
+fi
+
+# Escape application args
+save ( ) {
+    for i do printf %s\\\\n "\$i" | sed "s/'/'\\\\\\\\''/g;1s/^/'/;\\\$s/\\\$/' \\\\\\\\/" ; done
+    echo " "
+}
+APP_ARGS=\$(save "\$@")
+
+# Collect all arguments for the java command, following the shell quoting and substitution rules
+eval set -- \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" ${mainClassName} "\$APP_ARGS"
+
+# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
+if [ "\$(uname)" = "Darwin" ] && [ "\$HOME" = "\$PWD" ]; then
+  cd "\$(dirname "\$0")"
+fi
+
+exec "\$JAVACMD" "\$@"

--- a/java-gradle-tasks/startScriptTemplates/windowsStartScript.txt
+++ b/java-gradle-tasks/startScriptTemplates/windowsStartScript.txt
@@ -35,16 +35,16 @@ goto fail
 
 :findJavaFromJavaHome
 if defined VSCODE_JAVA_HOME (
-  set JAVA_HOME=%VSCODE_JAVA_HOME:"=%
+  set _JAVA_HOME=%VSCODE_JAVA_HOME:"=%
 ) else (
-  set JAVA_HOME=%JAVA_HOME:"=%
+  set _JAVA_HOME=%JAVA_HOME:"=%
 )
-set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+set JAVA_EXE=%_JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto init
 
 echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo ERROR: JAVA_HOME is set to an invalid directory: %_JAVA_HOME%
 echo.
 echo Please set the JAVA_HOME variable in your environment to match the
 echo location of your Java installation.

--- a/java-gradle-tasks/startScriptTemplates/windowsStartScript.txt
+++ b/java-gradle-tasks/startScriptTemplates/windowsStartScript.txt
@@ -1,0 +1,90 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  ${applicationName} startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.\
+
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%${appHomeRelativePath}
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and ${optsEnvironmentVar} to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=${defaultJvmOpts}
+
+@rem Find java.exe
+if defined VSCODE_JAVA_HOME goto findJavaFromJavaHome
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+if defined VSCODE_JAVA_HOME (
+  set JAVA_HOME=%VSCODE_JAVA_HOME:"=%
+) else (
+  set JAVA_HOME=%JAVA_HOME:"=%
+)
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=$classpath
+
+@rem Execute ${applicationName}
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %${optsEnvironmentVar}% <% if ( appNameSystemProperty ) { %>"-D${appNameSystemProperty}=%APP_BASE_NAME%"<% } %> -classpath "%CLASSPATH%" ${mainClassName} %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable ${exitEnvironmentVar} if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%${exitEnvironmentVar}%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,12 @@ export function getIsTasksExplorerEnabled(): boolean {
     .get<boolean>('enableTasksExplorer', true);
 }
 
+export function getJavaHome(): string | null {
+  return vscode.workspace
+    .getConfiguration('java')
+    .get<string | null>('home', null);
+}
+
 export function getIsDebugEnabled(): boolean {
   return vscode.workspace
     .getConfiguration('gradle')

--- a/src/server.ts
+++ b/src/server.ts
@@ -82,8 +82,14 @@ export class GradleTasksServer implements vscode.Disposable {
       OPT_RESTART
     );
     if (input === OPT_RESTART) {
-      this.start();
+      this.restart();
     }
+  }
+
+  public restart(): void {
+    logger.info('Restarting gradle server...');
+    this.taskExecution?.terminate();
+    this.start();
   }
 
   public dispose(): void {
@@ -107,5 +113,16 @@ export function registerServer(
   const server = new GradleTasksServer(opts, context);
   context.subscriptions.push(server);
   server.start();
+
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(
+      (event: vscode.ConfigurationChangeEvent) => {
+        if (event.affectsConfiguration('java.home')) {
+          server.restart();
+        }
+      }
+    )
+  );
+
   return server;
 }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -6,6 +6,7 @@ import {
   getIsAutoDetectionEnabled,
   getIsDebugEnabled,
   getTaskPresentationOptions,
+  getJavaHome,
   ConfigTaskPresentationOptions,
   ConfigTaskPresentationOptionsRevealKind,
   ConfigTaskPresentationOptionsPanelKind,
@@ -417,20 +418,27 @@ export function buildGradleServerTask(
   args: string[] = []
 ): vscode.Task {
   const cmd = `"${getGradleTasksServerCommand()}"`;
+  if (getIsDebugEnabled()) {
+    logger.debug(`Gradle Tasks Server dir: ${cwd}`);
+    logger.debug(`Gradle Tasks Server cmd: ${cmd} ${args}`);
+  }
   const taskType = 'gradle';
   const definition = {
     type: taskType,
   };
-  if (getIsDebugEnabled()) {
-    logger.debug(`Gradle Tasks Server dir: ${cwd}`);
-    logger.debug(`Gradle Tasks Server cmd: ${cmd} ${args}`);
+  const javaHome = getJavaHome();
+  const env = {};
+  if (javaHome) {
+    Object.assign(env, {
+      VSCODE_JAVA_HOME: javaHome,
+    });
   }
   const task = new vscode.Task(
     definition,
     vscode.TaskScope.Workspace,
     taskName,
     taskType,
-    new vscode.ShellExecution(cmd, args, { cwd })
+    new vscode.ShellExecution(cmd, args, { cwd, env })
   );
   // task.isBackground = true; // this hides errors on task start
   task.source = taskType;


### PR DESCRIPTION
Refs https://github.com/badsyntax/vscode-gradle/issues/249

This is a draft PR to support the `java.home` setting.

Tasks:

- [x] Change the start scripts to check for `VSCODE_JAVA_HOME`, else fallback to checking for `JAVA_HOME`, to build the path to the java executable
- [x] If `java.home` is set, then set environment var `VSCODE_JAVA_HOME` to this value when starting the gradle server. When this config changes, restart the gradle server process.
- [ ] ~~Add tests~~ (will be done with https://github.com/badsyntax/vscode-gradle/issues/21)