### PR TITLE
fix: Linting errors in windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,10 @@
 #
 # https://help.github.com/articles/dealing-with-line-endings/
 #
+
+# This matches the .editorconfig settings
+* text=auto eol=lf
+
 # These are explicitly windows files and should use crlf
 *.bat           text eol=crlf
 


### PR DESCRIPTION
When opening this project in windows with VSCode, the eslint plugin reports EOL problems.
![Screenshot 2021-08-03 111047](https://user-images.githubusercontent.com/45906942/127951660-2041c699-a709-436b-8ca5-08041ee89779.png)
