### PR TITLE
feat: Support Parallel running of Gradle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ This extension contributes the following settings:
 - `gradle.javaDebug`: Debug JavaExec tasks (see below for usage)
 - `gradle.debug`: Show extra debug info in the output panel (boolean)
 - `gradle.disableConfirmations`: Disable the warning confirm messages when performing batch actions (eg clear tasks, stop daemons etc) (boolean)
+- `gradle.allowParallelRun`: Allow to run tasks in parallel, each running will create a new terminal. This configuration takes effect only when `gradle.reuseTerminals` is set to `off`
 
 ## Gradle & Java Settings
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -760,7 +760,7 @@
           "type": "boolean",
           "default": false,
           "scope": "window",
-          "markdownDescription": "Allow to run tasks in parallel. When enabled, you can run a task multiple times even the previous running is not terminated. This configuration takes effect only when `gradle.reuseTerminals` is set to `off`."
+          "markdownDescription": "Allow to run tasks in parallel, each running will create a new terminal. This configuration takes effect only when `gradle.reuseTerminals` is set to `off`."
         }
       }
     },

--- a/extension/package.json
+++ b/extension/package.json
@@ -576,7 +576,7 @@
         },
         {
           "command": "gradle.runTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$|^gradleDefaultProjectsView$/ && viewItem =~ /^debugTask.*$|^task.*$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$|^gradleDefaultProjectsView$/ && viewItem =~ /^debugTask.*$|^task.*$/ || viewItem =~ /^runningTask.*$/ && allowParallelRun == true",
           "group": "inline@3"
         },
         {
@@ -755,6 +755,12 @@
           "default": false,
           "scope": "application",
           "description": "Show stopped daemons in the Gradle Daemons view"
+        },
+        "gradle.allowParallelRun": {
+          "type": "boolean",
+          "default": false,
+          "scope": "window",
+          "markdownDescription": "Allow to run tasks in parallel. When enabled, you can run a task multiple times even the previous running is not terminated. This configuration takes effect only when `gradle.reuseTerminals` is set to `off`."
         }
       }
     },

--- a/extension/package.json
+++ b/extension/package.json
@@ -561,32 +561,32 @@
         },
         {
           "command": "gradle.showTaskTerminal",
-          "when": "view == recentTasksView && viewItem =~ /^debugTask(WithArgs)?WithTerminals.*$|^task(WithArgs)?WithTerminals.*$|^runningTask(WithArgs)?WithTerminals.*$/",
+          "when": "view == recentTasksView && viewItem =~ /^debugTask(WithArgs)?WithTerminals.*$|^task(WithArgs)?WithTerminals.*$|^runningTask(WithArgs)?WithTerminals.*$|^runningDebugTask(WithArgs)?WithTerminals.*$/",
           "group": "inline@0"
         },
         {
           "command": "gradle.closeTaskTerminals",
-          "when": "view == recentTasksView  && viewItem =~ /^debugTask(WithArgs)?WithTerminals.*$|^task(WithArgs)?WithTerminals.*$|^runningTask(WithArgs)?WithTerminals.*$/",
+          "when": "view == recentTasksView  && viewItem =~ /^debugTask(WithArgs)?WithTerminals.*$|^task(WithArgs)?WithTerminals.*$|^runningTask(WithArgs)?WithTerminals.*$|^runningDebugTask(WithArgs)?WithTerminals.*$/",
           "group": "inline@1"
         },
         {
           "command": "gradle.debugTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^debugTask.*$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^debugTask.*$/ || viewItem =~ /^runningDebugTask.*$/ && allowParallelRun == true",
           "group": "inline@2"
         },
         {
           "command": "gradle.runTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$|^gradleDefaultProjectsView$/ && viewItem =~ /^debugTask.*$|^task.*$/ || viewItem =~ /^runningTask.*$/ && allowParallelRun == true",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$|^gradleDefaultProjectsView$/ && viewItem =~ /^debugTask.*$|^task.*$/ || viewItem =~ /^runningTask.*$|^runningDebugTask.*$/ && allowParallelRun == true",
           "group": "inline@3"
         },
         {
           "command": "gradle.restartTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^runningTask.*$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^runningTask.*$|^runningDebugTask.*$/",
           "group": "inline@4"
         },
         {
           "command": "gradle.cancelTreeItemTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^runningTask.*$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^runningTask.*$|^runningDebugTask.*$/",
           "group": "inline@5"
         },
         {

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -23,7 +23,7 @@ import {
 import { focusTaskInGradleTasksTree } from "./views/viewUtil";
 import { COMMAND_RENDER_TASK, COMMAND_REFRESH } from "./commands";
 import { Commands } from "./commands/Commands";
-import { getConfigIsDebugEnabled, getConfigFocusTaskInExplorer } from "./util/config";
+import { getConfigIsDebugEnabled, getConfigFocusTaskInExplorer, getAllowParallelRun } from "./util/config";
 import { FileWatcher } from "./util/FileWatcher";
 import { DependencyTreeItem } from "./views/gradleTasks/DependencyTreeItem";
 import { GRADLE_DEPENDENCY_REVEAL } from "./views/gradleTasks/DependencyUtils";
@@ -183,6 +183,7 @@ export class Extension {
 
         void this.activate();
         void startLanguageServer(this.context, this.gradleProjectContentProvider);
+        void vscode.commands.executeCommand("setContext", "allowParallelRun", getAllowParallelRun());
         void vscode.commands.executeCommand("setContext", Context.ACTIVATION_CONTEXT_KEY, true);
     }
 
@@ -322,6 +323,8 @@ export class Extension {
                     event.affectsConfiguration("java.import.gradle.wrapper.enabled")
                 ) {
                     await this.refresh();
+                } else if (event.affectsConfiguration("gradle.allowParallelRun")) {
+                    void vscode.commands.executeCommand("setContext", "allowParallelRun", getAllowParallelRun());
                 }
             }),
             vscode.window.onDidCloseTerminal((terminal: vscode.Terminal) => {

--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -24,7 +24,7 @@ import {
     getConfigIsAutoDetectionEnabled,
     getConfigReuseTerminals,
     getConfigJavaDebug,
-    getAllowParallelRun,
+    isAllowedParallelRun,
 } from "../util/config";
 
 const cancellingTasks: Map<string, vscode.Task> = new Map();
@@ -131,7 +131,7 @@ export function createTaskFromDefinition(
     client: GradleClient,
     useUniqueId = false
 ): vscode.Task {
-    if (getAllowParallelRun() && useUniqueId) {
+    if (isAllowedParallelRun() && useUniqueId) {
         // use a random id to distinguish tasks
         definition.id = definition.id + Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
     }
@@ -298,7 +298,7 @@ export async function runTask(
     debug = false
 ): Promise<void> {
     const isRunning = isTaskRunning(task, args);
-    if (!getAllowParallelRun() && isRunning) {
+    if (!isAllowedParallelRun() && isRunning) {
         logger.warn("Unable to run task, task is already running:", task.name);
         return;
     }
@@ -325,7 +325,7 @@ export async function runTask(
         }
     }
     try {
-        if (debug || args || getAllowParallelRun()) {
+        if (debug || args || isAllowedParallelRun()) {
             const clonedTask = cloneTask(rootProjectsStore, task, args, client, debug, isRunning);
             await vscode.tasks.executeTask(clonedTask);
         } else {

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -89,6 +89,13 @@ export function getConfigJavaDebug(workspaceFolder: vscode.WorkspaceFolder): Jav
     return vscode.workspace.getConfiguration("gradle", workspaceFolder.uri).get<JavaDebug>("javaDebug", defaultValue);
 }
 
+export function getAllowParallelRun(): boolean {
+    return (
+        vscode.workspace.getConfiguration("gradle").get<boolean>("allowParallelRun", false) &&
+        getConfigReuseTerminals() === "off"
+    );
+}
+
 export function getGradleConfig(): GradleConfig {
     const gradleConfig = new GradleConfig();
     const gradleHome = getConfigJavaImportGradleHome();

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -89,11 +89,12 @@ export function getConfigJavaDebug(workspaceFolder: vscode.WorkspaceFolder): Jav
     return vscode.workspace.getConfiguration("gradle", workspaceFolder.uri).get<JavaDebug>("javaDebug", defaultValue);
 }
 
+export function isAllowedParallelRun(): boolean {
+    return getAllowParallelRun() && getConfigReuseTerminals() === "off";
+}
+
 export function getAllowParallelRun(): boolean {
-    return (
-        vscode.workspace.getConfiguration("gradle").get<boolean>("allowParallelRun", false) &&
-        getConfigReuseTerminals() === "off"
-    );
+    return vscode.workspace.getConfiguration("gradle").get<boolean>("allowParallelRun", false);
 }
 
 export function getGradleConfig(): GradleConfig {

--- a/extension/src/views/constants.ts
+++ b/extension/src/views/constants.ts
@@ -14,6 +14,7 @@ export const PINNED_TASKS_VIEW = "pinnedTasksView";
 export const RECENT_TASKS_VIEW = "recentTasksView";
 
 export const TREE_ITEM_STATE_TASK_RUNNING = "runningTask";
+export const TREE_ITEM_STATE_TASK_DEBUG_RUNNING = "runningDebugTask";
 export const TREE_ITEM_STATE_TASK_CANCELLING = "cancellingTask";
 export const TREE_ITEM_STATE_TASK_IDLE = "task";
 export const TREE_ITEM_STATE_TASK_DEBUG_IDLE = "debugTask";

--- a/extension/src/views/viewUtil.ts
+++ b/extension/src/views/viewUtil.ts
@@ -5,6 +5,7 @@ import {
     TREE_ITEM_STATE_TASK_RUNNING,
     TREE_ITEM_STATE_TASK_DEBUG_IDLE,
     TREE_ITEM_STATE_TASK_IDLE,
+    TREE_ITEM_STATE_TASK_DEBUG_RUNNING,
 } from "./constants";
 import { GradleTaskDefinition } from "../tasks";
 import { logger } from "../logger";
@@ -123,15 +124,14 @@ export async function focusProjectInGradleTasksTree(
 }
 
 function getTreeItemRunningState(task: vscode.Task, javaDebug?: JavaDebug, args?: TaskArgs): string {
+    const isDebug = javaDebug && javaDebug.tasks.includes(task.definition.script);
     if (isTaskCancelling(task, args)) {
         return TREE_ITEM_STATE_TASK_CANCELLING;
     }
     if (isTaskRunning(task, args)) {
-        return TREE_ITEM_STATE_TASK_RUNNING;
+        return isDebug ? TREE_ITEM_STATE_TASK_DEBUG_RUNNING : TREE_ITEM_STATE_TASK_RUNNING;
     }
-    return javaDebug && javaDebug.tasks.includes(task.definition.script)
-        ? TREE_ITEM_STATE_TASK_DEBUG_IDLE
-        : TREE_ITEM_STATE_TASK_IDLE;
+    return isDebug ? TREE_ITEM_STATE_TASK_DEBUG_IDLE : TREE_ITEM_STATE_TASK_IDLE;
 }
 
 export function getTreeItemState(task: vscode.Task, javaDebug?: JavaDebug, args?: TaskArgs): string {


### PR DESCRIPTION
fix #1045 

Supports to run a task multiple times, this behavior is controlled by `gradle.allowParallelRun`.

![parallelRun](https://user-images.githubusercontent.com/45906942/146117331-13106fae-0053-4bd1-9307-46475d3baea6.gif)
