### PR TITLE
Fix client connect race condition issue

### DIFF
--- a/extension/src/client.ts
+++ b/extension/src/client.ts
@@ -40,8 +40,6 @@ export class GradleTasksClient implements vscode.Disposable {
   >();
   public readonly onConnect: vscode.Event<null> = this._onConnect.event;
   public readonly onConnectFail: vscode.Event<null> = this._onConnectFail.event;
-  private connectTries = 0;
-  private maxConnectTries = 5;
 
   public constructor(
     private readonly server: GradleTasksServer,
@@ -430,24 +428,15 @@ export class GradleTasksClient implements vscode.Disposable {
   };
 
   private handleConnectError = (e: Error): void => {
-    // Even though the gRPC client should keep retrying to connect, in some cases
-    // that doesn't work as expected (like CI tests in Windows), which is why we
-    // have to manually keep retrying.
-    if (this.connectTries < this.maxConnectTries) {
-      this.connectTries += 1;
-      this.grpcClient?.close();
-      this.connectToServer();
-    } else {
-      logger.error(
-        localize(
-          'client.errorConnectingToServer',
-          'Error connecting to gradle server: {0}',
-          e.message
-        )
-      );
-      this._onConnectFail.fire(null);
-      this.server.showRestartMessage();
-    }
+    logger.error(
+      localize(
+        'client.errorConnectingToServer',
+        'Error connecting to gradle server: {0}',
+        e.message
+      )
+    );
+    this._onConnectFail.fire(null);
+    this.server.showRestartMessage();
   };
 
   public dispose(): void {

--- a/extension/src/client.ts
+++ b/extension/src/client.ts
@@ -30,7 +30,9 @@ import { LoggerStream } from './LoggerSteam';
 const localize = nls.loadMessageBundle();
 
 export class GradleTasksClient implements vscode.Disposable {
-  private connectDeadline = 3; // seconds
+  // The connectDeadline is a high number because, even though the Java process has been
+  // started, the gGRPC server is not yet ready to accept connections.
+  private connectDeadline = 120;
   private grpcClient: GrpcClient | null = null;
   private _onConnect: vscode.EventEmitter<null> = new vscode.EventEmitter<
     null
@@ -436,6 +438,7 @@ export class GradleTasksClient implements vscode.Disposable {
       )
     );
     this._onConnectFail.fire(null);
+    // TODO: should this show a client reconnect message instead?
     this.server.showRestartMessage();
   };
 

--- a/extension/src/tasks.ts
+++ b/extension/src/tasks.ts
@@ -555,7 +555,7 @@ export function buildGradleServerTask(
     vscode.TaskScope.Workspace,
     taskName,
     taskType,
-    new vscode.ProcessExecution(cmd, args, { cwd, env })
+    new vscode.ShellExecution(cmd, args, { cwd, env })
   );
 }
 

--- a/extension/src/test/testUtil.ts
+++ b/extension/src/test/testUtil.ts
@@ -23,7 +23,7 @@ export function createTestRunner(pattern: string) {
     // Create the mocha test
     const mocha = new Mocha({
       ui: 'bdd',
-      timeout: 60000,
+      timeout: 130000,
       color: true,
     });
     mocha.bail(true);


### PR DESCRIPTION
Refs https://github.com/badsyntax/vscode-gradle/issues/397

Part of this fix was added in https://github.com/badsyntax/vscode-gradle/pull/405

It's super weird, but setting the task presentationOptions caused odd internal vscode behaviour, which is why i couldn't previously use onDidStartTaskProcess.