### PR TITLE
Wait for gRPC server to start before connecting client

### DIFF
--- a/extension/src/client.ts
+++ b/extension/src/client.ts
@@ -30,9 +30,7 @@ import { LoggerStream } from './LoggerSteam';
 const localize = nls.loadMessageBundle();
 
 export class GradleTasksClient implements vscode.Disposable {
-  // The connectDeadline is a high number because, even though the Java process has been
-  // started, the gGRPC server is not yet ready to accept connections.
-  private connectDeadline = 120;
+  private connectDeadline = 5; // seconds
   private grpcClient: GrpcClient | null = null;
   private _onConnect: vscode.EventEmitter<null> = new vscode.EventEmitter<
     null

--- a/extension/src/test/testUtil.ts
+++ b/extension/src/test/testUtil.ts
@@ -23,7 +23,7 @@ export function createTestRunner(pattern: string) {
     // Create the mocha test
     const mocha = new Mocha({
       ui: 'bdd',
-      timeout: 130000,
+      timeout: 60000,
       color: true,
     });
     mocha.bail(true);


### PR DESCRIPTION
Refs https://github.com/badsyntax/vscode-gradle/issues/397

As the gGRPC client should only try connect once the server is started, we now wait for the socket to be open before attempting to connect.

The extension will wait a maximum of 2 minutes for the socket to be open on the specified port. This should be more than enough time for most machines. 