### PR TITLE
Add support for task args

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The extension uses the Gradle wrapper to list daemons, and is quite a slow proce
 - Show flat or nested tasks in the explorer
 - Gracefully cancel a running task
 - Debug JavaExec tasks
-- Run/debug a task with custom arguments
+- Run/debug a task with arguments (supports both build & task args, eg `gradle tasks --all --info`)
 - Pin tasks
 - List recent tasks
 - List & stop daemons

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/RunTaskHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/RunTaskHandler.java
@@ -18,6 +18,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -98,6 +99,12 @@ public class RunTaskHandler {
           }
         };
 
+    // Specifying the tasks to run via build arguments provides support for task *and* build
+    // arguments.
+    // Using BuildLauncher.forTasks() prevents us from specifying task args.
+    ArrayList<String> argsList = new ArrayList<String>(req.getArgsList());
+    argsList.add(0, req.getTask());
+
     BuildLauncher build =
         connection
             .newBuild()
@@ -123,8 +130,7 @@ public class RunTaskHandler {
                   }
                 })
             .setColorOutput(req.getShowOutputColors())
-            .withArguments(req.getArgsList())
-            .forTasks(req.getTask());
+            .withArguments(argsList);
 
     if (!Strings.isNullOrEmpty(req.getInput())) {
       InputStream inputStream = new ByteArrayInputStream(req.getInput().getBytes());


### PR DESCRIPTION
Fixes https://github.com/badsyntax/vscode-gradle/issues/498

Previously, you could only set build args when running a task. This change adds support for both build args AND task args. 

Works with (for example) `tasks --all --info`