### PR TITLE
feat: Support workspaces without wrapper

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -33,7 +33,11 @@
   ],
   "activationEvents": [
     "workspaceContains:**/gradlew",
-    "workspaceContains:**/gradlew.bat"
+    "workspaceContains:**/gradlew.bat",
+    "workspaceContains:build.gradle",
+    "workspaceContains:settings.gradle",
+    "workspaceContains:build.gradle.kts",
+    "workspaceContains:settings.gradle.kts"
   ],
   "main": "./dist/index.js",
   "contributes": {

--- a/extension/src/stores/RootProjectsStore.ts
+++ b/extension/src/stores/RootProjectsStore.ts
@@ -91,22 +91,10 @@ export class RootProjectsStore extends StoreMap<string, RootProject> {
     if (
       (
         await vscode.workspace.findFiles(
-          new vscode.RelativePattern(folder, 'build.gradle')
-        )
-      )?.length ||
-      (
-        await vscode.workspace.findFiles(
-          new vscode.RelativePattern(folder, 'build.gradle.kts')
-        )
-      )?.length ||
-      (
-        await vscode.workspace.findFiles(
-          new vscode.RelativePattern(folder, 'settings.gradle')
-        )
-      )?.length ||
-      (
-        await vscode.workspace.findFiles(
-          new vscode.RelativePattern(folder, 'settings.gradle.kts')
+          new vscode.RelativePattern(
+            folder,
+            '{build.gradle,settings.gradle,build.gradle.kts,settings.gradle.kts}'
+          )
         )
       )?.length
     ) {

--- a/extension/src/stores/RootProjectsStore.ts
+++ b/extension/src/stores/RootProjectsStore.ts
@@ -93,22 +93,22 @@ export class RootProjectsStore extends StoreMap<string, RootProject> {
         await vscode.workspace.findFiles(
           new vscode.RelativePattern(folder, 'build.gradle')
         )
-      ).length ||
+      )?.length ||
       (
         await vscode.workspace.findFiles(
           new vscode.RelativePattern(folder, 'build.gradle.kts')
         )
-      ).length ||
+      )?.length ||
       (
         await vscode.workspace.findFiles(
           new vscode.RelativePattern(folder, 'settings.gradle')
         )
-      ).length ||
+      )?.length ||
       (
         await vscode.workspace.findFiles(
           new vscode.RelativePattern(folder, 'settings.gradle.kts')
         )
-      ).length
+      )?.length
     ) {
       return true;
     }


### PR DESCRIPTION
fix #1004 

since local Gradle installation has been supported, the requirement of wrapper can be removed. 