### PR TITLE
Ignore @grpc/proto-loader from build due to protobufjs bundle issues

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -5166,6 +5166,12 @@
         "fsevents": "~2.1.2"
       }
     },
+    "rollup-plugin-ignore": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-ignore/-/rollup-plugin-ignore-1.0.9.tgz",
+      "integrity": "sha512-+Q2jmD4gbO3ByFuljkDEfpEcYvll7J5+ZadUuk/Pu35x2KGrbHxKtt3+s+dPIgXX1mG7zCxG4s/NdRqztR5Ruw==",
+      "dev": true
+    },
     "rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",

--- a/extension/package.json
+++ b/extension/package.json
@@ -758,6 +758,7 @@
     "mocha": "^8.1.3",
     "prettier": "^2.1.2",
     "rollup": "^2.28.2",
+    "rollup-plugin-ignore": "^1.0.9",
     "rollup-plugin-terser": "^7.0.2",
     "sinon": "^9.1.0",
     "snyk": "^1.406.0",

--- a/extension/rollup.config.js
+++ b/extension/rollup.config.js
@@ -3,6 +3,7 @@ import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import json from '@rollup/plugin-json';
 import builtins from 'builtin-modules';
+import ignore from "rollup-plugin-ignore"
 import { terser } from 'rollup-plugin-terser';
 
 const outputPlugins = [];
@@ -21,10 +22,11 @@ export default [
       plugins: outputPlugins,
     },
     plugins: [
+      ignore(['@grpc/proto-loader']),
       resolve({ preferBuiltins: true }),
       typescript({ module: 'ES2015', outDir: 'dist', declaration: true }),
       commonjs({
-        ignore: ['encoding', 'google-auth-library', '@grpc/proto-loader'],
+        ignore: ['encoding', 'google-auth-library'],
       }),
       json(),
     ],


### PR DESCRIPTION
This is a quick-fix as the current release is broken.