### PR TITLE
Fix nested projects extension activate

### DIFF
--- a/extension/src/client/GradleClient.ts
+++ b/extension/src/client/GradleClient.ts
@@ -70,8 +70,12 @@ export class GradleClient implements vscode.Disposable {
   ) {
     this.server.onDidStart(this.handleServerStart);
     this.server.onDidStop(this.handleServerStop);
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    this.server.start();
+  }
+
+  public async connect(): Promise<void> {
+    if (!this.server.isReady()) {
+      await this.server.start();
+    }
   }
 
   private handleServerStop = (): void => {

--- a/extension/src/client/GradleClient.ts
+++ b/extension/src/client/GradleClient.ts
@@ -72,12 +72,6 @@ export class GradleClient implements vscode.Disposable {
     this.server.onDidStop(this.handleServerStop);
   }
 
-  public async connect(): Promise<void> {
-    if (!this.server.isReady()) {
-      await this.server.start();
-    }
-  }
-
   private handleServerStop = (): void => {
     this.close();
   };

--- a/extension/src/commands/RefreshCommand.ts
+++ b/extension/src/commands/RefreshCommand.ts
@@ -18,7 +18,6 @@ export class RefreshCommand extends Command {
   }
   async run(): Promise<void> {
     this.gradleTaskProvider.clearTasksCache();
-    // Explicitly load tasks as the views might not be visible
     void this.gradleTaskProvider.loadTasks();
     this.gradleTasksTreeDataProvider.refresh();
     this.pinnedTasksTreeDataProvider.refresh();

--- a/extension/src/commands/StopDaemonsCommand.ts
+++ b/extension/src/commands/StopDaemonsCommand.ts
@@ -22,7 +22,7 @@ export class StopDaemonsCommand extends Command {
     ) {
       return;
     }
-    const gradleRootFolders = await this.rootProjectsStore.buildAndGetProjectRootsWithUniqueVersions();
+    const gradleRootFolders = this.rootProjectsStore.getProjectRootsWithUniqueVersions();
     const promises: Promise<StopDaemonsReply | void>[] = gradleRootFolders.map(
       (rootProject) =>
         this.client.stopDaemons(rootProject.getProjectUri().fsPath)

--- a/extension/src/commands/StopDaemonsCommand.ts
+++ b/extension/src/commands/StopDaemonsCommand.ts
@@ -22,7 +22,7 @@ export class StopDaemonsCommand extends Command {
     ) {
       return;
     }
-    const gradleRootFolders = this.rootProjectsStore.getProjectRootsWithUniqueVersions();
+    const gradleRootFolders = await this.rootProjectsStore.getProjectRootsWithUniqueVersions();
     const promises: Promise<StopDaemonsReply | void>[] = gradleRootFolders.map(
       (rootProject) =>
         this.client.stopDaemons(rootProject.getProjectUri().fsPath)

--- a/extension/src/extension/Extension.ts
+++ b/extension/src/extension/Extension.ts
@@ -271,6 +271,9 @@ export class Extension {
             event.affectsConfiguration('gradle.javaDebug') ||
             event.affectsConfiguration('gradle.nestedProjects')
           ) {
+            await this.client.cancelBuilds();
+            this.rootProjectsStore.clear();
+            await this.refresh();
             await this.connect();
           }
           if (event.affectsConfiguration('gradle.debug')) {

--- a/extension/src/extension/Extension.ts
+++ b/extension/src/extension/Extension.ts
@@ -269,8 +269,8 @@ export class Extension {
             event.affectsConfiguration('gradle.nestedProjects')
           ) {
             this.rootProjectsStore.clear();
-            await this.activate();
             await this.refresh();
+            await this.activate();
           }
           if (event.affectsConfiguration('gradle.debug')) {
             const debug = getConfigIsDebugEnabled();

--- a/extension/src/index.ts
+++ b/extension/src/index.ts
@@ -4,9 +4,7 @@ import { Api } from './api';
 import { Extension } from './extension';
 
 export function activate(context: vscode.ExtensionContext): Api {
-  const extension = new Extension(context);
-  void extension.activate();
-  return extension.getApi();
+  return new Extension(context).getApi();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/extension/src/index.ts
+++ b/extension/src/index.ts
@@ -4,7 +4,9 @@ import { Api } from './api';
 import { Extension } from './extension';
 
 export function activate(context: vscode.ExtensionContext): Api {
-  return new Extension(context).getApi();
+  const extension = new Extension(context);
+  void extension.activate();
+  return extension.getApi();
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/extension/src/input/index.ts
+++ b/extension/src/input/index.ts
@@ -36,7 +36,7 @@ export function getGradleCommand(): Thenable<TaskArgs | undefined> {
 export async function getRootProjectFolder(
   rootProjectsStore: RootProjectsStore
 ): Promise<RootProject | undefined> {
-  const rootProjects = rootProjectsStore.getProjectRoots();
+  const rootProjects = await rootProjectsStore.getProjectRoots();
   if (rootProjects.length === 1) {
     return Promise.resolve(rootProjects[0]);
   }

--- a/extension/src/input/index.ts
+++ b/extension/src/input/index.ts
@@ -36,7 +36,7 @@ export function getGradleCommand(): Thenable<TaskArgs | undefined> {
 export async function getRootProjectFolder(
   rootProjectsStore: RootProjectsStore
 ): Promise<RootProject | undefined> {
-  const rootProjects = await rootProjectsStore.buildAndGetProjectRoots();
+  const rootProjects = rootProjectsStore.getProjectRoots();
   if (rootProjects.length === 1) {
     return Promise.resolve(rootProjects[0]);
   }

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -131,9 +131,14 @@ export class GradleServer implements vscode.Disposable {
     this._onDidStart.fire(null);
   }
 
-  public dispose(): void {
+  public stop(): void {
     this.process?.removeAllListeners();
     this.killProcess();
+    this.ready = false;
+  }
+
+  public dispose(): void {
+    this.stop();
     this._onDidStart.dispose();
     this._onDidStop.dispose();
   }

--- a/extension/src/tasks/GradleTaskProvider.ts
+++ b/extension/src/tasks/GradleTaskProvider.ts
@@ -83,7 +83,7 @@ export class GradleTaskProvider
     }
     logger.debug('Refreshing tasks');
     this._onDidStartRefresh.fire(null);
-    const folders = await this.rootProjectsStore.buildAndGetProjectRoots();
+    const folders = this.rootProjectsStore.getProjectRoots();
     if (!folders.length) {
       this.cachedTasks = [];
       return Promise.resolve(this.cachedTasks);

--- a/extension/src/tasks/GradleTaskProvider.ts
+++ b/extension/src/tasks/GradleTaskProvider.ts
@@ -83,7 +83,7 @@ export class GradleTaskProvider
     }
     logger.debug('Refreshing tasks');
     this._onDidStartRefresh.fire(null);
-    const folders = this.rootProjectsStore.getProjectRoots();
+    const folders = await this.rootProjectsStore.getProjectRoots();
     if (!folders.length) {
       this.cachedTasks = [];
       return Promise.resolve(this.cachedTasks);

--- a/extension/src/test/integration/nested-projects/extension.test.ts
+++ b/extension/src/test/integration/nested-projects/extension.test.ts
@@ -27,6 +27,11 @@ describe(getSuiteName('Extension'), () => {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   describe('Task provider', () => {
     describe('Without nestedProjects enabled', () => {
+      before(async () => {
+        await vscode.workspace
+          .getConfiguration('gradle')
+          .update('nestedProjects', false);
+      });
       it('should not load any tasks', async () => {
         const tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
         assert.equal(tasks.length, 0);
@@ -40,6 +45,7 @@ describe(getSuiteName('Extension'), () => {
         await vscode.workspace
           .getConfiguration('gradle')
           .update('nestedProjects', true);
+        await new Promise((res) => setTimeout(res, 100));
       });
 
       after(async () => {
@@ -87,6 +93,7 @@ describe(getSuiteName('Extension'), () => {
         await vscode.workspace
           .getConfiguration('gradle')
           .update('nestedProjects', ['gradle-groovy-default-build-file']);
+        await new Promise((res) => setTimeout(res, 100));
       });
 
       after(async () => {

--- a/extension/src/test/integration/nested-projects/extension.test.ts
+++ b/extension/src/test/integration/nested-projects/extension.test.ts
@@ -13,6 +13,18 @@ describe(getSuiteName('Extension'), () => {
     extension = vscode.extensions.getExtension(EXTENSION_NAME);
   });
 
+  before(async () => {
+    await vscode.workspace
+      .getConfiguration('gradle')
+      .update('nestedProjects', false);
+  });
+
+  after(async () => {
+    await vscode.workspace
+      .getConfiguration('gradle')
+      .update('nestedProjects', false);
+  });
+
   it('should be present', () => {
     assert.ok(extension);
   });
@@ -27,11 +39,6 @@ describe(getSuiteName('Extension'), () => {
   // eslint-disable-next-line sonarjs/cognitive-complexity
   describe('Task provider', () => {
     describe('Without nestedProjects enabled', () => {
-      before(async () => {
-        await vscode.workspace
-          .getConfiguration('gradle')
-          .update('nestedProjects', false);
-      });
       it('should not load any tasks', async () => {
         const tasks = await vscode.tasks.fetchTasks({ type: 'gradle' });
         assert.equal(tasks.length, 0);
@@ -45,12 +52,6 @@ describe(getSuiteName('Extension'), () => {
         await vscode.workspace
           .getConfiguration('gradle')
           .update('nestedProjects', true);
-      });
-
-      after(async () => {
-        await vscode.workspace
-          .getConfiguration('gradle')
-          .update('nestedProjects', false);
       });
 
       beforeEach(async () => {
@@ -92,12 +93,6 @@ describe(getSuiteName('Extension'), () => {
         await vscode.workspace
           .getConfiguration('gradle')
           .update('nestedProjects', ['gradle-groovy-default-build-file']);
-      });
-
-      after(async () => {
-        await vscode.workspace
-          .getConfiguration('gradle')
-          .update('nestedProjects', false);
       });
 
       beforeEach(async () => {

--- a/extension/src/test/integration/nested-projects/extension.test.ts
+++ b/extension/src/test/integration/nested-projects/extension.test.ts
@@ -45,7 +45,6 @@ describe(getSuiteName('Extension'), () => {
         await vscode.workspace
           .getConfiguration('gradle')
           .update('nestedProjects', true);
-        await new Promise((res) => setTimeout(res, 100));
       });
 
       after(async () => {
@@ -93,7 +92,6 @@ describe(getSuiteName('Extension'), () => {
         await vscode.workspace
           .getConfiguration('gradle')
           .update('nestedProjects', ['gradle-groovy-default-build-file']);
-        await new Promise((res) => setTimeout(res, 100));
       });
 
       after(async () => {

--- a/extension/src/test/runTests.ts
+++ b/extension/src/test/runTests.ts
@@ -7,7 +7,7 @@ import { runTests, downloadAndUnzipVSCode } from 'vscode-test';
 
 const extensionDevelopmentPath = path.resolve(__dirname, '../../');
 // TODO: consider also testing using insiders
-const VSCODE_VERSION = '1.49.0';
+const VSCODE_VERSION = '1.49.3';
 
 async function runTestsWithGradle(
   vscodeExecutablePath: string,

--- a/extension/src/test/testUtil.ts
+++ b/extension/src/test/testUtil.ts
@@ -99,6 +99,7 @@ export function stubWorkspaceFolders(
     vscode.workspace,
     'getWorkspaceFolder'
   );
+  const dirnameStub = sinon.stub(path, 'dirname');
   workspaceFolders.forEach((workspaceFolder) => {
     existsSyncStub
       .withArgs(path.join(workspaceFolder.uri.fsPath, 'gradlew'))
@@ -106,7 +107,14 @@ export function stubWorkspaceFolders(
     getWorkspaceFolderStub
       .withArgs(sinon.match.has('fsPath', workspaceFolder.uri.fsPath))
       .returns(workspaceFolder);
+    dirnameStub
+      .withArgs(workspaceFolder.uri.fsPath)
+      .returns(workspaceFolder.uri.fsPath);
   });
+  sinon
+    .stub(vscode.workspace, 'findFiles')
+    .withArgs('**/{gradlew,gradlew.bat}')
+    .returns(Promise.resolve(workspaceFolders.map((folder) => folder.uri)));
 }
 
 export function buildMockContext(): any {

--- a/extension/src/test/unit/gradleDaemons.test.ts
+++ b/extension/src/test/unit/gradleDaemons.test.ts
@@ -70,7 +70,7 @@ describe(getSuiteName('Gradle daemons'), () => {
     await rootProjectsStore.populate();
 
     // GradleClient.getBuild() sets the gradle versions once it receives the gradle environment
-    const projectRoots = rootProjectsStore.getProjectRoots();
+    const projectRoots = await rootProjectsStore.getProjectRoots();
     const gradleEnvironment1 = new GradleEnvironment();
     gradleEnvironment1.setGradleVersion('6.3');
     const environment1 = new Environment();
@@ -100,7 +100,7 @@ describe(getSuiteName('Gradle daemons'), () => {
   });
 
   it('should filter out projects with duplicate gradle versions', async () => {
-    const projects = rootProjectsStore.getProjectRootsWithUniqueVersions();
+    const projects = await rootProjectsStore.getProjectRootsWithUniqueVersions();
     assert.strictEqual(
       projects.length,
       2,

--- a/extension/src/test/unit/gradleTasks.test.ts
+++ b/extension/src/test/unit/gradleTasks.test.ts
@@ -102,10 +102,11 @@ describe(getSuiteName('Gradle tasks'), () => {
   let taskTerminalsStore: TaskTerminalsStore;
   let gradleTaskProvider: GradleTaskProvider;
   let client: any;
-  beforeEach(() => {
+  let rootProjectsStore: RootProjectsStore;
+  beforeEach(async () => {
     // const icons = new Icons(mockContext);
     client = buildMockClient();
-    const rootProjectsStore = new RootProjectsStore();
+    rootProjectsStore = new RootProjectsStore();
 
     taskTerminalsStore = new TaskTerminalsStore();
     gradleTaskProvider = new GradleTaskProvider(
@@ -129,8 +130,9 @@ describe(getSuiteName('Gradle tasks'), () => {
 
   describe('Without a multi-root workspace', () => {
     describe('With no gradle tasks', () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         stubWorkspaceFolders([mockWorkspaceFolder1]);
+        await rootProjectsStore.populate();
       });
       it('should build a "No Tasks" tree item when no tasks are found', async () => {
         client.getBuild.resolves(mockGradleBuildWithoutTasks);
@@ -165,6 +167,7 @@ describe(getSuiteName('Gradle tasks'), () => {
       beforeEach(async () => {
         stubWorkspaceFolders([mockWorkspaceFolder1]);
         client.getBuild.resolves(mockGradleBuildWithTasks);
+        await rootProjectsStore.populate();
       });
 
       describe('Expanded tree', () => {
@@ -409,6 +412,7 @@ describe(getSuiteName('Gradle tasks'), () => {
   describe('With a multi-root workspace', () => {
     beforeEach(async () => {
       stubWorkspaceFolders([mockWorkspaceFolder1, mockWorkspaceFolder2]);
+      await rootProjectsStore.populate();
     });
 
     describe('Without gradle tasks', () => {

--- a/extension/src/test/unit/pinnedTasks.test.ts
+++ b/extension/src/test/unit/pinnedTasks.test.ts
@@ -82,9 +82,10 @@ describe(getSuiteName('Pinned tasks'), () => {
   let pinnedTasksTreeDataProvider: PinnedTasksTreeDataProvider;
   let gradleTaskProvider: GradleTaskProvider;
   let pinnedTasksStore: PinnedTasksStore;
-  beforeEach(() => {
+  let rootProjectsStore: RootProjectsStore;
+  beforeEach(async () => {
     const client = buildMockClient();
-    const rootProjectsStore = new RootProjectsStore();
+    rootProjectsStore = new RootProjectsStore();
     const taskTerminalsStore = new TaskTerminalsStore();
     gradleTaskProvider = new GradleTaskProvider(
       rootProjectsStore,
@@ -120,6 +121,7 @@ describe(getSuiteName('Pinned tasks'), () => {
   describe('Without a multi-root workspace', () => {
     beforeEach(async () => {
       stubWorkspaceFolders([mockWorkspaceFolder1]);
+      await rootProjectsStore.populate();
       await gradleTaskProvider.loadTasks();
     });
 
@@ -382,6 +384,7 @@ describe(getSuiteName('Pinned tasks'), () => {
   describe('With a multi-root workspace', () => {
     beforeEach(async () => {
       stubWorkspaceFolders([mockWorkspaceFolder1, mockWorkspaceFolder2]);
+      await rootProjectsStore.populate();
       await gradleTaskProvider.loadTasks();
     });
 

--- a/extension/src/test/unit/recentTasks.test.ts
+++ b/extension/src/test/unit/recentTasks.test.ts
@@ -80,10 +80,11 @@ describe(getSuiteName('Recent tasks'), () => {
   let gradleTaskProvider: GradleTaskProvider;
   let recentTasksStore: RecentTasksStore;
   let taskTerminalsStore: TaskTerminalsStore;
-  beforeEach(() => {
+  let rootProjectsStore: RootProjectsStore;
+  beforeEach(async () => {
     const client = buildMockClient();
     const icons = new Icons(mockContext);
-    const rootProjectsStore = new RootProjectsStore();
+    rootProjectsStore = new RootProjectsStore();
     taskTerminalsStore = new TaskTerminalsStore();
     gradleTaskProvider = new GradleTaskProvider(
       rootProjectsStore,
@@ -112,6 +113,7 @@ describe(getSuiteName('Recent tasks'), () => {
   describe('Without a multi-root workspace', () => {
     beforeEach(async () => {
       stubWorkspaceFolders([mockWorkspaceFolder1]);
+      await rootProjectsStore.populate();
       await gradleTaskProvider.loadTasks();
     });
 
@@ -275,6 +277,7 @@ describe(getSuiteName('Recent tasks'), () => {
   describe('With multi-root workspace', () => {
     beforeEach(async () => {
       stubWorkspaceFolders([mockWorkspaceFolder1, mockWorkspaceFolder2]);
+      await rootProjectsStore.populate();
       recentTasksStore.addEntry(
         mockTaskDefinition1.id,
         mockTaskDefinition1.args
@@ -328,6 +331,7 @@ describe(getSuiteName('Recent tasks'), () => {
     const mockTerminal2 = buildMockTerminal();
     beforeEach(async () => {
       stubWorkspaceFolders([mockWorkspaceFolder1]);
+      await rootProjectsStore.populate();
       await gradleTaskProvider.loadTasks();
       recentTasksStore.addEntry(
         mockTaskDefinition1.id,

--- a/extension/src/views/gradleDaemons/GradleDaemonsTreeDataProvider.ts
+++ b/extension/src/views/gradleDaemons/GradleDaemonsTreeDataProvider.ts
@@ -68,8 +68,8 @@ export class GradleDaemonsTreeDataProvider
   }
 
   private async getProjectRootFolders(): Promise<string[]> {
-    return this.rootProjectsStore
-      .getProjectRootsWithUniqueVersions()
-      .map((rootProject) => rootProject.getProjectUri().fsPath);
+    return (
+      await this.rootProjectsStore.getProjectRootsWithUniqueVersions()
+    ).map((rootProject) => rootProject.getProjectUri().fsPath);
   }
 }

--- a/extension/src/views/gradleDaemons/GradleDaemonsTreeDataProvider.ts
+++ b/extension/src/views/gradleDaemons/GradleDaemonsTreeDataProvider.ts
@@ -68,8 +68,8 @@ export class GradleDaemonsTreeDataProvider
   }
 
   private async getProjectRootFolders(): Promise<string[]> {
-    return (
-      await this.rootProjectsStore.buildAndGetProjectRootsWithUniqueVersions()
-    ).map((rootProject) => rootProject.getProjectUri().fsPath);
+    return this.rootProjectsStore
+      .getProjectRootsWithUniqueVersions()
+      .map((rootProject) => rootProject.getProjectUri().fsPath);
   }
 }

--- a/extension/src/views/pinnedTasks/PinnedTasksTreeDataProvider.ts
+++ b/extension/src/views/pinnedTasks/PinnedTasksTreeDataProvider.ts
@@ -144,7 +144,7 @@ export class PinnedTasksTreeDataProvider
     pinnedTasksTreeItemMap.clear();
     pinnedTasksGradleProjectTreeItemMap.clear();
 
-    const rootProjects = this.rootProjectsStore.getProjectRoots();
+    const rootProjects = await this.rootProjectsStore.getProjectRoots();
     if (!rootProjects.length) {
       return [];
     }

--- a/extension/src/views/pinnedTasks/PinnedTasksTreeDataProvider.ts
+++ b/extension/src/views/pinnedTasks/PinnedTasksTreeDataProvider.ts
@@ -144,7 +144,7 @@ export class PinnedTasksTreeDataProvider
     pinnedTasksTreeItemMap.clear();
     pinnedTasksGradleProjectTreeItemMap.clear();
 
-    const rootProjects = await this.rootProjectsStore.buildAndGetProjectRoots();
+    const rootProjects = this.rootProjectsStore.getProjectRoots();
     if (!rootProjects.length) {
       return [];
     }

--- a/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
+++ b/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
@@ -167,7 +167,7 @@ export class RecentTasksTreeDataProvider
     recentTasksGradleProjectTreeItemMap.clear();
     recentTasksTreeItemMap.clear();
 
-    const gradleProjects = this.rootProjectsStore.getProjectRoots();
+    const gradleProjects = await this.rootProjectsStore.getProjectRoots();
     if (!gradleProjects.length) {
       return [];
     }

--- a/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
+++ b/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
@@ -167,7 +167,7 @@ export class RecentTasksTreeDataProvider
     recentTasksGradleProjectTreeItemMap.clear();
     recentTasksTreeItemMap.clear();
 
-    const gradleProjects = await this.rootProjectsStore.buildAndGetProjectRoots();
+    const gradleProjects = this.rootProjectsStore.getProjectRoots();
     if (!gradleProjects.length) {
       return [];
     }


### PR DESCRIPTION
Fixes https://github.com/badsyntax/vscode-gradle/issues/724

- Now no longer "activates" when there are nested projects but no corresponding config
- Correctly "activate" and "deactivate" when changing the nestedProjects config