### PR TITLE
fix: Reset total steps when select project type

### DIFF
--- a/extension/src/createProject/SelectProjectTypeStep.ts
+++ b/extension/src/createProject/SelectProjectTypeStep.ts
@@ -25,9 +25,11 @@ export class SelectProjectTypeStep implements IProjectCreationStep {
                         switch (selectedType.label) {
                             case "application":
                                 metadata.projectType = ProjectType.JAVA_APPLICATION;
+                                metadata.totalSteps = 5;
                                 break;
                             case "library":
                                 metadata.projectType = ProjectType.JAVA_LIBRARY;
+                                metadata.totalSteps = 5;
                                 break;
                             case "Gradle plugin":
                                 metadata.projectType = ProjectType.JAVA_GRADLE_PLUGIN;


### PR DESCRIPTION
![regression](https://user-images.githubusercontent.com/45906942/150717502-79985b51-2981-4da1-ab7c-6d1a25dda692.png)

Now when we just select to create a plugin and use back button to select an application or library again, the quickpick label will show wrong steps. 