### PR TITLE
chore: Rename default branch name to main 

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: "0 1 * * 5"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: Build & Publish
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   release:
     types: [published]
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   update_release_draft:

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Tasks run via the `Run a Gradle Build` command are not reflected in any of the t
 </details>
 
 <details><summary>Control task terminal behaviour</summary>
-    
+
 ----
-    
+
 Use one terminal for each task type (default):
 
 ```json
@@ -379,7 +379,7 @@ Refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for instructions on how to run the
 This project was originally started by [@badsyntax](https://github.com/badsyntax) and is now currently maintained by Microsoft. Huge thanks to [@badsyntax](https://github.com/badsyntax) who started it all and made this Gradle extension available.
 
 - Originally forked from [Cazzar/vscode-gradle](https://github.com/Cazzar/vscode-gradle)
-- Inspired by the built-in [npm extension](https://github.com/microsoft/vscode/tree/master/extensions/npm)
+- Inspired by the built-in [npm extension](https://github.com/microsoft/vscode/tree/main/extensions/npm)
 - Thanks to [@hanct](https://github.com/hanct) for providing feature suggestions and BETA testing
 - Thanks to [@dcermak](https://github.com/dcermak) for providing inspiration to write some unit tests
 - Thanks to all who have submitted bug reports and feedback

--- a/extension/src/util/decorators.ts
+++ b/extension/src/util/decorators.ts
@@ -1,4 +1,4 @@
-// Taken from https://github.com/microsoft/vscode/blob/master/src/vs/base/common/decorators.ts
+// Taken from https://github.com/microsoft/vscode/blob/main/src/vs/base/common/decorators.ts
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */


### PR DESCRIPTION
Since the default branch of this repo is renamed to **main**, some branch names in workflow and references should be renamed as well.