### PR TITLE
feat: Show task selectors

### DIFF
--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -190,7 +190,8 @@ public class GetBuildHandler {
 
 	private GradleProject getProjectData(org.gradle.tooling.model.GradleProject gradleProject,
 			org.gradle.tooling.model.GradleProject rootGradleProject, Set<GradleTask> taskSelectors) {
-		GradleProject.Builder project = GradleProject.newBuilder().setIsRoot(gradleProject.getParent() == null);
+		boolean isRoot = gradleProject.getParent() == null;
+		GradleProject.Builder project = GradleProject.newBuilder().setIsRoot(isRoot);
 		gradleProject.getChildren().stream().forEach(childGradleProject -> project
 				.addProjects(getProjectData(childGradleProject, rootGradleProject, taskSelectors)));
 		gradleProject.getTasks().stream().forEach(task -> {
@@ -207,9 +208,7 @@ public class GetBuildHandler {
 			project.addTasks(gradleTask.build());
 			taskSelectors.add(gradleTask.build());
 		});
-		String projectPath = gradleProject.getPath();
-		String rootProjectPath = rootGradleProject.getPath();
-		if (projectPath != null && rootProjectPath != null && projectPath.equals(rootProjectPath)) {
+		if (isRoot) {
 			Set<String> taskNames = new HashSet<>();
 			for (GradleTask existingTask : project.getTasksList()) {
 				taskNames.add(existingTask.getName());

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -207,7 +207,9 @@ public class GetBuildHandler {
 			project.addTasks(gradleTask.build());
 			taskSelectors.add(gradleTask.build());
 		});
-		if (gradleProject.getPath().equals(rootGradleProject.getPath())) {
+		String projectPath = gradleProject.getPath();
+		String rootProjectPath = rootGradleProject.getPath();
+		if (projectPath != null && rootProjectPath != null && projectPath.equals(rootProjectPath)) {
 			Set<String> taskNames = new HashSet<>();
 			for (GradleTask existingTask : project.getTasksList()) {
 				taskNames.add(existingTask.getName());


### PR DESCRIPTION
fix #1046 , see reference: https://docs.gradle.org/current/userguide/command_line_interface.html#executing_tasks_in_multi_project_builds

we show all tasks from subprojects in the root project to support task selectors, and this can keep alignment with the CLI output `gradle tasks`

![image](https://user-images.githubusercontent.com/45906942/146112811-615b1e5a-c0fe-4f5b-8e47-b1a3bf5ea971.png)
