### PR TITLE
fix: Support multiple jvmArguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ This extension supports the following settings which are contributed by the [Jav
 - `java.import.gradle.java.home`: Absolute path to JDK home folder used to launch the Gradle daemons (if set, this value takes precedence over `java.home`)
 - `java.import.gradle.user.home`: Setting for `GRADLE_USER_HOME`
 - `java.import.gradle.jvmArguments`: JVM arguments to pass to Gradle
+> Note: There should be a space ` ` between two arguments
 - `java.import.gradle.wrapper.enabled`: Enable/disable the Gradle wrapper
 - `java.import.gradle.version`: Gradle version, used if the Gradle wrapper is missing or disabled
 - `java.import.gradle.home`: Use Gradle from the specified local installation directory or GRADLE_HOME if the Gradle wrapper is missing or disabled and no 'java.import.gradle.version' is specified.

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -22,6 +22,7 @@ import com.google.protobuf.ByteString;
 import io.github.g00fy2.versioncompare.Version;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import org.gradle.internal.service.ServiceCreationException;
@@ -177,7 +178,10 @@ public class GetBuildHandler {
         .setStandardError(standardErrorListener);
     String jvmArguments = req.getGradleConfig().getJvmArguments();
     if (!Strings.isNullOrEmpty(jvmArguments)) {
-      buildEnvironment.setJvmArguments(jvmArguments.split(" "));
+      buildEnvironment.setJvmArguments(
+          Arrays.stream(jvmArguments.split(" "))
+              .filter(e -> e != null && !e.isEmpty())
+              .toArray(String[]::new));
     }
 
     try {
@@ -219,7 +223,10 @@ public class GetBuildHandler {
         .setColorOutput(req.getShowOutputColors());
     String jvmArguments = req.getGradleConfig().getJvmArguments();
     if (!Strings.isNullOrEmpty(jvmArguments)) {
-      projectBuilder.setJvmArguments(jvmArguments.split(" "));
+      projectBuilder.setJvmArguments(
+          Arrays.stream(jvmArguments.split(" "))
+              .filter(e -> e != null && !e.isEmpty())
+              .toArray(String[]::new));
     }
 
     try {

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -175,6 +175,10 @@ public class GetBuildHandler {
         .addProgressListener(progressListener, progressEvents)
         .setStandardOutput(standardOutputListener)
         .setStandardError(standardErrorListener);
+    String jvmArguments = req.getGradleConfig().getJvmArguments();
+    if (!Strings.isNullOrEmpty(jvmArguments)) {
+      buildEnvironment.setJvmArguments(jvmArguments.split(" "));
+    }
 
     try {
       BuildEnvironment environment = buildEnvironment.get();
@@ -213,8 +217,9 @@ public class GetBuildHandler {
         .setStandardOutput(standardOutputListener)
         .setStandardError(standardErrorListener)
         .setColorOutput(req.getShowOutputColors());
-    if (!Strings.isNullOrEmpty(req.getGradleConfig().getJvmArguments())) {
-      projectBuilder.setJvmArguments(req.getGradleConfig().getJvmArguments());
+    String jvmArguments = req.getGradleConfig().getJvmArguments();
+    if (!Strings.isNullOrEmpty(jvmArguments)) {
+      projectBuilder.setJvmArguments(jvmArguments.split(" "));
     }
 
     try {

--- a/gradle-server/src/test/java/com/github/badsyntax/gradle/GradleServerTest.java
+++ b/gradle-server/src/test/java/com/github/badsyntax/gradle/GradleServerTest.java
@@ -252,7 +252,7 @@ public class GradleServerTest {
 
     stub.getBuild(req, mockResponseObserver);
     verify(mockResponseObserver, never()).onError(any());
-    verify(mockGradleProjectBuilder).setJvmArguments(jvmArgs);
+    verify(mockGradleProjectBuilder).setJvmArguments(jvmArgs.split(" "));
   }
 
   @Test


### PR DESCRIPTION
part of #1077 

Currently, there will be an error when the setting `java.import.gradle.jvmArguments` is set to more than one argument (in vscode-java, the arguments are split by a space). Here to fix the logics and the doc.

![gradlejvmarguments](https://user-images.githubusercontent.com/45906942/140879454-16733b63-64c0-4878-a2c3-d90d357c7472.png)

