### PR TITLE
Expose gradleTaskProvider in API

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -154,6 +154,7 @@ export class Extension {
     this.api = new Api(
       this.client,
       this.gradleTasksTreeDataProvider,
+      this.gradleTaskProvider,
       this.icons
     );
 

--- a/extension/src/api/Api.ts
+++ b/extension/src/api/Api.ts
@@ -5,6 +5,7 @@ import { GradleTasksTreeDataProvider } from '../views';
 import { GradleClient } from '../client';
 import { Icons } from '../icons';
 import { getRunBuildCancellationKey } from '../client/CancellationKeys';
+import { GradleTaskProvider } from '../tasks';
 
 export interface RunTaskOpts {
   projectFolder: string;
@@ -41,6 +42,7 @@ export class Api {
   constructor(
     private readonly client: GradleClient,
     private readonly tasksTreeDataProvider: GradleTasksTreeDataProvider,
+    private readonly gradleTaskProvider: GradleTaskProvider,
     private readonly icons: Icons
   ) {}
 
@@ -105,6 +107,10 @@ export class Api {
 
   public getTasksTreeProvider(): GradleTasksTreeDataProvider {
     return this.tasksTreeDataProvider;
+  }
+
+  public getTaskProvider(): GradleTaskProvider {
+    return this.gradleTaskProvider;
   }
 
   public getIcons(): Icons {

--- a/extension/src/util/EventWaiter.ts
+++ b/extension/src/util/EventWaiter.ts
@@ -2,10 +2,10 @@ import * as vscode from 'vscode';
 
 type callback = () => void;
 
-export class EventWaiter {
+export class EventWaiter<T = null> {
   private eventRun = false;
 
-  constructor(private readonly event: vscode.Event<null>) {
+  constructor(private readonly event: vscode.Event<T>) {
     this.waitForEvent();
   }
 


### PR DESCRIPTION
I need this to enable/disable spotless if the spotlessApply tasks exists or not.