### PR TITLE
chore: Use cgmanifest.json to add missed packages

### DIFF
--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -78,3 +78,8 @@ jobs:
       displayName: Publish VSIX
       inputs:
         ArtifactName: extension
+    - task: ComponentGovernanceComponentDetection@0
+      inputs:
+        scanType: 'Register'
+        verbosity: 'Verbose'
+        alertWarningLevel: 'High'

--- a/.azure-pipelines/vscode-gradle-rc.yml
+++ b/.azure-pipelines/vscode-gradle-rc.yml
@@ -80,3 +80,8 @@ steps:
   displayName: Publish VSIX
   inputs:
     ArtifactName: extension
+- task: ComponentGovernanceComponentDetection@0
+  inputs:
+    scanType: 'Register'
+    verbosity: 'Verbose'
+    alertWarningLevel: 'High'

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,0 +1,180 @@
+{
+    "Registrations": [
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "org.eclipse.lsp4j",
+                    "ArtifactId": "org.eclipse.lsp4j",
+                    "Version": "0.12.0"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "org.eclipse.lsp4j",
+                    "ArtifactId": "org.eclipse.lsp4j.jsonrpc",
+                    "Version": "0.12.0"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "org.codehaus.groovy",
+                    "ArtifactId": "groovy-eclipse-batch",
+                    "Version": "3.0.8-01"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "com.google.code.gson",
+                    "ArtifactId": "gson",
+                    "Version": "2.8.7"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "org.apache.bcel",
+                    "ArtifactId": "bcel",
+                    "Version": "6.5.0"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "org.gradle",
+                    "ArtifactId": "gradle-tooling-api",
+                    "Version": "6.4"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "javax.annotation",
+                    "ArtifactId": "javax.annotation-api",
+                    "Version": "1.3.2"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "io.grpc",
+                    "ArtifactId": "grpc-protobuf",
+                    "Version": "1.30.0"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "io.grpc",
+                    "ArtifactId": "grpc-stub",
+                    "Version": "1.30.0"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "com.github.zafarkhaja",
+                    "ArtifactId": "java-semver",
+                    "Version": "0.9.0"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "io.grpc",
+                    "ArtifactId": "grpc-netty",
+                    "Version": "1.30.0"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "org.slf4j",
+                    "ArtifactId": "slf4j-simple",
+                    "Version": "2.0.0-alpha1"
+                }
+            },
+            "DevelopmentDependency": false
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "io.grpc",
+                    "ArtifactId": "grpc-testing",
+                    "Version": "1.30.0"
+                }
+            },
+            "DevelopmentDependency": true
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "junit",
+                    "ArtifactId": "junit",
+                    "Version": "4.13.1"
+                }
+            },
+            "DevelopmentDependency": true
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "org.powermock",
+                    "ArtifactId": "powermock-module-junit4",
+                    "Version": "2.0.9"
+                }
+            },
+            "DevelopmentDependency": true
+        },
+        {
+            "Component": {
+                "Type": "maven",
+                "Maven": {
+                    "GroupId": "org.powermock",
+                    "ArtifactId": "powermock-api-mockito2",
+                    "Version": "2.0.7"
+                }
+            },
+            "DevelopmentDependency": true
+        }
+    ]
+}


### PR DESCRIPTION
To use Component Governance in this Repo, we will manually add the cgmanifest.json to specify the gradle packages missed by auto detection.