### PR TITLE
fix: Remove vscode-java-debug activation check

### DIFF
--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -10,7 +10,6 @@ import {
     getJavaDebuggerExtension,
     JAVA_LANGUAGE_EXTENSION_ID,
     JAVA_DEBUGGER_EXTENSION_ID,
-    isJavaDebuggerExtensionActivated,
     isJavaLanguageSupportExtensionActivated,
 } from "../util/compat";
 import { getTaskArgs } from "../util/input";
@@ -315,9 +314,6 @@ export async function runTask(
                     JAVA_DEBUGGER_EXTENSION_ID,
                 ]);
             }
-            return;
-        } else if (!isJavaDebuggerExtensionActivated()) {
-            await vscode.window.showErrorMessage("The Java Debugger extension is not activated.");
             return;
         } else if (!isJavaLanguageSupportExtensionActivated()) {
             await vscode.window.showErrorMessage("The Java Language Support extension is not activated.");

--- a/extension/src/util/compat.ts
+++ b/extension/src/util/compat.ts
@@ -8,11 +8,6 @@ export function isJavaLanguageSupportExtensionActivated(): boolean {
     return javaExt?.isActive || false;
 }
 
-export function isJavaDebuggerExtensionActivated(): boolean {
-    const javaExt: vscode.Extension<unknown> | undefined = getJavaDebuggerExtension();
-    return javaExt?.isActive || false;
-}
-
 export function getJavaLanguageSupportExtension(): vscode.Extension<unknown> | undefined {
     return vscode.extensions.getExtension(JAVA_LANGUAGE_EXTENSION_ID);
 }


### PR DESCRIPTION
fix #1130 

Since `vscode-java-debug` register debug config type `Java` statically, we don't need to check the activation before calling `vscode.debug.startDebugging()`
![debug](https://user-images.githubusercontent.com/45906942/147210422-17f0f1db-8605-4014-a3fd-cd5580e550a1.gif)

