### PR TITLE
feat: Support JDK compatibility check

### DIFF
--- a/extension/src/client/GradleClient.ts
+++ b/extension/src/client/GradleClient.ts
@@ -211,7 +211,7 @@ export class GradleClient implements vscode.Disposable {
                     break;
                   case GetBuildReply.KindCase.COMPATIBILITY_CHECK_ERROR:
                     const message = getBuildReply.getCompatibilityCheckError()!;
-                    const options = ['Open Gradle Settings'];
+                    const options = ['Open Gradle Settings', 'Learn More'];
                     await vscode.window
                       .showErrorMessage(message, ...options)
                       .then((choice) => {
@@ -219,6 +219,12 @@ export class GradleClient implements vscode.Disposable {
                           void vscode.commands.executeCommand(
                             'workbench.action.openSettings',
                             'java.import.gradle'
+                          );
+                        } else if (choice === 'Learn More') {
+                          void vscode.env.openExternal(
+                            vscode.Uri.parse(
+                              'https://docs.gradle.org/current/userguide/compatibility.html'
+                            )
                           );
                         }
                       });

--- a/extension/src/client/GradleClient.ts
+++ b/extension/src/client/GradleClient.ts
@@ -149,6 +149,7 @@ export class GradleClient implements vscode.Disposable {
       async (
         progress: vscode.Progress<{ message?: string }>,
         token: vscode.CancellationToken
+        // eslint-disable-next-line sonarjs/cognitive-complexity
       ) => {
         const progressHandler = new ProgressHandler(
           progress,
@@ -207,6 +208,26 @@ export class GradleClient implements vscode.Disposable {
                     await vscode.commands.executeCommand(
                       COMMAND_REFRESH_DAEMON_STATUS
                     );
+                    break;
+                  case GetBuildReply.KindCase.COMPATIBILITY_CHECK_ERROR:
+                    const message = getBuildReply.getCompatibilityCheckError()!;
+                    const javaPack = vscode.extensions.getExtension(
+                      'vscjava.vscode-java-pack'
+                    );
+                    const options = javaPack ? ['Configure Java Runtime'] : [];
+                    options.push('Open Gradle Settings');
+                    await vscode.window
+                      .showErrorMessage(message, ...options)
+                      .then((choice) => {
+                        if (choice === 'Configure Java Runtime') {
+                          void vscode.commands.executeCommand('java.runtime');
+                        } else if (choice === 'Open Gradle Settings') {
+                          void vscode.commands.executeCommand(
+                            'workbench.action.openSettings',
+                            'java.import.gradle'
+                          );
+                        }
+                      });
                     break;
                 }
               })

--- a/extension/src/client/GradleClient.ts
+++ b/extension/src/client/GradleClient.ts
@@ -211,17 +211,11 @@ export class GradleClient implements vscode.Disposable {
                     break;
                   case GetBuildReply.KindCase.COMPATIBILITY_CHECK_ERROR:
                     const message = getBuildReply.getCompatibilityCheckError()!;
-                    const javaPack = vscode.extensions.getExtension(
-                      'vscjava.vscode-java-pack'
-                    );
-                    const options = javaPack ? ['Configure Java Runtime'] : [];
-                    options.push('Open Gradle Settings');
+                    const options = ['Open Gradle Settings'];
                     await vscode.window
                       .showErrorMessage(message, ...options)
                       .then((choice) => {
-                        if (choice === 'Configure Java Runtime') {
-                          void vscode.commands.executeCommand('java.runtime');
-                        } else if (choice === 'Open Gradle Settings') {
+                        if (choice === 'Open Gradle Settings') {
                           void vscode.commands.executeCommand(
                             'workbench.action.openSettings',
                             'java.import.gradle'

--- a/gradle-server/build.gradle
+++ b/gradle-server/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   implementation 'javax.annotation:javax.annotation-api:1.3.2'
   implementation "io.grpc:grpc-protobuf:${grpcVersion}"
   implementation "io.grpc:grpc-stub:${grpcVersion}"
+  implementation 'com.github.zafarkhaja:java-semver:0.9.0'
   runtimeOnly "io.grpc:grpc-netty:${grpcVersion}"
   runtimeOnly 'org.slf4j:slf4j-simple:2.0.0-alpha1'
   testImplementation "io.grpc:grpc-testing:${grpcVersion}"

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -330,7 +330,7 @@ public class GetBuildHandler {
             + gradleVersion
             + " and Java version "
             + javaVersion
-            + " to configure the build. Please consider either to change your Java Runtime to no more than Java "
+            + " to configure the build. Please consider either to change your Java Runtime to no higher than Java "
             + jdkMajorVersion
             + " or to change your Gradle settings.";
     responseObserver.onNext(

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -137,9 +137,9 @@ public class GetBuildHandler {
     // Ref: https://docs.gradle.org/current/userguide/compatibility.html
     Version gradleVer = createVersion(gradleVersion);
     if (gradleVer.lessThan(Version.valueOf("2.0.0"))) {
-      return Version.valueOf("7.0.0");
+      return Version.valueOf("1.7.0");
     } else if (gradleVer.lessThan(Version.valueOf("4.3.0"))) {
-      return Version.valueOf("8.0.0");
+      return Version.valueOf("1.8.0");
     } else if (gradleVer.lessThan(Version.valueOf("4.7.0"))) {
       return Version.valueOf("9.0.0");
     } else if (gradleVer.lessThan(Version.valueOf("5.0.0"))) {
@@ -161,17 +161,13 @@ public class GetBuildHandler {
   private Version createVersion(String version) {
     String[] versions = version.split("\\.");
     switch (versions.length) {
+      case 0:
+        return Version.forIntegers(0);
       case 1:
         return Version.forIntegers(Integer.parseInt(versions[0]));
-      case 2:
-        return Version.forIntegers(Integer.parseInt(versions[0]), Integer.parseInt(versions[1]));
-      case 3:
-        return Version.forIntegers(
-            Integer.parseInt(versions[0]),
-            Integer.parseInt(versions[1]),
-            Integer.parseInt(versions[2]));
       default:
-        return Version.forIntegers(0);
+        // Patch version doesn't affect compatibility
+        return Version.forIntegers(Integer.parseInt(versions[0]), Integer.parseInt(versions[1]));
     }
   }
 

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -17,6 +17,7 @@ import com.github.badsyntax.gradle.JavaEnvironment;
 import com.github.badsyntax.gradle.Output;
 import com.github.badsyntax.gradle.Progress;
 import com.github.badsyntax.gradle.exceptions.GradleConnectionException;
+import com.github.zafarkhaja.semver.Version;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import io.grpc.stub.StreamObserver;
@@ -44,6 +45,7 @@ public class GetBuildHandler {
   private ProgressListener progressListener;
   private ByteBufferOutputStream standardOutputListener;
   private ByteBufferOutputStream standardErrorListener;
+  private Environment environment;
 
   public GetBuildHandler(GetBuildRequest req, StreamObserver<GetBuildReply> responseObserver) {
     this.req = req;
@@ -85,7 +87,8 @@ public class GetBuildHandler {
     }
 
     try (ProjectConnection connection = gradleConnector.connect()) {
-      replyWithBuildEnvironment(buildEnvironment(connection));
+      this.environment = buildEnvironment(connection);
+      replyWithBuildEnvironment(this.environment);
       org.gradle.tooling.model.GradleProject gradleProject = getGradleProject(connection);
       replyWithProject(getProjectData(gradleProject, gradleProject));
     } catch (BuildCancelledException e) {
@@ -94,10 +97,81 @@ public class GetBuildHandler {
         | IOException
         | IllegalStateException
         | org.gradle.tooling.GradleConnectionException e) {
+      if (this.environment != null) {
+        String gradleVersion = this.environment.getGradleEnvironment().getGradleVersion();
+        String javaVersion = System.getProperty("java.version");
+        Version highestJDKVersion = getHighestJDKVersion(gradleVersion);
+        if (highestJDKVersion.lessThan(createVersion(javaVersion))) {
+          replyWithCompatibilityCheckError(
+              gradleVersion, javaVersion, highestJDKVersion.getMajorVersion());
+        }
+      } else {
+        String rootCause = getRootCause(e);
+        if (rootCause.contains("Could not determine java version")) {
+          // Current Gradle version requires no more than Java 8.
+          // Since the language server requires JDK11+,
+          // We recommend the user to change gradle settings
+          replyWithCompatibilityCheckError();
+        }
+      }
       logger.error(e.getMessage());
       replyWithError(e);
     } finally {
       GradleBuildCancellation.clearToken(req.getCancellationKey());
+    }
+  }
+
+  private String getRootCause(Throwable error) {
+    Throwable rootCause = error;
+    while (true) {
+      Throwable cause = rootCause.getCause();
+      if (cause == null || cause.getMessage() == null && !(cause instanceof StackOverflowError)) {
+        break;
+      }
+      rootCause = cause;
+    }
+    return rootCause.toString();
+  }
+
+  private Version getHighestJDKVersion(String gradleVersion) {
+    // Ref: https://docs.gradle.org/current/userguide/compatibility.html
+    Version gradleVer = createVersion(gradleVersion);
+    if (gradleVer.lessThan(Version.valueOf("2.0.0"))) {
+      return Version.valueOf("7.0.0");
+    } else if (gradleVer.lessThan(Version.valueOf("4.3.0"))) {
+      return Version.valueOf("8.0.0");
+    } else if (gradleVer.lessThan(Version.valueOf("4.7.0"))) {
+      return Version.valueOf("9.0.0");
+    } else if (gradleVer.lessThan(Version.valueOf("5.0.0"))) {
+      return Version.valueOf("10.0.0");
+    } else if (gradleVer.lessThan(Version.valueOf("5.4.0"))) {
+      return Version.valueOf("11.0.0");
+    } else if (gradleVer.lessThan(Version.valueOf("6.0.0"))) {
+      return Version.valueOf("12.0.0");
+    } else if (gradleVer.lessThan(Version.valueOf("6.3.0"))) {
+      return Version.valueOf("13.0.0");
+    } else if (gradleVer.lessThan(Version.valueOf("6.7.0"))) {
+      return Version.valueOf("14.0.0");
+    } else if (gradleVer.lessThan(Version.valueOf("7.0.0"))) {
+      return Version.valueOf("15.0.0");
+    }
+    return Version.valueOf("16.0.0");
+  }
+
+  private Version createVersion(String version) {
+    String[] versions = version.split("\\.");
+    switch (versions.length) {
+      case 1:
+        return Version.forIntegers(Integer.parseInt(versions[0]));
+      case 2:
+        return Version.forIntegers(Integer.parseInt(versions[0]), Integer.parseInt(versions[1]));
+      case 3:
+        return Version.forIntegers(
+            Integer.parseInt(versions[0]),
+            Integer.parseInt(versions[1]),
+            Integer.parseInt(versions[2]));
+      default:
+        return Version.forIntegers(0);
     }
   }
 
@@ -251,5 +325,26 @@ public class GetBuildHandler {
                     .setOutputType(Output.OutputType.STDERR)
                     .setOutputBytes(byteString))
             .build());
+  }
+
+  private void replyWithCompatibilityCheckError(
+      String gradleVersion, String javaVersion, int jdkMajorVersion) {
+    String errorMessage =
+        "Could not use Gradle version "
+            + gradleVersion
+            + " and Java version "
+            + javaVersion
+            + " to configure the build. Please consider either to change your Java Runtime to no more than Java "
+            + jdkMajorVersion
+            + " or to change your Gradle settings.";
+    responseObserver.onNext(
+        GetBuildReply.newBuilder().setCompatibilityCheckError(errorMessage).build());
+  }
+
+  private void replyWithCompatibilityCheckError() {
+    String errorMessage =
+        "The current Gradle version requires Java 8 or lower. Please consider to change your Gradle settings.";
+    responseObserver.onNext(
+        GetBuildReply.newBuilder().setCompatibilityCheckError(errorMessage).build());
   }
 }

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetDependenciesHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetDependenciesHandler.java
@@ -122,7 +122,7 @@ public class GetDependenciesHandler {
             + "allprojects {\n"
             + "    apply plugin: com.microsoft.gradle.GradlePlugin\n"
             + "}\n";
-    Files.writeString(outputFile.toPath(), template);
+    Files.write(outputFile.toPath(), template.getBytes());
   }
 
   private void replyWithCancelled() {

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/process/Process.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/process/Process.java
@@ -10,6 +10,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 public class Process implements AutoCloseable {
   public static final Boolean IS_WINDOWS =
@@ -43,6 +44,9 @@ public class Process implements AutoCloseable {
   public synchronized void exec(String... args) throws IOException, ProcessException {
     ProcessBuilder processBuilder = new ProcessBuilder(buildCommand(args));
     processBuilder.directory(workingDir);
+    Map<String, String> env = processBuilder.environment();
+    // use the same java runtime to execute wrapper
+    env.put("JAVA_HOME", System.getProperty("java.home"));
     java.lang.Process process = processBuilder.start();
     this.processOutput =
         new ProcessOutput(

--- a/proto/gradle.proto
+++ b/proto/gradle.proto
@@ -32,6 +32,7 @@ message GetBuildReply {
     Output output = 3;
     Cancelled cancelled = 4;
     Environment environment = 5;
+    string compatibility_check_error = 6;
   }
 }
 


### PR DESCRIPTION
fix #912 

There is a Compatibility Matrix describing the compatibility status between Gradle version and JDK version. See https://docs.gradle.org/current/userguide/compatibility.html

There are two kinds of compatibility issue:
- The Gradle execution requires JDK8-: The tooling API can't get build environment and there is an error message `Could not determine java version x`
- The Gradle execution requires JDK9+ but not suitable for the current version: The tooling API can get build environment but can't finalize getting model process https://github.com/microsoft/vscode-gradle/blob/c78383dffd8ef2ad8d58ac89ceea65f10c557b1f/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java#L161 and throws an exception. If the minor version doesn't meet the compatibility matrix there might not an **blocking** compatibility issue (Gradle 6.4 can also execute build in Java 15), so we check this after an exception occurs.