### PR TITLE
Fixed output stream buffering

### DIFF
--- a/tasks-server/src/main/java/com/github/badsyntax/gradletasks/ByteBufferOutputStream.java
+++ b/tasks-server/src/main/java/com/github/badsyntax/gradletasks/ByteBufferOutputStream.java
@@ -5,16 +5,11 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public abstract class ByteBufferOutputStream extends OutputStream {
-  private static final int MAX_SIZE = 1024;
   private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 
   @Override
   public final void write(int b) throws IOException {
     outputStream.write(b);
-    if (outputStream.size() == MAX_SIZE
-        || Character.toString((char) b).equals(System.lineSeparator())) {
-      flush();
-    }
   }
 
   @Override

--- a/tasks-server/src/main/java/com/github/badsyntax/gradletasks/StringBufferOutputStream.java
+++ b/tasks-server/src/main/java/com/github/badsyntax/gradletasks/StringBufferOutputStream.java
@@ -15,15 +15,10 @@ public abstract class StringBufferOutputStream extends OutputStream {
   @Override
   public void close() throws IOException {
     if (outputStream.size() > 0) {
-      flush();
+      onFlush(outputStream.toString());
+      outputStream.reset();
     }
     outputStream.close();
-  }
-
-  @Override
-  public void flush() {
-    onFlush(outputStream.toString());
-    outputStream.reset();
   }
 
   public abstract void onFlush(String output);


### PR DESCRIPTION
This fixes a couple of things:

- Showing massive output from internal gradle tasks (dependencies)
- Showing full string output from gradle tasks (eg spotlessApply)