### PR TITLE
feat: Support compiling and pushing diagnostics

### DIFF
--- a/gradle-language-server/build.gradle
+++ b/gradle-language-server/build.gradle
@@ -14,6 +14,7 @@ repositories  {
 dependencies {
   implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0"
   implementation "org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.12.0"
+  implementation "org.codehaus.groovy:groovy-eclipse-batch:3.0.8-01"
 }
 
 ext.mainClass = "com.microsoft.gradle.GradleLanguageServer"

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
@@ -13,7 +13,6 @@ package com.microsoft.gradle;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -22,7 +21,7 @@ import java.util.Set;
 
 import com.microsoft.gradle.compile.GradleCompilationUnit;
 import com.microsoft.gradle.manager.GradleFilesManager;
-import com.microsoft.gradle.utils.GradleUtils;
+import com.microsoft.gradle.utils.LSPUtils;
 
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.control.ErrorCollector;
@@ -119,7 +118,7 @@ public class GradleServices implements TextDocumentService, WorkspaceService, La
     for (Message error : collector.getErrors()) {
       if (error instanceof SyntaxErrorMessage) {
         SyntaxException exp = ((SyntaxErrorMessage)error).getCause();
-        Range range = GradleUtils.getExpressionLSPRange(exp);
+        Range range = LSPUtils.toRange(exp);
         Diagnostic diagnostic = new Diagnostic();
         diagnostic.setRange(range);
         diagnostic.setSeverity(DiagnosticSeverity.Error);

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
@@ -11,14 +11,35 @@
 
 package com.microsoft.gradle;
 
-import com.microsoft.gradle.manager.GradleFilesManager;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import com.microsoft.gradle.compile.GradleCompilationUnit;
+import com.microsoft.gradle.manager.GradleFilesManager;
+import com.microsoft.gradle.utils.GradleUtils;
+
+import org.codehaus.groovy.control.CompilationFailedException;
+import org.codehaus.groovy.control.ErrorCollector;
+import org.codehaus.groovy.control.Phases;
+import org.codehaus.groovy.control.messages.Message;
+import org.codehaus.groovy.control.messages.SyntaxErrorMessage;
+import org.codehaus.groovy.syntax.SyntaxException;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.TextDocumentService;
@@ -26,6 +47,7 @@ import org.eclipse.lsp4j.services.WorkspaceService;
 
 public class GradleServices implements TextDocumentService, WorkspaceService, LanguageClientAware {
 
+  private LanguageClient client;
   private GradleFilesManager gradleFilesManager;
 
   public GradleServices() {
@@ -34,22 +56,29 @@ public class GradleServices implements TextDocumentService, WorkspaceService, La
 
   @Override
   public void connect(LanguageClient client) {
-    // TODO
+    this.client = client;
   }
 
   @Override
   public void didOpen(DidOpenTextDocumentParams params) {
-    gradleFilesManager.didOpen(params);
+    URI uri = URI.create(params.getTextDocument().getUri());
+    gradleFilesManager.didOpen(uri, params.getTextDocument().getText());
+    GradleCompilationUnit unit = this.gradleFilesManager.getCompilationUnit(uri, params.getTextDocument().getVersion());
+    compile(uri, unit);
   }
 
   @Override
   public void didChange(DidChangeTextDocumentParams params) {
-    gradleFilesManager.didChange(params);
+    URI uri = URI.create(params.getTextDocument().getUri());
+    gradleFilesManager.didChange(uri, params.getContentChanges().get(0));
+    GradleCompilationUnit unit = this.gradleFilesManager.getCompilationUnit(uri, params.getTextDocument().getVersion());
+    compile(uri, unit);
   }
 
   @Override
   public void didClose(DidCloseTextDocumentParams params) {
-    gradleFilesManager.didClose(params);
+    URI uri = URI.create(params.getTextDocument().getUri());
+    gradleFilesManager.didClose(uri);
   }
 
   @Override
@@ -65,5 +94,50 @@ public class GradleServices implements TextDocumentService, WorkspaceService, La
   @Override
   public void didChangeConfiguration(DidChangeConfigurationParams params) {
     // TODO
+  }
+
+  private void compile(URI uri, GradleCompilationUnit unit) {
+    if (unit == null) {
+      return;
+    }
+    Set<PublishDiagnosticsParams> diagnostics = new HashSet<>();
+    try {
+      unit.compile(Phases.CANONICALIZATION);
+      // Send empty diagnostic if there is no error
+      diagnostics.add(new PublishDiagnosticsParams(uri.toString(), new ArrayList<>()));
+    } catch (CompilationFailedException e) {
+      diagnostics = generateDiagnostics(unit.getErrorCollector());
+    }
+    for (PublishDiagnosticsParams diagnostic : diagnostics) {
+      client.publishDiagnostics(diagnostic);
+    }
+  }
+
+  private Set<PublishDiagnosticsParams> generateDiagnostics(ErrorCollector collector) {
+    // URI, List<Diagnostic>
+    Map<String, List<Diagnostic>> diagnosticsStorage = new HashMap<>();
+    for (Message error : collector.getErrors()) {
+      if (error instanceof SyntaxErrorMessage) {
+        SyntaxException exp = ((SyntaxErrorMessage)error).getCause();
+        Range range = GradleUtils.getExpressionLSPRange(exp);
+        Diagnostic diagnostic = new Diagnostic();
+        diagnostic.setRange(range);
+        diagnostic.setSeverity(DiagnosticSeverity.Error);
+        diagnostic.setMessage(exp.getMessage());
+        diagnostic.setSource("Gradle");
+        if (diagnosticsStorage.containsKey(exp.getSourceLocator())) {
+          diagnosticsStorage.get(exp.getSourceLocator()).add(diagnostic);
+        } else {
+          List<Diagnostic> diagnostics = new ArrayList<>();
+          diagnostics.add(diagnostic);
+          diagnosticsStorage.put(exp.getSourceLocator(), diagnostics);
+        }
+      }
+    }
+    Set<PublishDiagnosticsParams> diagnosticsParams = new HashSet<>();
+    for (Map.Entry<String, List<Diagnostic>> entry : diagnosticsStorage.entrySet()) {
+      diagnosticsParams.add(new PublishDiagnosticsParams(entry.getKey(), entry.getValue()));
+    }
+    return diagnosticsParams;
   }
 }

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/GradleCompilationUnit.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/GradleCompilationUnit.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.microsoft.gradle.compile;
+
+import java.security.CodeSource;
+
+import org.codehaus.groovy.control.CompilationUnit;
+import org.codehaus.groovy.control.CompilerConfiguration;
+
+import groovy.lang.GroovyClassLoader;
+
+public class GradleCompilationUnit extends CompilationUnit {
+  private Integer version;
+
+  public GradleCompilationUnit(CompilerConfiguration configuration, CodeSource codeSource, GroovyClassLoader loader, Integer version) {
+    super(configuration, codeSource, loader);
+    this.version = version;
+  }
+
+  public Integer getVersion() {
+    return this.version;
+  }
+}

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/manager/GradleFilesManager.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/manager/GradleFilesManager.java
@@ -93,7 +93,7 @@ public class GradleFilesManager {
     return currentIndex + character;
   }
 
-  public synchronized GradleCompilationUnit getCompilationUnit(URI uri, Integer version) {
+  public GradleCompilationUnit getCompilationUnit(URI uri, Integer version) {
     if (this.unitStorage.containsKey(uri) && this.unitStorage.get(uri).getVersion().equals(version)) {
       return this.unitStorage.get(uri);
     }

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/utils/GradleUtils.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/utils/GradleUtils.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    Microsoft Corporation - initial API and implementation
+ *******************************************************************************/
+
+package com.microsoft.gradle.utils;
+
+import org.codehaus.groovy.syntax.SyntaxException;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+public class GradleUtils {
+  public static Range getExpressionLSPRange(SyntaxException exp) {
+    // LSP Range start from 0, while groovy classes start from 1
+    return new Range(new Position(exp.getStartLine() - 1, exp.getStartColumn() - 1),
+        new Position(exp.getEndLine() - 1, exp.getEndColumn() - 1));
+  }
+}

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/utils/LSPUtils.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/utils/LSPUtils.java
@@ -15,8 +15,8 @@ import org.codehaus.groovy.syntax.SyntaxException;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
-public class GradleUtils {
-  public static Range getExpressionLSPRange(SyntaxException exp) {
+public class LSPUtils {
+  public static Range toRange(SyntaxException exp) {
     // LSP Range start from 0, while groovy classes start from 1
     return new Range(new Position(exp.getStartLine() - 1, exp.getStartColumn() - 1),
         new Position(exp.getEndLine() - 1, exp.getEndColumn() - 1));


### PR DESCRIPTION
Part of #956 

![diag](https://user-images.githubusercontent.com/45906942/131432526-d189a49c-37d1-4e38-9400-19af4e2f7458.gif)

One concern here is to reconstruct a new `CompilationUnit` once the text changes. Currently I can't find a proper way to support reuse `CompilationUnit` by changing it's `SourceUnit`, and there is no API found. Just test an extreme case on a Gradle file with more than 1000+ lines, writing a Gradle Closure, and the compile time is acceptable. 

Just search in GitHub and find the following results (Aug.31 2021):
example:
![ev](https://user-images.githubusercontent.com/45906942/131449205-0e8a331c-2433-4da8-ab80-1c81b2175f80.png)

result:
Constant condition: `language:Gradle filename:build.gradle extension:gradle`

| Additional Condition | Results | Percentage |
|---|---|---|
| None | 5333504 | 100% |
| Size > 100 | 5254537 | 98.5% |
| Size > 10000 | 54387 | 1.01% |
| Size > 35000 | 1380 | 0.0259% |
| Size > 50000 | 583 | 0.0109% |

My test Gradle file has about 1000 lines and the size is about 35KB. So I think the result can cover most case of gradle files.

![jp-1000](https://user-images.githubusercontent.com/45906942/131432679-f1225860-d9b4-4384-b8dd-226ec3f5ee45.png)
(This record is just a reference and recorded in my feature branch with semantic highlighting, completion and documentSymbol on, just to show the percentage of compiling)