### PR TITLE
fix: Support lazy load dependencies

### DIFF
--- a/extension/src/views/gradleTasks/DependencyUtils.ts
+++ b/extension/src/views/gradleTasks/DependencyUtils.ts
@@ -8,35 +8,28 @@ import { DependencyTreeItem } from './DependencyTreeItem';
 import { ProjectDependencyTreeItem } from './ProjectDependencyTreeItem';
 export const GRADLE_OMITTED_REVEAL = 'gradle.omitted.reveal';
 
-export function protocolItem2ProjectDependencyTreeItem(
+export function getDependencyConfigurationTreeItems(
   protocolItem: DependencyItem,
-  parent: vscode.TreeItem
-): ProjectDependencyTreeItem | undefined {
-  const name = 'Dependencies';
-  const projectItem: ProjectDependencyTreeItem = new ProjectDependencyTreeItem(
-    name,
-    vscode.TreeItemCollapsibleState.Collapsed,
-    parent
-  );
+  parent: ProjectDependencyTreeItem
+): DependencyConfigurationTreeItem[] | undefined {
   const children = protocolItem.getChildrenList();
-  const treeChildren = [];
+  const configItems = [];
   for (const child of children) {
     if (child.getType() !== GradleDependencyType.CONFIGURATION) {
       continue;
     }
     const configurationItem = protocolItem2DependencyConfigurationTreeItem(
       child,
-      projectItem
+      parent
     );
     if (configurationItem) {
-      treeChildren.push(configurationItem);
+      configItems.push(configurationItem);
     }
   }
-  if (!treeChildren.length) {
+  if (!configItems.length) {
     return undefined;
   }
-  projectItem.setChildren(treeChildren);
-  return projectItem;
+  return configItems;
 }
 
 function protocolItem2DependencyConfigurationTreeItem(

--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -169,7 +169,7 @@ export class GradleTasksTreeDataProvider
       element
     );
     projectTaskItem.setChildren([...element.groups, ...element.tasks]);
-    const results = [projectTaskItem];
+    const results: vscode.TreeItem[] = [projectTaskItem];
     const resourceUri = element.resourceUri;
     if (!resourceUri) {
       return results;

--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -129,9 +129,8 @@ export class GradleTasksTreeDataProvider
       return [];
     }
     if (element instanceof ProjectDependencyTreeItem) {
-      const dirname = path.dirname(element.getResourceUri().fsPath);
       const dependencyItem = await this.client.getDependencies(
-        dirname,
+        element.getProjectPath(),
         getGradleConfig(),
         element.getProjectName()
       );
@@ -178,7 +177,7 @@ export class GradleTasksTreeDataProvider
       'Dependencies',
       vscode.TreeItemCollapsibleState.Collapsed,
       element,
-      resourceUri,
+      path.dirname(resourceUri.fsPath),
       element.label || resourceUri.fsPath
     );
     return [...results, projectDependencyTreeItem];

--- a/extension/src/views/gradleTasks/HintItem.ts
+++ b/extension/src/views/gradleTasks/HintItem.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+
+export class HintItem extends vscode.TreeItem {
+  constructor(message: string) {
+    super('', vscode.TreeItemCollapsibleState.None);
+    this.description = message;
+  }
+}

--- a/extension/src/views/gradleTasks/ProjectDependencyTreeItem.ts
+++ b/extension/src/views/gradleTasks/ProjectDependencyTreeItem.ts
@@ -9,6 +9,8 @@ export class ProjectDependencyTreeItem extends vscode.TreeItem {
     name: string,
     collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly parentTreeItem: vscode.TreeItem,
+    readonly resourceUri: vscode.Uri,
+    readonly projectName: string,
     // TODO: https://github.com/microsoft/vscode-codicons/issues/77
     iconPath: vscode.ThemeIcon = new vscode.ThemeIcon('file-submodule')
   ) {
@@ -22,5 +24,13 @@ export class ProjectDependencyTreeItem extends vscode.TreeItem {
 
   public getChildren(): vscode.TreeItem[] | undefined {
     return this.children;
+  }
+
+  public getResourceUri(): vscode.Uri {
+    return this.resourceUri;
+  }
+
+  public getProjectName(): string {
+    return this.projectName;
   }
 }

--- a/extension/src/views/gradleTasks/ProjectDependencyTreeItem.ts
+++ b/extension/src/views/gradleTasks/ProjectDependencyTreeItem.ts
@@ -9,7 +9,7 @@ export class ProjectDependencyTreeItem extends vscode.TreeItem {
     name: string,
     collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly parentTreeItem: vscode.TreeItem,
-    readonly resourceUri: vscode.Uri,
+    readonly projectPath: string,
     readonly projectName: string,
     // TODO: https://github.com/microsoft/vscode-codicons/issues/77
     iconPath: vscode.ThemeIcon = new vscode.ThemeIcon('file-submodule')
@@ -26,8 +26,8 @@ export class ProjectDependencyTreeItem extends vscode.TreeItem {
     return this.children;
   }
 
-  public getResourceUri(): vscode.Uri {
-    return this.resourceUri;
+  public getProjectPath(): string {
+    return this.projectPath;
   }
 
   public getProjectName(): string {


### PR DESCRIPTION
To avoid multiple dependency resolving process showed in the notification, I'd like to apply lazy load for dependencies view. Only when the user clicks to expand the dependency node the resolving process will start. See gif below.

![lazy](https://user-images.githubusercontent.com/45906942/130185252-9b8dfd65-e152-4359-b807-758a32c320f8.gif)
