### PR TITLE
chore: Add telemetry for authoring features

### DIFF
--- a/extension/src/constant.ts
+++ b/extension/src/constant.ts
@@ -5,3 +5,9 @@
 export namespace Context {
     export const ACTIVATION_CONTEXT_KEY = "gradle:extensionActivated";
 }
+
+export const GRADLE_BUILD_FILE_CHANGE = "gradle.buildFileChanged";
+
+export const GRADLE_BUILD_FILE_OPEN = "gradle.buildFileOpened";
+
+export const GRADLE_PROPERTIES_FILE_CHANGE = "gradle.propertiesFileChanged";

--- a/extension/src/constant.ts
+++ b/extension/src/constant.ts
@@ -11,3 +11,15 @@ export const GRADLE_BUILD_FILE_CHANGE = "gradle.buildFileChanged";
 export const GRADLE_BUILD_FILE_OPEN = "gradle.buildFileOpened";
 
 export const GRADLE_PROPERTIES_FILE_CHANGE = "gradle.propertiesFileChanged";
+
+export const GRADLE_COMPLETION = "gradle.triggerCompletion";
+
+export const VSCODE_TRIGGER_COMPLETION = "editor.action.triggerSuggest";
+
+export enum CompletionKinds {
+    DEPENDENCY_GROUP = "dependency_group",
+    DEPENDENCY_ARTIFACT = "dependency_artifact",
+    DEPENDENCY_VERSION = "dependency_version",
+    METHOD_CALL = "method_call",
+    PROPERTY = "property",
+}

--- a/extension/src/constant.ts
+++ b/extension/src/constant.ts
@@ -12,7 +12,7 @@ export const GRADLE_BUILD_FILE_OPEN = "gradle.buildFileOpened";
 
 export const GRADLE_PROPERTIES_FILE_CHANGE = "gradle.propertiesFileChanged";
 
-export const GRADLE_COMPLETION = "gradle.triggerCompletion";
+export const GRADLE_COMPLETION = "gradle.completion";
 
 export const VSCODE_TRIGGER_COMPLETION = "editor.action.triggerSuggest";
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/CompletionHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/CompletionHandler.java
@@ -8,6 +8,8 @@ import com.microsoft.gradle.resolver.GradleClosure;
 import com.microsoft.gradle.resolver.GradleField;
 import com.microsoft.gradle.resolver.GradleLibraryResolver;
 import com.microsoft.gradle.resolver.GradleMethod;
+import com.microsoft.gradle.utils.CompletionUtils;
+import com.microsoft.gradle.utils.CompletionUtils.CompletionKinds;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,6 +23,7 @@ import org.apache.bcel.classfile.JavaClass;
 import org.apache.bcel.classfile.Method;
 import org.apache.bcel.generic.ObjectType;
 import org.codehaus.groovy.ast.expr.MethodCallExpression;
+import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionItemTag;
@@ -121,6 +124,11 @@ public class CompletionHandler {
 					property.setTags(Arrays.asList(CompletionItemTag.Deprecated));
 				}
 				property.setKind(CompletionItemKind.Property);
+				List<Object> propertyArguments = new ArrayList<>();
+				propertyArguments.add(CompletionKinds.PROPERTY.toString());
+				propertyArguments.add(propertyName);
+				item.setCommand(new Command(CompletionUtils.completionTitle, CompletionUtils.completionCommand,
+						propertyArguments));
 				if (resultSet.add(propertyName)) {
 					results.add(property);
 				}
@@ -140,6 +148,11 @@ public class CompletionHandler {
 				item.setKind(CompletionItemKind.Function);
 				item.setInsertTextFormat(InsertTextFormat.Snippet);
 				item.setInsertText(insertBuilder.toString());
+				List<Object> arguments = new ArrayList<>();
+				arguments.add(CompletionKinds.METHOD_CALL.toString());
+				arguments.add(plugin);
+				item.setCommand(
+						new Command(CompletionUtils.completionTitle, CompletionUtils.completionCommand, arguments));
 				results.add(item);
 			}
 		}
@@ -164,6 +177,10 @@ public class CompletionHandler {
 			insertTextBuilder.append(closure.name);
 			insertTextBuilder.append(" {$0}");
 			item.setInsertText(insertTextBuilder.toString());
+			List<Object> arguments = new ArrayList<>();
+			arguments.add(CompletionKinds.METHOD_CALL.toString());
+			arguments.add(closure.name);
+			item.setCommand(new Command(CompletionUtils.completionTitle, CompletionUtils.completionCommand, arguments));
 			if (resultSet.add(item.getLabel())) {
 				results.add(item);
 			}
@@ -193,6 +210,11 @@ public class CompletionHandler {
 					if (field.deprecated) {
 						property.setTags(Arrays.asList(CompletionItemTag.Deprecated));
 					}
+					List<Object> arguments = new ArrayList<>();
+					arguments.add(CompletionKinds.PROPERTY.toString());
+					arguments.add(field.name);
+					property.setCommand(
+							new Command(CompletionUtils.completionTitle, CompletionUtils.completionCommand, arguments));
 					if (resultSet.add(field.name)) {
 						results.add(property);
 					}
@@ -237,6 +259,10 @@ public class CompletionHandler {
 			builder.append("($0)");
 		}
 		item.setInsertText(builder.toString());
+		List<Object> itemArguments = new ArrayList<>();
+		itemArguments.add(CompletionKinds.METHOD_CALL.toString());
+		itemArguments.add(name);
+		item.setCommand(new Command(CompletionUtils.completionTitle, CompletionUtils.completionCommand, itemArguments));
 		return item;
 	}
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/utils/CompletionUtils.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/utils/CompletionUtils.java
@@ -18,8 +18,24 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class CompletionUtils {
 
-	public static String completionCommand = "editor.action.triggerSuggest";
+	public static String completionCommand = "gradle.triggerCompletion";
 	public static String completionTitle = "completion";
+
+	public enum CompletionKinds {
+		DEPENDENCY_GROUP("dependency_group"), DEPENDENCY_ARTIFACT("dependency_artifact"), DEPENDENCY_VERSION(
+				"dependency_version"), METHOD_CALL("method_call"), PROPERTY("property");
+
+		private final String text;
+
+		CompletionKinds(final String text) {
+			this.text = text;
+		}
+
+		@Override
+		public String toString() {
+			return text;
+		}
+	}
 
 	public static List<CompletionItem> getGroupIdCompletions(String text, Range range, Collection<String> keys,
 			String sequence) {
@@ -34,7 +50,10 @@ public class CompletionUtils {
 			completionItem.setKind(CompletionItemKind.Module);
 			completionItem.setDetail("GroupID: " + groupId);
 			completionItem.setSortText(sequence + String.format("%08d", i));
-			completionItem.setCommand(new Command(completionTitle, completionCommand));
+			List<Object> arguments = new ArrayList<>();
+			arguments.add(CompletionKinds.DEPENDENCY_GROUP.toString());
+			arguments.add(groupId);
+			completionItem.setCommand(new Command(completionTitle, completionCommand, arguments));
 			items.add(completionItem);
 		}
 		return items;
@@ -56,7 +75,10 @@ public class CompletionUtils {
 			completionItem.setKind(CompletionItemKind.Module);
 			completionItem.setDetail("ArtifactID: " + artifactId);
 			completionItem.setSortText(sequence + String.format("%08d", i));
-			completionItem.setCommand(new Command(completionTitle, completionCommand));
+			List<Object> arguments = new ArrayList<>();
+			arguments.add(CompletionKinds.DEPENDENCY_ARTIFACT.toString());
+			arguments.add(groupId + ":" + artifactId);
+			completionItem.setCommand(new Command(completionTitle, completionCommand, arguments));
 			items.add(completionItem);
 		}
 		return items;

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/utils/CompletionUtils.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/utils/CompletionUtils.java
@@ -18,7 +18,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class CompletionUtils {
 
-	public static String completionCommand = "gradle.triggerCompletion";
+	public static String completionCommand = "gradle.completion";
 	public static String completionTitle = "completion";
 
 	public enum CompletionKinds {


### PR DESCRIPTION
fix #1120 

add following telemetry:

- `gradle.buildFileChanged`: when change a build file
- `gradle.buildFileOpened`: when open a build file (semantic highlighting and document symbol are related)
- `gradle.propertiesFileChanged`: when change a `gradle.properties` file
- `gradle.completion`: record an auto completion operation.
  - will send an info during this operation, recording completionKind and completionContent.