### PR TITLE
fix: Recognize patterns like `gradle-${version}-all.zip`

### DIFF
--- a/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
@@ -137,7 +137,7 @@ public class GradleLibraryResolver {
       String content = null;
       while ((content = reader.readLine()) != null) {
         if (content.startsWith("distributionUrl")) {
-          Pattern p = Pattern.compile("(gradle-(?s)(.*))-bin");
+          Pattern p = Pattern.compile("(gradle-(?s)(.*))-(bin|all)");
           Matcher matcher = p.matcher(content);
           if (matcher.find()) {
             String gradleDist = matcher.group(1);


### PR DESCRIPTION
fix #1048 