### PR TITLE
feat: Support basic tasks and dependencies

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -76,7 +76,12 @@
         {
           "id": "gradleTasksView",
           "name": "Gradle Projects",
-          "when": "gradle:activated"
+          "when": "gradle:activated && !gradle:defaultView"
+        },
+        {
+          "id": "gradleDefaultProjectsView",
+          "name": "Default Gradle Projects",
+          "when": "gradle:activated && gradle:defaultView"
         },
         {
           "id": "pinnedTasksView",
@@ -456,7 +461,7 @@
         },
         {
           "command": "gradle.openSettings",
-          "when": "view == gradleTasksView"
+          "when": "view == gradleTasksView || view == gradleDefaultProjectsView"
         },
         {
           "command": "gradle.findTask",
@@ -464,7 +469,7 @@
         },
         {
           "command": "gradle.runBuild",
-          "when": "view == gradleTasksView",
+          "when": "view == gradleTasksView || view == gradleDefaultProjectsView",
           "group": "navigation@0"
         },
         {
@@ -516,12 +521,12 @@
       "view/item/context": [
         {
           "command": "gradle.runTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^debugTask.*$|^task.*$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$|^gradleDefaultProjectsView$/ && viewItem =~ /^debugTask.*$|^task.*$/",
           "group": "contextGroup1@0"
         },
         {
           "command": "gradle.runTaskWithArgs",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^debugTask(WithTerminals)?$|^task(WithTerminals)?$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$|^gradleDefaultProjectsView$/ && viewItem =~ /^debugTask(WithTerminals)?$|^task(WithTerminals)?$/",
           "group": "contextGroup1@1"
         },
         {
@@ -551,7 +556,7 @@
         },
         {
           "command": "gradle.runTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^debugTask.*$|^task.*$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$|^gradleDefaultProjectsView$/ && viewItem =~ /^debugTask.*$|^task.*$/",
           "group": "inline@3"
         },
         {

--- a/extension/package.json
+++ b/extension/package.json
@@ -80,7 +80,7 @@
         },
         {
           "id": "gradleDefaultProjectsView",
-          "name": "Default Gradle Projects",
+          "name": "Gradle Projects",
           "when": "gradle:activated && gradle:defaultView"
         },
         {

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -26,6 +26,7 @@ import {
   PINNED_TASKS_VIEW,
   GRADLE_DAEMONS_VIEW,
   RECENT_TASKS_VIEW,
+  GRADLE_DEFAULT_PROJECTS_VIEW,
 } from './views/constants';
 import { focusTaskInGradleTasksTree } from './views/viewUtil';
 import { COMMAND_RENDER_TASK, COMMAND_REFRESH } from './commands';
@@ -40,6 +41,7 @@ import { GRADLE_DEPENDENCY_REVEAL } from './views/gradleTasks/DependencyUtils';
 import { GradleDependencyProvider } from './dependencies/GradleDependencyProvider';
 import { getSpecificVersionStatus } from './views/gradleDaemons/util';
 import { startLanguageServer } from './languageServer/languageServer';
+import { DefaultProjectsTreeDataProvider } from './views/defaultProject/DefaultProjectsTreeDataProvider';
 
 export class Extension {
   private readonly client: GradleClient;
@@ -63,6 +65,8 @@ export class Extension {
   private readonly recentTasksTreeDataProvider: RecentTasksTreeDataProvider;
   private readonly recentTasksTreeView: vscode.TreeView<vscode.TreeItem>;
   private readonly gradleTasksTreeDataProvider: GradleTasksTreeDataProvider;
+  private readonly defaultProjectsTreeView: vscode.TreeView<vscode.TreeItem>;
+  private readonly defaultProjectsTreeDataProvider: DefaultProjectsTreeDataProvider;
   private readonly api: Api;
   private readonly commands: Commands;
   private readonly _onDidTerminalOpen: vscode.EventEmitter<vscode.Terminal> =
@@ -154,6 +158,19 @@ export class Extension {
       treeDataProvider: this.recentTasksTreeDataProvider,
       showCollapseAll: false,
     });
+    this.defaultProjectsTreeDataProvider = new DefaultProjectsTreeDataProvider(
+      this.gradleTaskProvider,
+      this.rootProjectsStore,
+      this.client,
+      this.icons
+    );
+    this.defaultProjectsTreeView = vscode.window.createTreeView(
+      GRADLE_DEFAULT_PROJECTS_VIEW,
+      {
+        treeDataProvider: this.defaultProjectsTreeDataProvider,
+        showCollapseAll: false,
+      }
+    );
 
     this.gradleTaskManager = new GradleTaskManager(context);
     this.buildFileWatcher = new FileWatcher('**/*.{gradle,gradle.kts}');
@@ -218,7 +235,8 @@ export class Extension {
       this.gradleDaemonsTreeView,
       this.gradleTasksTreeView,
       this.pinnedTasksTreeView,
-      this.recentTasksTreeView
+      this.recentTasksTreeView,
+      this.defaultProjectsTreeView
     );
   }
 
@@ -231,6 +249,11 @@ export class Extension {
       'setContext',
       'gradle:activated',
       activated
+    );
+    await vscode.commands.executeCommand(
+      'setContext',
+      'gradle:defaultView',
+      true
     );
   }
 

--- a/extension/src/client/GradleClient.ts
+++ b/extension/src/client/GradleClient.ts
@@ -46,6 +46,10 @@ import {
 } from './CancellationKeys';
 import { EventWaiter } from '../util/EventWaiter';
 import { getGradleConfig, getConfigJavaDebug } from '../util/config';
+import {
+  setDefault,
+  unsetDefault,
+} from '../views/defaultProject/DefaultProjectUtils';
 
 function logBuildEnvironment(environment: Environment): void {
   const javaEnv = environment.getJavaEnvironment()!;
@@ -191,6 +195,7 @@ export class GradleClient implements vscode.Disposable {
                         );
                         break;
                       case Output.OutputType.STDERR:
+                        void setDefault();
                         stdErrLoggerStream.write(
                           getBuildReply.getOutput()!.getOutputBytes_asU8()
                         );
@@ -201,6 +206,7 @@ export class GradleClient implements vscode.Disposable {
                     this.handleGetBuildCancelled(getBuildReply.getCancelled()!);
                     break;
                   case GetBuildReply.KindCase.GET_BUILD_RESULT:
+                    void unsetDefault();
                     build = getBuildReply.getGetBuildResult()!.getBuild();
                     break;
                   case GetBuildReply.KindCase.ENVIRONMENT:

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -20,6 +20,8 @@ import {
 } from '../util/config';
 const CHANNEL_NAME = 'Gradle Language Server';
 
+export let isLanguageServerStarted = false;
+
 export async function startLanguageServer(
   context: vscode.ExtensionContext
 ): Promise<void> {
@@ -91,6 +93,7 @@ export async function startLanguageServer(
         );
         languageClient.onReady().then(resolve, (e) => {
           resolve();
+          isLanguageServerStarted = true;
           void vscode.window.showErrorMessage(e);
         });
         const disposable = languageClient.start();

--- a/extension/src/views/constants.ts
+++ b/extension/src/views/constants.ts
@@ -8,6 +8,7 @@ export const ICON_DAEMON_STOPPED = 'close.svg';
 
 export const GRADLE_CONTAINER_VIEW = 'gradleContainerView';
 export const GRADLE_TASKS_VIEW = 'gradleTasksView';
+export const GRADLE_DEFAULT_PROJECTS_VIEW = 'gradleDefaultProjectsView';
 export const GRADLE_DAEMONS_VIEW = 'gradleDaemonsView';
 export const PINNED_TASKS_VIEW = 'pinnedTasksView';
 export const RECENT_TASKS_VIEW = 'recentTasksView';

--- a/extension/src/views/defaultProject/DefaultProjectProvider.ts
+++ b/extension/src/views/defaultProject/DefaultProjectProvider.ts
@@ -3,7 +3,6 @@
 
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { Range } from 'vscode-languageclient/node';
 import { GradleClient } from '../../client';
 import { isLanguageServerStarted } from '../../languageServer/languageServer';
 import { RootProject } from '../../rootProject';
@@ -13,38 +12,12 @@ import { DependencyConfigurationTreeItem } from '../gradleTasks/DependencyConfig
 import { DependencyTreeItem } from '../gradleTasks/DependencyTreeItem';
 import { HintItem } from '../gradleTasks/HintItem';
 import { ProjectDependencyTreeItem } from '../gradleTasks/ProjectDependencyTreeItem';
+import { generateDefaultTaskDefinitions } from './DefaultProjectUtils';
+import { DefaultDependencyItem, DefaultTaskDefinition } from './types';
 
 export class DefaultProjectProvider {
-  // task name, task group, task description
-  private static defaultTaskDefinitions: [string, string, string][] = [
-    ['init', 'build setup', 'Initializes a new Gradle build.'],
-    ['wrapper', 'build setup', 'Generates Gradle wrapper files.'],
-    [
-      'buildEnvironment',
-      'help',
-      'Displays all buildscript dependencies declared in root project.',
-    ],
-    [
-      'dependencies',
-      'help',
-      'Displays all dependencies declared in root project.',
-    ],
-    [
-      'dependencyInsight',
-      'help',
-      'Displays the insight into a specific dependency in root project.',
-    ],
-    ['help', 'help', 'Displays a help message.'],
-    ['javaToolchains', 'help', 'Displays the detected java toolchains.'],
-    [
-      'outgoingVariants',
-      'help',
-      'Displays the outgoing variants of root project.',
-    ],
-    ['projects', 'help', 'Displays the sub-projects of root project.'],
-    ['properties', 'help', 'Displays the properties of root project.'],
-    ['tasks', 'help', 'Displays the tasks runnable from root project.'],
-  ];
+  private static defaultTaskDefinitions: DefaultTaskDefinition[] =
+    generateDefaultTaskDefinitions();
 
   constructor() {
     this.defaultTasks = [];
@@ -72,11 +45,11 @@ export class DefaultProjectProvider {
           createTaskFromDefinition(
             this.generateDefaultTaskDefinition(
               rootProject,
-              defaultTaskDefinition[0],
+              defaultTaskDefinition.name,
               rootProject.getWorkspaceFolder().name,
               path.join(rootProject.getProjectUri().fsPath, 'build.gradle'),
-              defaultTaskDefinition[2],
-              defaultTaskDefinition[1]
+              defaultTaskDefinition.description,
+              defaultTaskDefinition.group
             ),
             rootProject,
             client
@@ -166,10 +139,4 @@ export class DefaultProjectProvider {
     );
     return this.defaultDependencies.get(buildFileUri.toString()) || [];
   }
-}
-
-interface DefaultDependencyItem {
-  name: string;
-  configuration: string;
-  range: Range;
 }

--- a/extension/src/views/defaultProject/DefaultProjectProvider.ts
+++ b/extension/src/views/defaultProject/DefaultProjectProvider.ts
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { Range } from 'vscode-languageclient/node';
+import { GradleClient } from '../../client';
+import { isLanguageServerStarted } from '../../languageServer/languageServer';
+import { RootProject } from '../../rootProject';
+import { GradleTaskDefinition } from '../../tasks';
+import { buildTaskId, createTaskFromDefinition } from '../../tasks/taskUtil';
+import { DependencyConfigurationTreeItem } from '../gradleTasks/DependencyConfigurationTreeItem';
+import { DependencyTreeItem } from '../gradleTasks/DependencyTreeItem';
+import { HintItem } from '../gradleTasks/HintItem';
+import { ProjectDependencyTreeItem } from '../gradleTasks/ProjectDependencyTreeItem';
+
+export class DefaultProjectProvider {
+  // task name, task group, task description
+  private static defaultTaskDefinitions: [string, string, string][] = [
+    ['init', 'build setup', 'Initializes a new Gradle build.'],
+    ['wrapper', 'build setup', 'Generates Gradle wrapper files.'],
+    [
+      'buildEnvironment',
+      'help',
+      'Displays all buildscript dependencies declared in root project.',
+    ],
+    [
+      'dependencies',
+      'help',
+      'Displays all dependencies declared in root project.',
+    ],
+    [
+      'dependencyInsight',
+      'help',
+      'Displays the insight into a specific dependency in root project.',
+    ],
+    ['help', 'help', 'Displays a help message.'],
+    ['javaToolchains', 'help', 'Displays the detected java toolchains.'],
+    [
+      'outgoingVariants',
+      'help',
+      'Displays the outgoing variants of root project.',
+    ],
+    ['projects', 'help', 'Displays the sub-projects of root project.'],
+    ['properties', 'help', 'Displays the properties of root project.'],
+    ['tasks', 'help', 'Displays the tasks runnable from root project.'],
+  ];
+
+  constructor() {
+    this.defaultTasks = [];
+    this.defaultDependencies = new Map();
+  }
+
+  private defaultTasks: vscode.Task[];
+  private defaultDependencies: Map<string, vscode.TreeItem[]>;
+
+  public refresh(): void {
+    this.defaultTasks = [];
+  }
+
+  public async getDefaultTasks(
+    rootProjects: RootProject[],
+    client: GradleClient
+  ): Promise<vscode.Task[]> {
+    if (this.defaultTasks.length) {
+      return this.defaultTasks;
+    }
+    const tasks = [];
+    for (const rootProject of rootProjects) {
+      for (const defaultTaskDefinition of DefaultProjectProvider.defaultTaskDefinitions) {
+        tasks.push(
+          createTaskFromDefinition(
+            this.generateDefaultTaskDefinition(
+              rootProject,
+              defaultTaskDefinition[0],
+              rootProject.getWorkspaceFolder().name,
+              path.join(rootProject.getProjectUri().fsPath, 'build.gradle'),
+              defaultTaskDefinition[2],
+              defaultTaskDefinition[1]
+            ),
+            rootProject,
+            client
+          )
+        );
+      }
+    }
+    this.defaultTasks = tasks;
+    return tasks;
+  }
+
+  private generateDefaultTaskDefinition(
+    rootProject: RootProject,
+    script: string,
+    projectName: string,
+    projectFile: string,
+    description: string,
+    group?: string
+  ): Required<GradleTaskDefinition> {
+    return {
+      type: 'gradle',
+      id: buildTaskId(rootProject.getProjectUri().fsPath, script, projectName),
+      script,
+      description: description,
+      group: (group || 'other').toLowerCase(),
+      project: projectName,
+      buildFile: projectFile,
+      rootProject: projectName,
+      projectFolder: rootProject.getProjectUri().fsPath,
+      workspaceFolder: rootProject.getWorkspaceFolder().uri.fsPath,
+      args: '',
+      javaDebug: false,
+    };
+  }
+
+  public async getDefaultDependencyItems(
+    element: ProjectDependencyTreeItem
+  ): Promise<vscode.TreeItem[]> {
+    const configurationMap: Map<string, DependencyConfigurationTreeItem> =
+      new Map();
+    const buildFileUri = vscode.Uri.file(
+      // Due to no project knowledge, we only get informations from project root's build.gradle
+      path.join(element.projectPath, 'build.gradle')
+    );
+    if (!isLanguageServerStarted) {
+      return [new HintItem('No dependencies')];
+    }
+    const dependencyItems = await vscode.commands.executeCommand<
+      DefaultDependencyItem[]
+    >('gradle.getDependencies', buildFileUri.toString());
+    if (!dependencyItems) {
+      return [new HintItem('No dependencies')];
+    }
+    for (const dependencyItem of dependencyItems) {
+      const configuration = dependencyItem.configuration;
+      if (!configurationMap.has(configuration)) {
+        const configItem: DependencyConfigurationTreeItem =
+          new DependencyConfigurationTreeItem(
+            dependencyItem.configuration,
+            vscode.TreeItemCollapsibleState.Collapsed,
+            element
+          );
+        configurationMap.set(configuration, configItem);
+      }
+      const configurationItem = configurationMap.get(configuration);
+      if (!configurationItem) {
+        continue;
+      }
+      const dependencyTreeItem: DependencyTreeItem = new DependencyTreeItem(
+        dependencyItem.name,
+        vscode.TreeItemCollapsibleState.None,
+        configurationItem
+      );
+      dependencyTreeItem.command = {
+        title: 'Show Dependency',
+        command: 'vscode.open',
+        arguments: [
+          buildFileUri,
+          <vscode.TextDocumentShowOptions>{ selection: dependencyItem.range },
+        ],
+      };
+      configurationItem.getChildren().push(dependencyTreeItem);
+    }
+    this.defaultDependencies.set(
+      buildFileUri.toString(),
+      Array.from(configurationMap.values())
+    );
+    return this.defaultDependencies.get(buildFileUri.toString()) || [];
+  }
+}
+
+interface DefaultDependencyItem {
+  name: string;
+  configuration: string;
+  range: Range;
+}

--- a/extension/src/views/defaultProject/DefaultProjectUtils.ts
+++ b/extension/src/views/defaultProject/DefaultProjectUtils.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as vscode from 'vscode';
+import { DefaultTaskDefinition } from './types';
 
 export async function setDefault(): Promise<void> {
   await vscode.commands.executeCommand(
@@ -17,4 +18,94 @@ export async function unsetDefault(): Promise<void> {
     'gradle:defaultView',
     false
   );
+}
+
+export function generateDefaultTaskDefinitions(): DefaultTaskDefinition[] {
+  const result = [];
+  result.push(
+    getDefaultTaskDefinition(
+      'init',
+      'build setup',
+      'Initializes a new Gradle build.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'wrapper',
+      'build setup',
+      'Generates Gradle wrapper files.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'buildEnvironment',
+      'help',
+      'Displays all buildscript dependencies declared in root project.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'dependencies',
+      'help',
+      'Displays all dependencies declared in root project.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'dependencyInsight',
+      'help',
+      'Displays the insight into a specific dependency in root project.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition('help', 'help', 'Displays a help message.')
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'javaToolchains',
+      'help',
+      'Displays the detected java toolchains.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'outgoingVariants',
+      'help',
+      'Displays the outgoing variants of root project.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'projects',
+      'help',
+      'Displays the sub-projects of root project.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'properties',
+      'help',
+      'Displays the properties of root project.'
+    )
+  );
+  result.push(
+    getDefaultTaskDefinition(
+      'tasks',
+      'help',
+      'Displays the tasks runnable from root project.'
+    )
+  );
+  return result;
+}
+
+export function getDefaultTaskDefinition(
+  name: string,
+  group: string,
+  description: string
+): DefaultTaskDefinition {
+  return {
+    name: name,
+    group: group,
+    description: description,
+  };
 }

--- a/extension/src/views/defaultProject/DefaultProjectUtils.ts
+++ b/extension/src/views/defaultProject/DefaultProjectUtils.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+
+export async function setDefault(): Promise<void> {
+  await vscode.commands.executeCommand(
+    'setContext',
+    'gradle:defaultView',
+    true
+  );
+}
+
+export async function unsetDefault(): Promise<void> {
+  await vscode.commands.executeCommand(
+    'setContext',
+    'gradle:defaultView',
+    false
+  );
+}

--- a/extension/src/views/defaultProject/DefaultProjectsTreeDataProvider.ts
+++ b/extension/src/views/defaultProject/DefaultProjectsTreeDataProvider.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from 'vscode';
+import {
+  GradleTasksTreeDataProvider,
+  GroupTreeItem,
+  ProjectTreeItem,
+} from '..';
+import { GradleClient } from '../../client';
+import { RootProjectsStore } from '../../stores';
+import { GradleTaskProvider } from '../../tasks';
+import { DefaultProjectProvider } from './DefaultProjectProvider';
+import { Icons } from '../../icons';
+import { ProjectDependencyTreeItem } from '../gradleTasks/ProjectDependencyTreeItem';
+import { ProjectTaskTreeItem } from '../gradleTasks/ProjectTaskTreeItem';
+
+export class DefaultProjectsTreeDataProvider
+  implements vscode.TreeDataProvider<vscode.TreeItem>
+{
+  private defaultProjectProvider: DefaultProjectProvider;
+
+  constructor(
+    private readonly gradleTaskProvider: GradleTaskProvider,
+    private readonly rootProjectStore: RootProjectsStore,
+    private readonly client: GradleClient,
+    private readonly icons: Icons
+  ) {
+    this.defaultProjectProvider = new DefaultProjectProvider();
+  }
+
+  public getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  public async getChildren(
+    element?: vscode.TreeItem
+  ): Promise<vscode.TreeItem[] | undefined> {
+    if (!element) {
+      // async configuring
+      void this.gradleTaskProvider.loadTasks();
+      return GradleTasksTreeDataProvider.buildItemsTreeFromTasks(
+        await this.defaultProjectProvider.getDefaultTasks(
+          await this.rootProjectStore.getProjectRoots(),
+          this.client
+        ),
+        this.rootProjectStore,
+        false,
+        this.icons
+      );
+    } else if (element instanceof ProjectTreeItem) {
+      return GradleTasksTreeDataProvider.getChildrenForProjectTreeItem(element);
+    } else if (element instanceof ProjectDependencyTreeItem) {
+      return this.defaultProjectProvider.getDefaultDependencyItems(element);
+    } else if (element instanceof ProjectTaskTreeItem) {
+      return element.getChildren();
+    } else if (element instanceof GroupTreeItem) {
+      return element.tasks;
+    }
+    return [];
+  }
+}

--- a/extension/src/views/defaultProject/DefaultProjectsTreeDataProvider.ts
+++ b/extension/src/views/defaultProject/DefaultProjectsTreeDataProvider.ts
@@ -35,7 +35,7 @@ export class DefaultProjectsTreeDataProvider
 
   public async getChildren(
     element?: vscode.TreeItem
-  ): Promise<vscode.TreeItem[] | undefined> {
+  ): Promise<vscode.TreeItem[]> {
     if (!element) {
       // async configuring
       void this.gradleTaskProvider.loadTasks();
@@ -53,7 +53,7 @@ export class DefaultProjectsTreeDataProvider
     } else if (element instanceof ProjectDependencyTreeItem) {
       return this.defaultProjectProvider.getDefaultDependencyItems(element);
     } else if (element instanceof ProjectTaskTreeItem) {
-      return element.getChildren();
+      return element.getChildren() || [];
     } else if (element instanceof GroupTreeItem) {
       return element.tasks;
     }

--- a/extension/src/views/defaultProject/types.ts
+++ b/extension/src/views/defaultProject/types.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { Range } from 'vscode-languageclient/node';
+
+export interface DefaultDependencyItem {
+  name: string;
+  configuration: string;
+  range: Range;
+}
+
+export interface DefaultTaskDefinition {
+  name: string;
+  group: string;
+  description: string;
+}

--- a/extension/src/views/gradleTasks/DependencyConfigurationTreeItem.ts
+++ b/extension/src/views/gradleTasks/DependencyConfigurationTreeItem.ts
@@ -4,7 +4,7 @@
 import * as vscode from 'vscode';
 
 export class DependencyConfigurationTreeItem extends vscode.TreeItem {
-  private children: vscode.TreeItem[] | undefined;
+  private children: vscode.TreeItem[];
   constructor(
     name: string,
     collapsibleState: vscode.TreeItemCollapsibleState,
@@ -13,13 +13,14 @@ export class DependencyConfigurationTreeItem extends vscode.TreeItem {
   ) {
     super(name, collapsibleState);
     this.iconPath = iconPath;
+    this.children = [];
   }
 
   public setChildren(children: vscode.TreeItem[]): void {
     this.children = children;
   }
 
-  public getChildren(): vscode.TreeItem[] | undefined {
+  public getChildren(): vscode.TreeItem[] {
     return this.children;
   }
 }

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/GradleLanguageServer.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/GradleLanguageServer.java
@@ -28,6 +28,7 @@ import com.microsoft.gradle.semantictokens.TokenType;
 
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.DocumentFilter;
+import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.SaveOptions;
@@ -104,6 +105,7 @@ public class GradleLanguageServer implements LanguageServer, LanguageClientAware
     serverCapabilities.setTextDocumentSync(textDocumentSyncOptions);
     CompletionOptions completionOptions = new CompletionOptions(false, Arrays.asList(".", ":"));
     serverCapabilities.setCompletionProvider(completionOptions);
+    serverCapabilities.setExecuteCommandProvider(new ExecuteCommandOptions(GradleServices.supportedCommands));
     InitializeResult initializeResult = new InitializeResult(serverCapabilities);
     return CompletableFuture.completedFuture(initializeResult);
   }

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
@@ -43,9 +43,14 @@ public class DocumentSymbolVisitor {
 
   private URI currentUri;
   private Map<URI, List<DocumentSymbol>> documentSymbols = new HashMap<>();
+  private Map<URI, List<DocumentSymbol>> dependencies = new HashMap<>();
 
   public List<DocumentSymbol> getDocumentSymbols(URI uri) {
     return this.documentSymbols.get(uri);
+  }
+
+  public List<DocumentSymbol> getDependencies(URI uri) {
+    return this.dependencies.get(uri);
   }
 
   public void visitCompilationUnit(URI uri, GradleCompilationUnit compilationUnit) {
@@ -57,6 +62,7 @@ public class DocumentSymbolVisitor {
     ModuleNode moduleNode = unit.getAST();
     if (moduleNode != null) {
       this.documentSymbols.put(uri, new ArrayList<>());
+      this.dependencies.put(uri, new ArrayList<>());
       visitModule(moduleNode);
     }
   }
@@ -117,7 +123,9 @@ public class DocumentSymbolVisitor {
     symbol.setSelectionRange(LSPUtils.toRange(expression));
     symbol.setRange(LSPUtils.toRange(expression));
     if (expression.getMethodAsString().equals("dependencies")) {
-      symbol.setChildren(getDependencies(expression));
+      List<DocumentSymbol> dependencySymbols = getDependencies(expression);
+      symbol.setChildren(dependencySymbols);
+      this.dependencies.get(currentUri).addAll(dependencySymbols);
     }
     return symbol;
   }

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/DefaultDependenciesHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/DefaultDependenciesHandler.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Microsoft Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Microsoft Corporation - initial API and implementation
+*******************************************************************************/
+package com.microsoft.gradle.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.lsp4j.DocumentSymbol;
+import org.eclipse.lsp4j.Range;
+
+public class DefaultDependenciesHandler {
+  public class DefaultDependencyItem {
+    private String name;
+    private String configuration;
+    private Range range;
+
+    public DefaultDependencyItem(String name, String configuration, Range range) {
+      this.name = name;
+      this.configuration = configuration;
+      this.range = range;
+    }
+  }
+
+  public List<DefaultDependencyItem> getDefaultDependencies(List<DocumentSymbol> symbols) {
+    List<DefaultDependencyItem> dependencies  = new ArrayList<>();
+    for (DocumentSymbol symbol : symbols) {
+      String configuration = symbol.getName();
+      String id = symbol.getDetail();
+      Range range = symbol.getRange();
+      DefaultDependencyItem item = new DefaultDependencyItem(id, configuration, range);
+      dependencies.add(item);
+    }
+    return dependencies;
+  }
+}


### PR DESCRIPTION
fix #949 

![basicview](https://user-images.githubusercontent.com/45906942/134468750-96547180-0b87-4227-b7c2-8a0a19523520.gif)

Will show basic tasks and dependencies, in case of
- configuring projects
- fatal error occurs

Add a new workspace command `gradle.getDependencies` to fetch the literal dependencies from the `build.gradle` in the **project root**. When importing huge projects, the literal information of dependencies and tasks will provide more information to the user. 

Here we introduce a new view `gradleDefaultProjectsView` to provide default contents and use a context value `gradle:defaultView` to control which view (default view or common view) to show.