### PR TITLE
Support relative paths

### DIFF
--- a/extension/src/server.ts
+++ b/extension/src/server.ts
@@ -55,11 +55,13 @@ export class GradleTasksServer implements vscode.Disposable {
       this.fireOnReady();
     } else {
       this.port = await getPort();
-      const cwd = this.context.asAbsolutePath('lib');
-      const task = buildGradleServerTask(SERVER_TASK_NAME, cwd, [
+      const executableDir = this.context.asAbsolutePath('lib');
+      const task = buildGradleServerTask(SERVER_TASK_NAME, executableDir, [
         String(this.port),
       ]);
-      this.taskExecution = await vscode.tasks.executeTask(task);
+      if (task) {
+        this.taskExecution = await vscode.tasks.executeTask(task);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/badsyntax/vscode-gradle/issues/245
Refs https://github.com/badsyntax/vscode-gradle/issues/243

This is still a POC. 

## What do we want? 

We want vscode-gradle and vscode-java to support standard gradle builds with relative paths. There are real uses cases for it as reported by the linked issues.

## Where are relative paths defined?

Relative paths can be set is various places, including:

- vscode settings 
  - eg `java.import.gradle.user.home`
- `build.gradle` 
  - eg `def buildNumber = new File("build.num").text.toInteger() + 1`)
- `gradle.properties` 
  - eg `org.gradle.java.home=../../../../../Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home`
  - eg `org.gradle.jvmargs=-Djavax.net.ssl.trustStore="../../../../modules/Common/security/cacerts" -Djavax.net.ssl.trustStorePassword=<trust-password>`

## How do we support relative paths?

In some cases we can normalise paths in the client (eg for vscode settings), but in the other cases we cannot. 

The core of the problem is that, when running `./gradlew` from the root of the project, the `cwd` that gradle uses is the root of the project, and relative paths work. When running gradle from a server, the `cwd` is *not* the root of the project, and in the case of vscode, is usually an extension directory.

So the fix/workaround, is to start the server from the root of the project, as demonstrated by the POC code in this PR. Think `cp.exec('/absolute/path/to/executable', { cwd: projectRoot })`

The problem with this approach, is it doesn't support multi-root workspaces. 