### PR TITLE
Kill process group

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -757,6 +757,7 @@
     "sinon": "^9.0.3",
     "snyk": "^1.366.2",
     "string-argv": "^0.3.1",
+    "tree-kill": "^1.2.2",
     "ts-protoc-gen": "^0.13.0",
     "typescript": "^3.9.7",
     "vsce": "^1.77.0",

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as cp from 'child_process';
 import getPort from 'get-port';
+import kill from 'tree-kill';
 import { getGradleServerCommand, getGradleServerEnv } from './serverUtil';
 import { isDebuggingServer } from '../util';
 import { Logger } from '../logger/index';
@@ -48,7 +49,11 @@ export class GradleServer implements vscode.Disposable {
       this.logger.debug('Starting server');
       this.logger.debug(`Gradle Server cmd: ${cmd} ${args.join(' ')}`);
 
-      this.process = cp.spawn('"' + cmd + '"', args, { cwd, env, shell: true });
+      this.process = cp.spawn(`"${cmd}"`, args, {
+        cwd,
+        env,
+        shell: true,
+      });
       this.process.stdout.on('data', this.logOutput);
       this.process.stderr.on('data', this.logOutput);
       this.process
@@ -112,7 +117,9 @@ export class GradleServer implements vscode.Disposable {
   };
 
   private killProcess(): void {
-    this.process?.kill('SIGTERM');
+    if (this.process) {
+      kill(this.process.pid, 'SIGTERM');
+    }
   }
 
   private async handleServerStartError(): Promise<void> {


### PR DESCRIPTION
Fixes #684

We start the java process via a shell script. We spawn that shell script in its own shell. When we try to kill the sub-process, we're just killing the shell and not the process started by the shell. Using [tree-kill](https://www.npmjs.com/package/tree-kill) we can kill all descendant processes of the shell.

Manually tested in MacOS, Windows & Linux