### PR TITLE
Add Gradle Tasks options to context menus

### DIFF
--- a/extension/i18n/es/package.i18n.json
+++ b/extension/i18n/es/package.i18n.json
@@ -14,6 +14,7 @@
   "extension.command.cancellingTreeItemTaskShow.title": "Tarea de cancelación",
   "extension.command.restartTask.title": "Reiniciar tarea",
   "extension.command.debugTask.title": "Tarea de depuración",
+  "extension.command.showTasks.title": "Mostrar tareas de Gradle",
   "extension.config.autoDetect.description": "Controla si las tareas de Gradle deben detectarse automáticamente",
   "extension.config.enableTasksExplorer.description": "Habilitar una vista de explorador para tareas de Gradle",
   "extension.config.debug.description": "Mostrar información adicional de depuración en el panel de salida",

--- a/extension/package.json
+++ b/extension/package.json
@@ -322,6 +322,13 @@
           "command": "gradle.showTasks",
           "group": "gradle@0"
         }
+      ],
+      "editor/context": [
+        {
+          "when": "resourceFilename =~ /^((?!settings).)*\\.gradle(\\.kts)?$/",
+          "command": "gradle.showTasks",
+          "group": "gradle@0"
+        }
       ]
     },
     "configuration": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -117,6 +117,10 @@
         }
       },
       {
+        "command": "gradle.showTasks",
+        "title": "%extension.command.showTasks.title%"
+      },
+      {
         "command": "gradle.runTaskWithArgs",
         "title": "%extension.command.runTaskWithArgs.title%"
       },
@@ -191,6 +195,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "gradle.showTasks",
+          "when": "false"
+        },
         {
           "command": "gradle.runTask",
           "when": "false"
@@ -306,6 +314,13 @@
           "command": "gradle.cancellingTreeItemTask",
           "when": "view == gradleTreeView && viewItem == cancellingTask",
           "group": "inline@4"
+        }
+      ],
+      "explorer/context": [
+        {
+          "when": "resourceFilename =~ /^((?!settings).)*\\.gradle(\\.kts)?$/",
+          "command": "gradle.showTasks",
+          "group": "gradle@0"
         }
       ]
     },

--- a/extension/package.nls.json
+++ b/extension/package.nls.json
@@ -14,6 +14,7 @@
   "extension.command.cancellingTreeItemTaskShow.title": "Cancelling Task",
   "extension.command.restartTask.title": "Restart Task",
   "extension.command.debugTask.title": "Debug Task",
+  "extension.command.showTasks.title": "Show Gradle Tasks",
   "extension.config.autoDetect.description": "Controls whether Gradle tasks should be automatically detected",
   "extension.config.enableTasksExplorer.description": "Enable an explorer view for Gradle tasks",
   "extension.config.debug.description": "Show extra debug information in the output panel",

--- a/extension/src/commands.ts
+++ b/extension/src/commands.ts
@@ -24,6 +24,24 @@ const packageJson = JSON.parse(
   fs.readFileSync(path.join(__dirname, '../package.json')).toString()
 );
 
+function registerShowTasks(
+  treeDataProvider: GradleTasksTreeDataProvider,
+  treeView: vscode.TreeView<vscode.TreeItem>
+): vscode.Disposable {
+  return vscode.commands.registerCommand(
+    'gradle.showTasks',
+    async (uri: vscode.Uri) => {
+      const treeItem = treeDataProvider.findProjectTreeItem(uri);
+      if (treeItem) {
+        await treeView.reveal(treeItem, {
+          focus: true,
+          expand: true,
+        });
+      }
+    }
+  );
+}
+
 function registerRunTaskCommand(client: GradleTasksClient): vscode.Disposable {
   return vscode.commands.registerCommand(
     'gradle.runTask',
@@ -307,9 +325,11 @@ export function registerCommands(
   statusBarItem: vscode.StatusBarItem,
   client: GradleTasksClient,
   treeDataProvider: GradleTasksTreeDataProvider,
+  treeView: vscode.TreeView<vscode.TreeItem>,
   taskProvider: GradleTaskProvider
 ): void {
   context.subscriptions.push(
+    registerShowTasks(treeDataProvider, treeView),
     registerRunTaskCommand(client),
     registerDebugTaskCommand(client),
     registerRestartTaskCommand(),

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -34,12 +34,13 @@ export async function activate(
   const server = registerServer({ host: 'localhost' }, context);
   const client = registerClient(server, statusBarItem, context);
   const taskProvider = registerTaskProvider(context, client);
-  const treeDataProvider = registerExplorer(context);
+  const { treeDataProvider, treeView } = registerExplorer(context);
   registerCommands(
     context,
     statusBarItem,
     client,
     treeDataProvider,
+    treeView,
     taskProvider
   );
   return { treeDataProvider, context, client, logger };

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -51,6 +51,7 @@ module.exports = () => {
               loader: 'ts-loader',
               options: {
                 transpileOnly: true,
+                module: 'es6',
               },
             },
           ],


### PR DESCRIPTION
This feature will show a "Show Gradle Tasks" content menu option in the explorer and editor views when focusing on a gradle build file.