### PR TITLE
fix: `gradle.allowParallelRun` will override `gradle.reuseTerminals`

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ This extension contributes the following settings:
 - `gradle.javaDebug`: Debug JavaExec tasks (see below for usage)
 - `gradle.debug`: Show extra debug info in the output panel (boolean)
 - `gradle.disableConfirmations`: Disable the warning confirm messages when performing batch actions (eg clear tasks, stop daemons etc) (boolean)
-- `gradle.allowParallelRun`: Allow to run tasks in parallel, each running will create a new terminal. This configuration takes effect only when `gradle.reuseTerminals` is set to `off`
+- `gradle.allowParallelRun`: Allow to run tasks in parallel, each running will create a new terminal. This configuration will override `gradle.reuseTerminals` and always create new task terminals when running or debugging a task.
 
 ## Gradle & Java Settings
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -695,7 +695,7 @@
           ],
           "default": "task",
           "scope": "window",
-          "description": "Reuse task terminals behaviour"
+          "markdownDescription": "Reuse task terminals behaviour, will be overridden to `off` if `gradle.allowParallelRun` is true."
         },
         "gradle.debug": {
           "type": "boolean",
@@ -760,7 +760,7 @@
           "type": "boolean",
           "default": false,
           "scope": "window",
-          "markdownDescription": "Allow to run tasks in parallel, each running will create a new terminal. This configuration takes effect only when `gradle.reuseTerminals` is set to `off`."
+          "markdownDescription": "Allow to run tasks in parallel, each running will create a new terminal. This configuration will override `gradle.reuseTerminals` and always create new task terminals when running or debugging a task."
         }
       }
     },

--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -24,7 +24,7 @@ import {
     getConfigIsAutoDetectionEnabled,
     getConfigReuseTerminals,
     getConfigJavaDebug,
-    isAllowedParallelRun,
+    getAllowParallelRun,
 } from "../util/config";
 
 const cancellingTasks: Map<string, vscode.Task> = new Map();
@@ -131,7 +131,7 @@ export function createTaskFromDefinition(
     client: GradleClient,
     useUniqueId = false
 ): vscode.Task {
-    if (isAllowedParallelRun() && useUniqueId) {
+    if (getAllowParallelRun() && useUniqueId) {
         // use a random id to distinguish tasks
         definition.id = definition.id + Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
     }
@@ -298,7 +298,7 @@ export async function runTask(
     debug = false
 ): Promise<void> {
     const isRunning = isTaskRunning(task, args);
-    if (!isAllowedParallelRun() && isRunning) {
+    if (!getAllowParallelRun() && isRunning) {
         logger.warn("Unable to run task, task is already running:", task.name);
         return;
     }
@@ -325,7 +325,7 @@ export async function runTask(
         }
     }
     try {
-        if (debug || args || isAllowedParallelRun()) {
+        if (debug || args || getAllowParallelRun()) {
             const clonedTask = cloneTask(rootProjectsStore, task, args, client, debug, isRunning);
             await vscode.tasks.executeTask(clonedTask);
         } else {

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -51,6 +51,9 @@ export function getConfigIsDebugEnabled(): boolean {
 export type ReuseTerminalsValue = "task" | "off" | "all";
 
 export function getConfigReuseTerminals(): ReuseTerminalsValue {
+    if (getAllowParallelRun()) {
+        return "off";
+    }
     return vscode.workspace.getConfiguration("gradle").get<ReuseTerminalsValue>("reuseTerminals", "task");
 }
 
@@ -87,10 +90,6 @@ export function getConfigJavaDebug(workspaceFolder: vscode.WorkspaceFolder): Jav
         clean: true,
     };
     return vscode.workspace.getConfiguration("gradle", workspaceFolder.uri).get<JavaDebug>("javaDebug", defaultValue);
-}
-
-export function isAllowedParallelRun(): boolean {
-    return getAllowParallelRun() && getConfigReuseTerminals() === "off";
 }
 
 export function getAllowParallelRun(): boolean {


### PR DESCRIPTION
to provide better user experience:

if `gradle.allowParallelRun` is set to true, the reuse terminal strategy will not be affected by `gradle.reuseTerminals`, the extension will always create a new terminal to run a task.
if `gradle.allowParallelRun` is set to false(default value), keep the current behavior.