### PR TITLE
Sanitized Gradle server start script to allow for spaced PATH

### DIFF
--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -48,7 +48,7 @@ export class GradleServer implements vscode.Disposable {
       this.logger.debug('Starting server');
       this.logger.debug(`Gradle Server cmd: ${cmd} ${args.join(' ')}`);
 
-      this.process = cp.spawn(cmd, args, { cwd, env, shell: true });
+      this.process = cp.spawn('"' + cmd + '"', args, { cwd, env, shell: true });
       this.process.stdout.on('data', this.logOutput);
       this.process.stderr.on('data', this.logOutput);
       this.process


### PR DESCRIPTION
Had an issue where the Gradle server simply wouldn't start due to my PATH containing a space. Quick fix was to manually sanitize the batch file path when spawning the process. This should not be considered a long term solution, but it will work.