### PR TITLE
Fix adding carriage return at end of terminal output

### DIFF
--- a/extension/src/terminal/GradleRunnerTerminal.ts
+++ b/extension/src/terminal/GradleRunnerTerminal.ts
@@ -12,7 +12,7 @@ import { COMMAND_CANCEL_BUILD } from '../commands';
 
 const NL = '\n';
 const CR = '\r';
-const nlRegExp = new RegExp(`${NL}([^${CR}])`, 'g');
+const nlRegExp = new RegExp(`${NL}([^${CR}]|$)`, 'g');
 
 export class GradleRunnerTerminal {
   private readonly writeEmitter = new vscode.EventEmitter<string>();


### PR DESCRIPTION
Fixes https://github.com/badsyntax/vscode-gradle/issues/523