### PR TITLE
fix: Specify template type in `GradleModelAction`

### DIFF
--- a/gradle-plugin-api/src/main/java/com/microsoft/gradle/api/GradleModelAction.java
+++ b/gradle-plugin-api/src/main/java/com/microsoft/gradle/api/GradleModelAction.java
@@ -11,11 +11,10 @@
 
 package com.microsoft.gradle.api;
 
-import java.io.Serializable;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
 
-public class GradleModelAction implements Serializable, BuildAction {
+public class GradleModelAction implements BuildAction<GradleToolingModel> {
   @Override
   public GradleToolingModel execute(BuildController controller) {
     return controller.getModel(GradleToolingModel.class);


### PR DESCRIPTION
Current pipeline:

> Task :gradle-server:compileJava
Note: /home/runner/work/vscode-gradle/vscode-gradle/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetDependenciesHandler.java uses unchecked or unsafe operations.

