### PR TITLE
fix: Use GradleDependencyProvider to cache dependencies

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -38,6 +38,7 @@ import {
 import { FileWatcher } from './util/FileWatcher';
 import { DependencyTreeItem } from './views/gradleTasks/DependencyTreeItem';
 import { GRADLE_OMITTED_REVEAL } from './views/gradleTasks/DependencyUtils';
+import { GradleDependencyProvider } from './dependencies/GradleDependencyProvider';
 
 export class Extension {
   private readonly client: GradleClient;
@@ -47,6 +48,7 @@ export class Extension {
   private readonly taskTerminalsStore: TaskTerminalsStore;
   private readonly rootProjectsStore: RootProjectsStore;
   private readonly gradleTaskProvider: GradleTaskProvider;
+  private readonly gradleDependencyProvider: GradleDependencyProvider;
   private readonly taskProvider: vscode.Disposable;
   private readonly gradleTaskManager: GradleTaskManager;
   private readonly icons: Icons;
@@ -96,6 +98,7 @@ export class Extension {
       this.rootProjectsStore,
       this.client
     );
+    this.gradleDependencyProvider = new GradleDependencyProvider(this.client);
     this.taskProvider = vscode.tasks.registerTaskProvider(
       'gradle',
       this.gradleTaskProvider
@@ -106,8 +109,8 @@ export class Extension {
       this.context,
       this.rootProjectsStore,
       this.gradleTaskProvider,
-      this.icons,
-      this.client
+      this.gradleDependencyProvider,
+      this.icons
     );
     this.gradleTasksTreeView = vscode.window.createTreeView(GRADLE_TASKS_VIEW, {
       treeDataProvider: this.gradleTasksTreeDataProvider,
@@ -166,6 +169,7 @@ export class Extension {
       this.context,
       this.pinnedTasksStore,
       this.gradleTaskProvider,
+      this.gradleDependencyProvider,
       this.gradleTasksTreeDataProvider,
       this.pinnedTasksTreeDataProvider,
       this.recentTasksTreeDataProvider,

--- a/extension/src/commands/Commands.ts
+++ b/extension/src/commands/Commands.ts
@@ -69,6 +69,7 @@ import {
   FindTaskCommand,
 } from '.';
 import { GradleClient } from '../client';
+import { GradleDependencyProvider } from '../dependencies/GradleDependencyProvider';
 import {
   PinnedTasksStore,
   RecentTasksStore,
@@ -89,6 +90,7 @@ export class Commands {
     private context: vscode.ExtensionContext,
     private pinnedTasksStore: PinnedTasksStore,
     private gradleTaskProvider: GradleTaskProvider,
+    private gradleDependencyProvider: GradleDependencyProvider,
     private gradleTasksTreeDataProvider: GradleTasksTreeDataProvider,
     private pinnedTasksTreeDataProvider: PinnedTasksTreeDataProvider,
     private recentTasksTreeDataProvider: RecentTasksTreeDataProvider,
@@ -180,6 +182,7 @@ export class Commands {
       COMMAND_REFRESH,
       new RefreshCommand(
         this.gradleTaskProvider,
+        this.gradleDependencyProvider,
         this.gradleTasksTreeDataProvider,
         this.pinnedTasksTreeDataProvider,
         this.recentTasksTreeDataProvider

--- a/extension/src/commands/RefreshCommand.ts
+++ b/extension/src/commands/RefreshCommand.ts
@@ -1,3 +1,4 @@
+import { GradleDependencyProvider } from '../dependencies/GradleDependencyProvider';
 import { GradleTaskProvider } from '../tasks';
 import {
   GradleTasksTreeDataProvider,
@@ -10,6 +11,7 @@ export const COMMAND_REFRESH = 'gradle.refresh';
 export class RefreshCommand extends Command {
   constructor(
     private gradleTaskProvider: GradleTaskProvider,
+    private gradleDependencyProvider: GradleDependencyProvider,
     private gradleTasksTreeDataProvider: GradleTasksTreeDataProvider,
     private pinnedTasksTreeDataProvider: PinnedTasksTreeDataProvider,
     private recentTasksTreeDataProvider: RecentTasksTreeDataProvider
@@ -18,6 +20,7 @@ export class RefreshCommand extends Command {
   }
   async run(): Promise<void> {
     this.gradleTaskProvider.clearTasksCache();
+    this.gradleDependencyProvider.clearDependenciesCache();
     void this.gradleTaskProvider.loadTasks();
     this.gradleTasksTreeDataProvider.refresh();
     this.pinnedTasksTreeDataProvider.refresh();

--- a/extension/src/dependencies/GradleDependencyProvider.ts
+++ b/extension/src/dependencies/GradleDependencyProvider.ts
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import { GradleClient } from '../client';
+import { getGradleConfig } from '../util/config';
+import { getDependencyConfigurationTreeItems } from '../views/gradleTasks/DependencyUtils';
+import { HintItem } from '../views/gradleTasks/HintItem';
+import { ProjectDependencyTreeItem } from '../views/gradleTasks/ProjectDependencyTreeItem';
+
+export class GradleDependencyProvider {
+  // <projectPath, configItem[]>
+  private cachedDependencies: Map<string, vscode.TreeItem[]> = new Map();
+
+  constructor(private readonly client: GradleClient) {}
+
+  public async getDependencies(
+    element: ProjectDependencyTreeItem
+  ): Promise<vscode.TreeItem[]> {
+    const projectPath = element.getProjectPath();
+    if (this.cachedDependencies.has(projectPath)) {
+      return this.cachedDependencies.get(projectPath)!;
+    }
+    const dependencyItem = await this.client.getDependencies(
+      projectPath,
+      getGradleConfig(),
+      element.getProjectName()
+    );
+    if (dependencyItem) {
+      const configItems = getDependencyConfigurationTreeItems(
+        dependencyItem,
+        element
+      );
+      if (configItems) {
+        this.cachedDependencies.set(projectPath, configItems);
+        return configItems;
+      }
+    }
+    const noDependencies = [new HintItem('No dependencies')];
+    this.cachedDependencies.set(projectPath, noDependencies);
+    return noDependencies;
+  }
+
+  public clearDependenciesCache(): void {
+    this.cachedDependencies.clear();
+  }
+}

--- a/extension/src/test/unit/gradleTasks.test.ts
+++ b/extension/src/test/unit/gradleTasks.test.ts
@@ -45,6 +45,7 @@ import {
 import { removeCancellingTask } from '../../tasks/taskUtil';
 import { RootProjectsStore } from '../../stores';
 import { getRunTaskCommandCancellationKey } from '../../client/CancellationKeys';
+import { GradleDependencyProvider } from '../../dependencies/GradleDependencyProvider';
 
 const mockContext = buildMockContext();
 
@@ -99,19 +100,20 @@ mockGradleBuildWithoutTasks.setProject(mockGradleProjectWithoutTasks);
 describe(getSuiteName('Gradle tasks'), () => {
   let gradleTasksTreeDataProvider: GradleTasksTreeDataProvider;
   let gradleTaskProvider: GradleTaskProvider;
+  let gradleDependencyProvider: GradleDependencyProvider;
   let client: any;
   let rootProjectsStore: RootProjectsStore;
   beforeEach(async () => {
     client = buildMockClient();
     rootProjectsStore = new RootProjectsStore();
-
     gradleTaskProvider = new GradleTaskProvider(rootProjectsStore, client);
+    gradleDependencyProvider = new GradleDependencyProvider(client);
     gradleTasksTreeDataProvider = new GradleTasksTreeDataProvider(
       mockContext,
       rootProjectsStore,
       gradleTaskProvider,
-      new Icons(mockContext),
-      client
+      gradleDependencyProvider,
+      new Icons(mockContext)
     );
     logger.reset();
     logger.setLoggingChannel(buildMockOutputChannel());

--- a/extension/src/test/unit/pinnedTasks.test.ts
+++ b/extension/src/test/unit/pinnedTasks.test.ts
@@ -44,6 +44,7 @@ import {
   PinTaskWithArgsCommand,
   RemovePinnedTaskCommand,
 } from '../../commands';
+import { GradleDependencyProvider } from '../../dependencies/GradleDependencyProvider';
 
 const mockContext = buildMockContext();
 
@@ -76,19 +77,21 @@ describe(getSuiteName('Pinned tasks'), () => {
   let gradleTasksTreeDataProvider: GradleTasksTreeDataProvider;
   let pinnedTasksTreeDataProvider: PinnedTasksTreeDataProvider;
   let gradleTaskProvider: GradleTaskProvider;
+  let gradleDependencyProvider: GradleDependencyProvider;
   let pinnedTasksStore: PinnedTasksStore;
   let rootProjectsStore: RootProjectsStore;
   beforeEach(async () => {
     const client = buildMockClient();
     rootProjectsStore = new RootProjectsStore();
     gradleTaskProvider = new GradleTaskProvider(rootProjectsStore, client);
+    gradleDependencyProvider = new GradleDependencyProvider(client);
     const icons = new Icons(mockContext);
     gradleTasksTreeDataProvider = new GradleTasksTreeDataProvider(
       mockContext,
       rootProjectsStore,
       gradleTaskProvider,
-      icons,
-      client
+      gradleDependencyProvider,
+      icons
     );
     pinnedTasksStore = new PinnedTasksStore(mockContext);
     pinnedTasksTreeDataProvider = new PinnedTasksTreeDataProvider(

--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -14,14 +14,11 @@ import { isWorkspaceFolder } from '../../util';
 import { isGradleTask } from '../../tasks/taskUtil';
 import { RootProjectsStore } from '../../stores';
 import { Icons } from '../../icons';
-import { GradleClient } from '../../client';
-import { getGradleConfig } from '../../util/config';
 import { DependencyConfigurationTreeItem } from './DependencyConfigurationTreeItem';
 import { DependencyTreeItem } from './DependencyTreeItem';
-import { getDependencyConfigurationTreeItems } from './DependencyUtils';
 import { ProjectDependencyTreeItem } from './ProjectDependencyTreeItem';
 import { ProjectTaskTreeItem } from './ProjectTaskTreeItem';
-import { HintItem } from './HintItem';
+import { GradleDependencyProvider } from '../../dependencies/GradleDependencyProvider';
 
 const gradleTaskTreeItemMap: Map<string, GradleTaskTreeItem> = new Map();
 const gradleProjectTreeItemMap: Map<string, RootProjectTreeItem> = new Map();
@@ -55,8 +52,8 @@ export class GradleTasksTreeDataProvider
     private readonly context: vscode.ExtensionContext,
     private readonly rootProjectStore: RootProjectsStore,
     private readonly gradleTaskProvider: GradleTaskProvider,
-    private readonly icons: Icons,
-    private readonly client: GradleClient
+    private readonly gradleDependencyProvider: GradleDependencyProvider,
+    private readonly icons: Icons
   ) {
     const collapsed = this.context.workspaceState.get(
       'gradleTasksCollapsed',
@@ -129,22 +126,7 @@ export class GradleTasksTreeDataProvider
       return [];
     }
     if (element instanceof ProjectDependencyTreeItem) {
-      const dependencyItem = await this.client.getDependencies(
-        element.getProjectPath(),
-        getGradleConfig(),
-        element.getProjectName()
-      );
-      if (!dependencyItem) {
-        return [new HintItem('No dependencies')];
-      }
-      const configItems = getDependencyConfigurationTreeItems(
-        dependencyItem,
-        element
-      );
-      if (!configItems) {
-        return [new HintItem('No dependencies')];
-      }
-      return configItems;
+      return this.gradleDependencyProvider.getDependencies(element);
     }
     if (
       element instanceof ProjectTaskTreeItem ||


### PR DESCRIPTION
fix #934

Here to add a dependency cache to prevent from getting dependencies again. The cache will be cleared once `refresh()` calls.