### PR TITLE
chore: Change extension info after release by Microsoft

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,7 +8,7 @@
     "sonarsource.sonarlint-vscode",
     "zxh404.vscode-proto3",
     "streetsidesoftware.code-spell-checker",
-    "richardwillis.vscode-gradle",
+    "vscjava.vscode-gradle",
     "esbenp.prettier-vscode"
   ]
 }

--- a/API.md
+++ b/API.md
@@ -19,7 +19,7 @@ npm install vscode-gradle --save
 import * as util from "util";
 import { ExtensionApi as GradleApi, RunTaskOpts, Output } from "vscode-gradle";
 
-const extension = vscode.extensions.getExtension("richardwillis.vscode-gradle");
+const extension = vscode.extensions.getExtension("vscjava.vscode-gradle");
 const gradleApi = extension!.exports as GradleApi;
 const runTaskOpts: RunTaskOpts = {
   projectFolder: "/absolute/path/to/project/root",

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Gradle Tasks
 
-[![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/richardwillis.vscode-gradle)](https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-gradle)
+[![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/vscjava.vscode-gradle)](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-gradle)
 [![Build & Publish](https://github.com/microsoft/vscode-gradle/workflows/Build%20&%20Publish/badge.svg)](https://github.com/microsoft/vscode-gradle/actions/workflows/main.yml?query=workflow%3A%22%5C%22Build%22)
-[![CodeQL](https://github.com/microsoft/vscode-gradle/workflows/CodeQL/badge.svg)](https://github.com/microsoft/vscode-gradle/actions?query=workflow%3ACodeQL)
+[![CodeQL](https://github.com/badsyntax/vscode-gradle/workflows/CodeQL/badge.svg)](https://github.com/badsyntax/vscode-gradle/actions?query=workflow%3ACodeQL)
 [![GitHub bug issues](https://img.shields.io/github/issues/microsoft/vscode-gradle/bug?label=bug%20reports)](https://github.com/microsoft/vscode-gradle/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
-
 This VS Code extension provides a visual interface for your Gradle build. It supports whatever Gradle supports and is language agnostic, but can work nicely alongside other extensions like the [Java language support extension](https://github.com/redhat-developer/vscode-java).
 
 ![Gradle Tasks Screencast](images/screencast.gif)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Visual Studio Marketplace Installs](https://img.shields.io/visual-studio-marketplace/i/vscjava.vscode-gradle)](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-gradle)
 [![Build & Publish](https://github.com/microsoft/vscode-gradle/workflows/Build%20&%20Publish/badge.svg)](https://github.com/microsoft/vscode-gradle/actions/workflows/main.yml?query=workflow%3A%22%5C%22Build%22)
-[![CodeQL](https://github.com/badsyntax/vscode-gradle/workflows/CodeQL/badge.svg)](https://github.com/badsyntax/vscode-gradle/actions?query=workflow%3ACodeQL)
+[![CodeQL](https://github.com/microsoft/vscode-gradle/workflows/CodeQL/badge.svg)](https://github.com/microsoft/vscode-gradle/actions?query=workflow%3ACodeQL)
 [![GitHub bug issues](https://img.shields.io/github/issues/microsoft/vscode-gradle/bug?label=bug%20reports)](https://github.com/microsoft/vscode-gradle/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
 This VS Code extension provides a visual interface for your Gradle build. It supports whatever Gradle supports and is language agnostic, but can work nicely alongside other extensions like the [Java language support extension](https://github.com/redhat-developer/vscode-java).
 

--- a/extension/beta/README.md
+++ b/extension/beta/README.md
@@ -1,5 +1,5 @@
 # VS Code Gradle Tasks - Preview
 
-This is the preview release of Gradle Tasks. The stable release can be found here: https://marketplace.visualstudio.com/items?itemName=richardwillis.vscode-gradle
+This is the preview release of Gradle Tasks. The stable release can be found here: https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-gradle
 
 This version is only used for BETA testing of unstable features and is likely to be broken.


### PR DESCRIPTION
This PR includes some changes should be applied after `vscjava.vscode-gradle` released.