### PR TITLE
fix: Update project after modifying build file

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -317,8 +317,8 @@ export class Extension {
   private handleWatchEvents(): void {
     this.buildFileWatcher.onDidChange(async (uri: vscode.Uri) => {
       logger.info('Build file changed:', uri.fsPath);
-      void this.syncBuildFile(uri);
       await this.refresh();
+      void this.syncBuildFile(uri);
     });
     this.buildFileWatcher.onDidOpen(async (uri: vscode.Uri) => {
       logger.info('Build file opened:', uri.fsPath);

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { logger, LogVerbosity, Logger } from './logger';
 import { Api } from './api';
 import { GradleClient } from './client';
@@ -42,6 +43,7 @@ import { GradleDependencyProvider } from './dependencies/GradleDependencyProvide
 import {
   isLanguageServerStarted,
   startLanguageServer,
+  syncLanguageServer,
 } from './languageServer/languageServer';
 import { DefaultProjectsTreeDataProvider } from './views/defaultProject/DefaultProjectsTreeDataProvider';
 import { GradleProjectContentProvider } from './projectContent/GradleProjectContentProvider';
@@ -315,7 +317,12 @@ export class Extension {
   private handleWatchEvents(): void {
     this.buildFileWatcher.onDidChange(async (uri: vscode.Uri) => {
       logger.info('Build file changed:', uri.fsPath);
+      void this.syncBuildFile(uri);
       await this.refresh();
+    });
+    this.buildFileWatcher.onDidOpen(async (uri: vscode.Uri) => {
+      logger.info('Build file opened:', uri.fsPath);
+      void this.syncBuildFile(uri);
     });
     this.gradleWrapperWatcher.onDidChange(async (uri: vscode.Uri) => {
       logger.info('Gradle wrapper properties changed:', uri.fsPath);
@@ -324,6 +331,20 @@ export class Extension {
         void vscode.commands.executeCommand('gradle.distributionChanged');
       }
     });
+  }
+
+  private async syncBuildFile(uri: vscode.Uri): Promise<void> {
+    const fsPath = uri.fsPath;
+    const dirName = path.dirname(fsPath);
+    const baseName = path.basename(dirName);
+    const projectContent =
+      await this.gradleProjectContentProvider.getProjectContent(
+        dirName,
+        baseName
+      );
+    if (projectContent) {
+      await syncLanguageServer(dirName, projectContent);
+    }
   }
 
   private async restartServer(): Promise<void> {

--- a/extension/src/dependencies/GradleDependencyProvider.ts
+++ b/extension/src/dependencies/GradleDependencyProvider.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as vscode from 'vscode';
+import { syncLanguageServer } from '../languageServer/languageServer';
 import { GradleProjectContentProvider } from '../projectContent/GradleProjectContentProvider';
 import { getDependencyConfigurationTreeItems } from '../views/gradleTasks/DependencyUtils';
 import { HintItem } from '../views/gradleTasks/HintItem';
@@ -29,6 +30,7 @@ export class GradleDependencyProvider {
       this.cachedDependencies.set(projectPath, noDependencies);
       return noDependencies;
     }
+    await syncLanguageServer(projectPath, project);
     const dependencyItem = project.getItem();
     if (dependencyItem) {
       const configItems = getDependencyConfigurationTreeItems(

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -198,10 +198,13 @@ async function handleLanguageServerStart(
       const projectPath = folders[0].uri.fsPath;
       // when language server starts, it knows nothing about the project
       // here to asynchronously sync the project content (plugins, closures) with language server
-      void contentProvider.getProjectContent(
+      const projectContent = await contentProvider.getProjectContent(
         projectPath,
         path.basename(projectPath)
       );
+      if (projectContent) {
+        await syncLanguageServer(projectPath, projectContent);
+      }
     }
   }
 }

--- a/extension/src/projectContent/GradleProjectContentProvider.ts
+++ b/extension/src/projectContent/GradleProjectContentProvider.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import { GradleClient } from '../client';
-import { syncLanguageServer } from '../languageServer/languageServer';
 import { GetProjectsReply } from '../proto/gradle_pb';
 import { getGradleConfig } from '../util/config';
 
@@ -25,7 +24,6 @@ export class GradleProjectContentProvider {
     );
     if (projectContent) {
       this.cachedContent.set(projectPath, projectContent);
-      await syncLanguageServer(projectPath, projectContent);
     }
     return projectContent;
   }

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/manager/GradleFilesManager.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/manager/GradleFilesManager.java
@@ -107,6 +107,10 @@ public class GradleFilesManager {
 
   public void didClose(URI uri) {
     openFiles.remove(uri);
+    this.unitStorage.remove(uri);
+    String projectPath = Utils.getFolderPath(uri);
+    this.configs.remove(projectPath);
+    this.scriptClasspaths.remove(projectPath);
   }
 
   public String getContents(URI uri) {


### PR DESCRIPTION
fix #1065 

when the following events are watched
- change build file
- open build file

we trigger get projects process to update the classpath and closure infos of the given build file. we have a cache mechanism in https://github.com/microsoft/vscode-gradle/blob/6f051190b7273a2e747555aa100e09dbab4e80dc/extension/src/projectContent/GradleProjectContentProvider.ts#L18 so get project process from plugin will be triggered if
- A gradle file is opened at the first time
- A gradle file is changed.

