### PR TITLE
chore: Revisit copyright header for source files created by Microsoft

### DIFF
--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -1,7 +1,5 @@
-/* --------------------------------------------------------------------------------------------
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License. See License.txt in the project root for license information.
- * ------------------------------------------------------------------------------------------ */
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 import * as net from 'net';
 import * as path from 'path';

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/GradleLanguageServer.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/GradleLanguageServer.java
@@ -1,13 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 package com.microsoft.gradle;
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
@@ -1,13 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 package com.microsoft.gradle;
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/CompletionVisitor.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/CompletionVisitor.java
@@ -1,13 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.compile;
 
 import java.net.URI;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
@@ -1,13 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.compile;
 
 import java.net.URI;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/GradleCompilationUnit.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/GradleCompilationUnit.java
@@ -1,13 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 package com.microsoft.gradle.compile;
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/SemanticTokenVisitor.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/SemanticTokenVisitor.java
@@ -1,13 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.compile;
 
 import java.net.URI;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/delegate/GradleDelegate.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/delegate/GradleDelegate.java
@@ -1,13 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 package com.microsoft.gradle.delegate;
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/CompletionHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/CompletionHandler.java
@@ -1,13 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.handlers;
 
 import java.lang.reflect.Modifier;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/DefaultDependenciesHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/DefaultDependenciesHandler.java
@@ -1,15 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Microsoft Corporation - initial API and implementation
-*******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.handlers;
 
 import java.util.ArrayList;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/DependencyCompletionHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/DependencyCompletionHandler.java
@@ -1,13 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.handlers;
 
 import java.io.InputStreamReader;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/manager/GradleFilesManager.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/manager/GradleFilesManager.java
@@ -1,13 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 package com.microsoft.gradle.manager;
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
@@ -1,13 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.resolver;
 
 import java.io.File;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/semantictokens/SemanticToken.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/semantictokens/SemanticToken.java
@@ -1,13 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.semantictokens;
 
 import java.util.ArrayList;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/semantictokens/TokenModifier.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/semantictokens/TokenModifier.java
@@ -1,15 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Microsoft Corporation - initial API and implementation
-*******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.semantictokens;
 
 import java.util.Arrays;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/semantictokens/TokenType.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/semantictokens/TokenType.java
@@ -1,15 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Microsoft Corporation - initial API and implementation
-*******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.semantictokens;
 
 import org.eclipse.lsp4j.SemanticTokenTypes;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/utils/LSPUtils.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/utils/LSPUtils.java
@@ -1,13 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.microsoft.gradle.utils;
 
 import org.codehaus.groovy.ast.expr.Expression;

--- a/gradle-language-server/src/test/java/com/microsoft/gradle/GradleCompletionTest.java
+++ b/gradle-language-server/src/test/java/com/microsoft/gradle/GradleCompletionTest.java
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+
 package com.microsoft.gradle;
 
 import java.nio.file.Path;

--- a/gradle-language-server/src/test/java/com/microsoft/gradle/GradleDiagnosticsTest.java
+++ b/gradle-language-server/src/test/java/com/microsoft/gradle/GradleDiagnosticsTest.java
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+
 package com.microsoft.gradle;
 
 import java.nio.file.Path;

--- a/gradle-language-server/src/test/java/com/microsoft/gradle/GradleDocumentSymbolTest.java
+++ b/gradle-language-server/src/test/java/com/microsoft/gradle/GradleDocumentSymbolTest.java
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+
 package com.microsoft.gradle;
 
 import java.nio.file.Path;

--- a/gradle-language-server/src/test/java/com/microsoft/gradle/GradleSemanticsTest.java
+++ b/gradle-language-server/src/test/java/com/microsoft/gradle/GradleSemanticsTest.java
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+
 package com.microsoft.gradle;
 
 import java.nio.file.Path;

--- a/gradle-language-server/src/test/java/com/microsoft/gradle/GradleTestConstants.java
+++ b/gradle-language-server/src/test/java/com/microsoft/gradle/GradleTestConstants.java
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+
 package com.microsoft.gradle;
 
 import java.nio.file.Path;

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleExecution.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleExecution.java
@@ -1,15 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.github.badsyntax.gradle;
 
 import com.github.badsyntax.gradle.exceptions.GradleExecutionException;

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleLocalInstallation.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleLocalInstallation.java
@@ -1,15 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.github.badsyntax.gradle;
 
 import com.github.badsyntax.gradle.exceptions.GradleExecutionException;

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleProjectConnectionType.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleProjectConnectionType.java
@@ -1,15 +1,6 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License 2.0
- * which accompanies this distribution, and is available at
- * https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *     Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.github.badsyntax.gradle;
 
 public enum GradleProjectConnectionType {

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/exceptions/GradleExecutionException.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/exceptions/GradleExecutionException.java
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 package com.github.badsyntax.gradle.exceptions;
 
 public class GradleExecutionException extends Exception {

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/CancelProjectsHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/CancelProjectsHandler.java
@@ -1,13 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 package com.github.badsyntax.gradle.handlers;
 

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetProjectsHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetProjectsHandler.java
@@ -1,13 +1,5 @@
-/*******************************************************************************
- * Copyright (c) 2021 Microsoft Corporation and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
- *
- * Contributors:
- *    Microsoft Corporation - initial API and implementation
- *******************************************************************************/
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 package com.github.badsyntax.gradle.handlers;
 


### PR DESCRIPTION
fix #1073 , we will add the MIT license copyright header for the source files created by Microsoft.