### PR TITLE
chore: Hide restart button and cancel button when parallel run

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -581,12 +581,12 @@
         },
         {
           "command": "gradle.restartTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^runningTask.*$|^runningDebugTask.*$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^runningTask.*$|^runningDebugTask.*$/ && !allowParallelRun",
           "group": "inline@4"
         },
         {
           "command": "gradle.cancelTreeItemTask",
-          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^runningTask.*$|^runningDebugTask.*$/",
+          "when": "view =~ /^gradleTasksView$|^pinnedTasksView$|^recentTasksView$/ && viewItem =~ /^runningTask.*$|^runningDebugTask.*$/ && !allowParallelRun",
           "group": "inline@5"
         },
         {


### PR DESCRIPTION
Since we allow run a task multiple times when `gradle.allowParallelRun` is true. It makes no sense to show these two buttons (since we will have multiple tasks to restart and cancel)

![image](https://user-images.githubusercontent.com/45906942/146880824-b5221ad7-48e0-4295-90c0-e7ee360561d5.png)
