### PR TITLE
feat: Support basic java plugin aware

### DIFF
--- a/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
@@ -267,14 +267,15 @@ public class GradleServices implements TextDocumentService, WorkspaceService, La
         containingCall = call;
       }
     }
+    boolean javaPluginsIncluded = this.libraryResolver.isJavaPluginsIncluded(this.completionVisitor.getPlugins(uri));
     CompletionHandler handler = new CompletionHandler();
     // check again
     if (containingCall == null && isGradleRoot(uri, params.getPosition())) {
       return CompletableFuture.completedFuture(Either
-          .forLeft(handler.getCompletionItems(null, Paths.get(uri).getFileName().toString(), this.libraryResolver)));
+          .forLeft(handler.getCompletionItems(null, Paths.get(uri).getFileName().toString(), this.libraryResolver, javaPluginsIncluded)));
     }
     return CompletableFuture.completedFuture(Either.forLeft(
-        handler.getCompletionItems(containingCall, Paths.get(uri).getFileName().toString(), this.libraryResolver)));
+        handler.getCompletionItems(containingCall, Paths.get(uri).getFileName().toString(), this.libraryResolver, javaPluginsIncluded)));
   }
 
   private boolean isGradleRoot(URI uri, Position position) {


### PR DESCRIPTION
related to #982 

In `CompletionVisitor`, supports two kinds of plugin declaration:

```
plugins {
  id: "java" (optional: version: "")
}
```
and
```
apply plugin: "java"
```
and collect the applied plugins information.

In `GradleLibraryResolver`, get available java related configurations from public fields in `org.gradle.api.plugins.JavaPlugin`

In `CompletionHandler`, if current closure is `dependencies` and java related plugin is applied, we offer java configurations as completion items too.

![plugin](https://user-images.githubusercontent.com/45906942/132275833-2116fd4e-6980-4787-bd1d-230bd0f98648.gif)
