### PR TITLE
chore: Upgrade gson to 2.8.9

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -39,7 +39,7 @@
                 "Maven": {
                     "GroupId": "com.google.code.gson",
                     "ArtifactId": "gson",
-                    "Version": "2.8.7"
+                    "Version": "2.8.9"
                 }
             },
             "DevelopmentDependency": false

--- a/gradle-language-server/build.gradle
+++ b/gradle-language-server/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.12.0"
   implementation "org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.12.0"
   implementation "org.codehaus.groovy:groovy-eclipse-batch:3.0.8-01"
-  implementation "com.google.code.gson:gson:2.8.7"
+  implementation "com.google.code.gson:gson:2.8.9"
   implementation "org.apache.bcel:bcel:6.5.0"
 }
 


### PR DESCRIPTION
to solve CG vulnerability issue: WS-2021-0419