### PR TITLE
feat: Support local Gradle installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ This extension supports the following settings which are contributed by the [Jav
 - `java.import.gradle.jvmArguments`: JVM arguments to pass to Gradle
 - `java.import.gradle.wrapper.enabled`: Enable/disable the Gradle wrapper
 - `java.import.gradle.version`: Gradle version, used if the Gradle wrapper is missing or disabled
+- `java.import.gradle.home`: Use Gradle from the specified local installation directory or GRADLE_HOME if the Gradle wrapper is missing or disabled and no 'java.import.gradle.version' is specified.
 
 ### Class References
 

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -54,6 +54,12 @@ export function getConfigJavaImportGradleVersion(): string | null {
     .get<string | null>('import.gradle.version', null);
 }
 
+export function getConfigJavaImportGradleHome(): string | null {
+  return vscode.workspace
+    .getConfiguration('java')
+    .get<string | null>('import.gradle.home', null);
+}
+
 export function getConfigIsDebugEnabled(): boolean {
   return vscode.workspace
     .getConfiguration('gradle')
@@ -107,9 +113,13 @@ export function getConfigJavaDebug(
 
 export function getGradleConfig(): GradleConfig {
   const gradleConfig = new GradleConfig();
+  const gradleHome = getConfigJavaImportGradleHome();
   const gradleUserHome = getConfigJavaImportGradleUserHome();
   const gradleJvmArguments = getConfigJavaImportGradleJvmArguments();
   const gradleVersion = getConfigJavaImportGradleVersion();
+  if (gradleHome !== null) {
+    gradleConfig.setGradleHome(gradleHome);
+  }
   if (gradleUserHome !== null) {
     gradleConfig.setUserHome(gradleUserHome);
   }

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleProjectConnector.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleProjectConnector.java
@@ -25,11 +25,15 @@ public class GradleProjectConnector {
       gradleConnector.useGradleUserHomeDir(
           buildGradleUserHomeFile(config.getUserHome(), projectDir));
     }
-    if (!config.getWrapperEnabled() && Strings.isNullOrEmpty(config.getVersion())) {
-      throw new GradleConnectionException("Gradle version is required");
-    }
-    if (!Strings.isNullOrEmpty(config.getVersion())) {
-      gradleConnector.useGradleVersion(config.getVersion());
+    if (!config.getWrapperEnabled()) {
+      if (!Strings.isNullOrEmpty(config.getVersion())) {
+        gradleConnector.useGradleVersion(config.getVersion());
+      } else if (!Strings.isNullOrEmpty(config.getGradleHome())) {
+        gradleConnector.useInstallation(new File(config.getGradleHome()));
+      } else {
+        throw new GradleConnectionException(
+            "java.import.gradle.home is invalid, please check it again.");
+      }
     }
   }
 

--- a/gradle-server/src/test/java/com/github/badsyntax/gradle/GradleServerTest.java
+++ b/gradle-server/src/test/java/com/github/badsyntax/gradle/GradleServerTest.java
@@ -200,7 +200,8 @@ public class GradleServerTest {
   }
 
   @Test
-  public void getBuild_shouldThrowIfWrapperNotEnabledAndNoVersionSpecified() throws IOException {
+  public void getBuild_shouldThrowIfWrapperNotEnabledAndNoVersionAndNoGradleHomeSpecified()
+      throws IOException {
     StreamObserver<GetBuildReply> mockResponseObserver =
         (StreamObserver<GetBuildReply>) mock(StreamObserver.class);
 
@@ -213,7 +214,9 @@ public class GradleServerTest {
     ArgumentCaptor<Throwable> onError = ArgumentCaptor.forClass(Throwable.class);
     stub.getBuild(req, mockResponseObserver);
     verify(mockResponseObserver).onError(onError.capture());
-    assertEquals("INTERNAL: Gradle version is required", onError.getValue().getMessage());
+    assertEquals(
+        "INTERNAL: java.import.gradle.home is invalid, please check it again.",
+        onError.getValue().getMessage());
   }
 
   @Test
@@ -342,7 +345,8 @@ public class GradleServerTest {
   }
 
   @Test
-  public void runBuild_shouldThrowIfWrapperNotEnabledAndNoVersionSpecified() throws IOException {
+  public void runBuild_shouldThrowIfWrapperNotEnabledAndNoVersionAndNoGradleHomeSpecified()
+      throws IOException {
     StreamObserver<RunBuildReply> mockResponseObserver =
         (StreamObserver<RunBuildReply>) mock(StreamObserver.class);
 
@@ -356,7 +360,9 @@ public class GradleServerTest {
     ArgumentCaptor<Throwable> onError = ArgumentCaptor.forClass(Throwable.class);
     stub.runBuild(req, mockResponseObserver);
     verify(mockResponseObserver).onError(onError.capture());
-    assertEquals("INTERNAL: Gradle version is required", onError.getValue().getMessage());
+    assertEquals(
+        "INTERNAL: java.import.gradle.home is invalid, please check it again.",
+        onError.getValue().getMessage());
   }
 
   @Test

--- a/proto/gradle.proto
+++ b/proto/gradle.proto
@@ -148,6 +148,7 @@ message DaemonInfo {
 }
 
 message GradleConfig {
+  string gradle_home = 1;
   string user_home = 2;
   string jvm_arguments = 3;
   bool wrapper_enabled = 4;


### PR DESCRIPTION
Consumes `java.import.gradle.home` from vscode-java. See https://github.com/microsoft/vscode-gradle/issues/922#issuecomment-901753485 for more details.