### PR TITLE
feat: Upgrade requirement to `1.60.0` and apply `folder-library` icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This VS Code extension provides a visual interface for your Gradle build. It sup
 
 ## Requirements
 
-- [VS Code >= 1.45.0](https://code.visualstudio.com/download)
+- [VS Code >= 1.60.0](https://code.visualstudio.com/download)
 - [Java >= 8](https://adoptopenjdk.net/)
 - Local [Gradle Wrapper](https://docs.gradle.org/current/userguide/gradle_wrapper.html) executables
 

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -192,6 +192,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
     "@types/fs-extra": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.8.tgz",
@@ -372,6 +378,40 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "@vscode/test-electron": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-1.6.2.tgz",
+      "integrity": "sha512-W01ajJEMx6223Y7J5yaajGjVs1QfW3YGkkOJHVKfAMEqNB1ZHN9wCcViehv5ZwVSSJnjhu6lYEYgwBdHtCxqhQ==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "dependencies": {
+        "http-proxy-agent": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+          "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+          "dev": true,
+          "requires": {
+            "@tootallnate/once": "1",
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
@@ -902,6 +942,12 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "dev": true
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "dev": true
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -913,6 +959,16 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
       "dev": true
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -1084,10 +1140,22 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
       "dev": true
     },
     "builtin-status-codes": {
@@ -1195,6 +1263,15 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
       "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
       "dev": true
+    },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
     },
     "chalk": {
       "version": "4.1.0",
@@ -1778,6 +1855,15 @@
         "domhandler": "^4.2.0"
       }
     },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -1884,21 +1970,6 @@
       "dev": true,
       "requires": {
         "prr": "~1.0.1"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "escalade": {
@@ -2638,6 +2709,29 @@
       "dev": true,
       "optional": true
     },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3071,42 +3165,6 @@
         "entities": "^2.0.0"
       }
     },
-    "http-proxy-agent": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-      "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-      "dev": true,
-      "requires": {
-        "agent-base": "4",
-        "debug": "3.1.0"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "dev": true,
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
-      }
-    },
     "https-browserify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
@@ -3478,6 +3536,12 @@
       "requires": {
         "uc.micro": "^1.0.1"
       }
+    },
+    "listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+      "dev": true
     },
     "loader-runner": {
       "version": "2.4.0",
@@ -5418,6 +5482,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true
+    },
     "tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -5751,6 +5821,32 @@
         }
       }
     },
+    "unzipper": {
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
+      "integrity": "sha512-+BrAq2oFqWod5IESRjL3S8baohbevGcVA+teAIOYWM3pDVdseogqbzhhvvmiyQrUNKFUnDMtELW3X8ykbyDCJw==",
+      "dev": true,
+      "requires": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "^1.0.12",
+        "graceful-fs": "^4.2.2",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "~1.0.4"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.4.7",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+          "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+          "dev": true
+        }
+      }
+    },
     "upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -5945,47 +6041,6 @@
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
           "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
-      }
-    },
-    "vscode-test": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.1.tgz",
-      "integrity": "sha512-Ls7+JyC06cUCuomlTYk4aNJI00Rri09hgtkNl3zfQ1bj6meXglpSPpuzJ/RPNetlUHFMm4eGs0Xr/H5pFPVwfQ==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^2.1.0",
-        "https-proxy-agent": "^2.2.4",
-        "rimraf": "^2.6.3"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-          "dev": true,
-          "requires": {
-            "es6-promisify": "^5.0.0"
-          }
-        },
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
-          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
-          "dev": true,
-          "requires": {
-            "agent-base": "^4.3.0",
-            "debug": "^3.1.0"
-          }
         }
       }
     },

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -257,9 +257,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.45.0.tgz",
-      "integrity": "sha512-b0Gyir7sPBCqiKLygAhn/AYVfzWD+SMPkWltBrIuPEyTOxSU1wVApWY/FcxYO2EWTRacoubTl4+gvZf86RkecA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.60.0.tgz",
+      "integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -17,7 +17,7 @@
   },
   "license": "SEE LICENSE IN LICENSE.md",
   "engines": {
-    "vscode": "^1.45.0",
+    "vscode": "^1.60.0",
     "node": "^14.15.4",
     "npm": "^6.14.10"
   },
@@ -807,7 +807,7 @@
     "@types/mocha": "^8.2.1",
     "@types/node": "^14.14.31",
     "@types/sinon": "^9.0.10",
-    "@types/vscode": "1.45.0",
+    "@types/vscode": "1.60.0",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
     "eslint": "^7.21.0",

--- a/extension/package.json
+++ b/extension/package.json
@@ -810,6 +810,7 @@
     "@types/vscode": "1.60.0",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
+    "@vscode/test-electron": "^1.6.2",
     "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-prettier": "^3.3.1",
@@ -829,7 +830,6 @@
     "ts-protoc-gen": "^0.14.0",
     "typescript": "^4.2.3",
     "vsce": "^1.88.0",
-    "vscode-test": "^1.4.1",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   },

--- a/extension/src/test/runTests.ts
+++ b/extension/src/test/runTests.ts
@@ -187,8 +187,6 @@ async function runTestsForVsCodeVersion(version: string): Promise<void> {
   );
   const vscodeExecutablePath = await downloadAndUnzipVSCode(version);
 
-  let hasErr = false;
-
   try {
     await runUnitTests(vscodeExecutablePath, tmpDir);
     await runTestsWithGradle(vscodeExecutablePath, tmpDir);
@@ -198,13 +196,8 @@ async function runTestsForVsCodeVersion(version: string): Promise<void> {
     await runNestedProjectTests(vscodeExecutablePath, tmpDir);
     await runTestsWithoutGradle(vscodeExecutablePath, tmpDir);
   } catch (err) {
-    hasErr = true;
     console.error('Error running tests:', err.message);
-  } finally {
-    await fs.remove(tmpDir);
-    if (hasErr) {
-      process.exit(1);
-    }
+    process.exit(1);
   }
 }
 
@@ -212,15 +205,8 @@ async function main(): Promise<void> {
   for (const version of VSCODE_TEST_VERSIONS) {
     await runTestsForVsCodeVersion(version);
   }
+  console.log('Finished running tests');
+  process.exit(0);
 }
 
-main().then(
-  () => {
-    console.log('Finished running tests');
-    process.exit(0);
-  },
-  (err) => {
-    console.error('Error cleaning up tests:', err.message);
-    process.exit(1);
-  }
-);
+void main();

--- a/extension/src/test/runTests.ts
+++ b/extension/src/test/runTests.ts
@@ -217,8 +217,10 @@ async function main(): Promise<void> {
 main().then(
   () => {
     console.log('Finished running tests');
+    process.exit(0);
   },
   (err) => {
     console.error('Error cleaning up tests:', err.message);
+    process.exit(1);
   }
 );

--- a/extension/src/test/runTests.ts
+++ b/extension/src/test/runTests.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs-extra';
 
-import { runTests, downloadAndUnzipVSCode } from 'vscode-test';
+import { runTests, downloadAndUnzipVSCode } from '@vscode/test-electron';
 import { VSCODE_TEST_VERSIONS } from './vscode-version';
 
 const extensionDevelopmentPath = path.resolve(__dirname, '../../');

--- a/extension/src/test/vscode-version.ts
+++ b/extension/src/test/vscode-version.ts
@@ -1,1 +1,1 @@
-export const VSCODE_TEST_VERSIONS = ['1.45.0', '1.54.1'];
+export const VSCODE_TEST_VERSIONS = ['1.60.0'];

--- a/extension/src/views/gradleTasks/DependencyConfigurationTreeItem.ts
+++ b/extension/src/views/gradleTasks/DependencyConfigurationTreeItem.ts
@@ -9,8 +9,7 @@ export class DependencyConfigurationTreeItem extends vscode.TreeItem {
     name: string,
     collapsibleState: vscode.TreeItemCollapsibleState,
     public readonly parentTreeItem: vscode.TreeItem,
-    // TODO: https://github.com/microsoft/vscode-codicons/issues/77
-    iconPath: vscode.ThemeIcon = new vscode.ThemeIcon('file-submodule')
+    iconPath: vscode.ThemeIcon = new vscode.ThemeIcon('folder-library')
   ) {
     super(name, collapsibleState);
     this.iconPath = iconPath;

--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -160,7 +160,7 @@ export class GradleTasksTreeDataProvider
       vscode.TreeItemCollapsibleState.Collapsed,
       element,
       path.dirname(resourceUri.fsPath),
-      element.label || resourceUri.fsPath
+      typeof element.label === 'string' ? element.label : resourceUri.fsPath
     );
     return [...results, projectDependencyTreeItem];
   }

--- a/extension/src/views/gradleTasks/ProjectDependencyTreeItem.ts
+++ b/extension/src/views/gradleTasks/ProjectDependencyTreeItem.ts
@@ -11,8 +11,7 @@ export class ProjectDependencyTreeItem extends vscode.TreeItem {
     public readonly parentTreeItem: vscode.TreeItem,
     readonly projectPath: string,
     readonly projectName: string,
-    // TODO: https://github.com/microsoft/vscode-codicons/issues/77
-    iconPath: vscode.ThemeIcon = new vscode.ThemeIcon('file-submodule')
+    iconPath: vscode.ThemeIcon = new vscode.ThemeIcon('folder-library')
   ) {
     super(name, collapsibleState);
     this.iconPath = iconPath;


### PR DESCRIPTION
fix #994 
Since `folder-library` has been shipped with VSCode 1.60.0, we can apply it and update our requirement.

![Screenshot 2021-09-10 104021](https://user-images.githubusercontent.com/45906942/132790894-8c9fa8bc-37f3-4db2-b56a-5883d5834a0f.png)
