### PR TITLE
fix: Distinguish classpaths among projects

### DIFF
--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -146,11 +146,13 @@ function getGradleSettings(): unknown {
 }
 
 export async function syncLanguageServer(
+  projectPath: string,
   projectContent: GetProjectsReply
 ): Promise<void> {
   if (isLanguageServerStarted) {
     await vscode.commands.executeCommand(
       'gradle.setPlugins',
+      projectPath,
       projectContent.getPluginsList()
     );
     const closures = projectContent.getPluginclosuresList().map((value) => {
@@ -173,9 +175,14 @@ export async function syncLanguageServer(
         fields: JSONField,
       };
     });
-    await vscode.commands.executeCommand('gradle.setClosures', closures);
+    await vscode.commands.executeCommand(
+      'gradle.setClosures',
+      projectPath,
+      closures
+    );
     await vscode.commands.executeCommand(
       'gradle.setScriptClasspaths',
+      projectPath,
       projectContent.getScriptclasspathsList()
     );
   }

--- a/extension/src/projectContent/GradleProjectContentProvider.ts
+++ b/extension/src/projectContent/GradleProjectContentProvider.ts
@@ -25,7 +25,7 @@ export class GradleProjectContentProvider {
     );
     if (projectContent) {
       this.cachedContent.set(projectPath, projectContent);
-      await syncLanguageServer(projectContent);
+      await syncLanguageServer(projectPath, projectContent);
     }
     return projectContent;
   }

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/utils/Utils.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/utils/Utils.java
@@ -4,7 +4,9 @@
 package com.microsoft.gradle.utils;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -53,5 +55,14 @@ public class Utils {
       }
     }
     return allFiles;
+  }
+
+  public static String getFolderPath(URI uri) {
+    Path path = Paths.get(uri);
+    Path folderPath = path.getParent();
+    if (folderPath == null) {
+      return null;
+    }
+    return folderPath.toString();
   }
 }


### PR DESCRIPTION
fix #1069 

for different projects (subprojects), we distinguish them by different folders containing `build.gradle` files, thus we can store different
- plugins
- closures from plugins
- classpaths

of them. And use them to compile or provide auto completions.