### PR TITLE
fix: Task execution terminal always shows error

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -608,8 +608,8 @@
           ],
           "enumDescriptions": [
             "Use a dedicated terminal for a specific task. The terminal is not shared with other tasks.",
-            "Create a new terminal when a task is executed",
-            "Share the terminal with other tasks"
+            "Create a new terminal when a task is executed.",
+            "Share the terminal with other tasks."
           ],
           "default": "task",
           "scope": "window",

--- a/extension/package.json
+++ b/extension/package.json
@@ -606,6 +606,11 @@
             "off",
             "all"
           ],
+          "enumDescriptions": [
+            "Use a dedicated terminal for a specific task. The terminal is not shared with other tasks.",
+            "Create a new terminal when a task is executed",
+            "Share the terminal with other tasks"
+          ],
           "default": "task",
           "scope": "window",
           "description": "Reuse task terminals behaviour"

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -33,7 +33,6 @@ import { Commands } from './commands/Commands';
 import {
   getConfigIsDebugEnabled,
   getConfigFocusTaskInExplorer,
-  getConfigReuseTerminals,
 } from './util/config';
 import { FileWatcher } from './util/FileWatcher';
 
@@ -226,10 +225,6 @@ export class Extension {
     definition: GradleTaskDefinition,
     terminal: vscode.Terminal
   ): void {
-    const reuseTerminals = getConfigReuseTerminals();
-
-    // Close previously opened task terminals
-    this.taskTerminalsStore.disposeTaskTerminals(definition, reuseTerminals);
     // Add this task terminal to the store
     const terminalTaskName = terminal.name.replace('Task - ', '');
     if (terminalTaskName === definition.script) {

--- a/extension/src/stores/TaskTerminalsStore.ts
+++ b/extension/src/stores/TaskTerminalsStore.ts
@@ -1,8 +1,6 @@
 import * as vscode from 'vscode';
 import { TaskId } from './types';
 import { StoreMapSet } from '.';
-import { GradleTaskDefinition } from '../tasks';
-import { ReuseTerminalsValue } from '../util/config';
 
 export class TaskTerminalsStore extends StoreMapSet<TaskId, vscode.Terminal> {
   removeTerminal(terminal: vscode.Terminal): void {
@@ -17,28 +15,5 @@ export class TaskTerminalsStore extends StoreMapSet<TaskId, vscode.Terminal> {
       }
     });
     this.fireOnDidChange(null);
-  }
-
-  disposeTaskTerminals(
-    definition: GradleTaskDefinition,
-    reuseTerminals: ReuseTerminalsValue
-  ): void {
-    if (reuseTerminals === 'task') {
-      const previousTerminals = this.get(definition.script);
-      if (previousTerminals) {
-        for (const previousTerminal of previousTerminals.values()) {
-          previousTerminal.dispose();
-        }
-        previousTerminals.clear();
-      }
-    } else if (reuseTerminals === 'all') {
-      const store = this.getData();
-      for (const taskTerminals of store.values()) {
-        for (const previousTerminal of taskTerminals.values()) {
-          previousTerminal.dispose();
-        }
-        taskTerminals.clear();
-      }
-    }
   }
 }

--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -22,6 +22,7 @@ import { RootProjectsStore, TaskTerminalsStore } from '../stores';
 import {
   getGradleConfig,
   getConfigIsAutoDetectionEnabled,
+  getConfigReuseTerminals,
 } from '../util/config';
 
 const cancellingTasks: Map<string, vscode.Task> = new Map();
@@ -184,12 +185,20 @@ export function createTaskFromDefinition(
     ),
     ['$gradle']
   );
+
+  const reuseTerminals = getConfigReuseTerminals();
+  let panelKind = vscode.TaskPanelKind.Dedicated;
+  if (reuseTerminals === 'off') {
+    panelKind = vscode.TaskPanelKind.New;
+  } else if (reuseTerminals === 'all') {
+    panelKind = vscode.TaskPanelKind.Shared;
+  }
   task.presentationOptions = {
     showReuseMessage: false,
     clear: true,
     echo: true,
     focus: true,
-    panel: vscode.TaskPanelKind.Shared,
+    panel: panelKind,
     reveal: vscode.TaskRevealKind.Always,
   };
   terminal.setTask(task);

--- a/extension/src/terminal/GradleRunnerTerminal.ts
+++ b/extension/src/terminal/GradleRunnerTerminal.ts
@@ -18,10 +18,10 @@ const nlRegExp = new RegExp(`${NL}([^${CR}]|$)`, 'g');
 export class GradleRunnerTerminal implements vscode.Pseudoterminal {
   private readonly writeEmitter = new vscode.EventEmitter<string>();
   private stdOutLoggerStream: LoggerStream | undefined;
-  private readonly closeEmitter = new vscode.EventEmitter<void>();
+  private readonly closeEmitter = new vscode.EventEmitter<number>();
   private task?: vscode.Task;
   public readonly onDidWrite: vscode.Event<string> = this.writeEmitter.event;
-  public readonly onDidClose: vscode.Event<void> = this.closeEmitter.event;
+  public readonly onDidClose: vscode.Event<number> = this.closeEmitter.event;
 
   constructor(
     private readonly rootProject: RootProject,
@@ -108,7 +108,7 @@ export class GradleRunnerTerminal implements vscode.Pseudoterminal {
     } catch (e) {
       this.handleError(e);
     } finally {
-      this.closeEmitter.fire();
+      this.closeEmitter.fire(0);
     }
   }
 

--- a/extension/src/terminal/GradleRunnerTerminal.ts
+++ b/extension/src/terminal/GradleRunnerTerminal.ts
@@ -105,10 +105,10 @@ export class GradleRunnerTerminal implements vscode.Pseudoterminal {
         true
       );
       await runTask;
+      this.closeEmitter.fire(0);
     } catch (e) {
       this.handleError(e);
-    } finally {
-      this.closeEmitter.fire(0);
+      this.closeEmitter.fire(1);
     }
   }
 


### PR DESCRIPTION
Currently, the task execution terminal will always show error after the task executed, although there is no error when running this task.
![task](https://user-images.githubusercontent.com/45906942/124856632-7219ec00-dfdd-11eb-8bfe-3bc4185f9fb1.png)
This PR will fix the bug. The root cause can be found here: https://github.com/microsoft/vscode/issues/125725

Besides, this PR uses `vscode.TaskPanelKind` to control terminal behavior, which also fix #936 