### PR TITLE
chore: retire compatibility check when `redhat.java` > 1.3.0

### DIFF
--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -106,5 +106,12 @@ export function getGradleConfig(): GradleConfig {
         gradleConfig.setVersion(gradleVersion);
     }
     gradleConfig.setWrapperEnabled(getConfigJavaImportGradleWrapperEnabled());
+    const javaExtension = vscode.extensions.getExtension("redhat.java");
+    if (javaExtension) {
+        const version = javaExtension.packageJSON.version;
+        if (version) {
+            gradleConfig.setJavaExtensionVersion(version);
+        }
+    }
     return gradleConfig;
 }

--- a/proto/gradle.proto
+++ b/proto/gradle.proto
@@ -174,6 +174,7 @@ message GradleConfig {
   string jvm_arguments = 3;
   bool wrapper_enabled = 4;
   string version = 5;
+  string java_extension_version = 6;
 }
 
 message GradleBuild { GradleProject project = 1; }


### PR DESCRIPTION
follow #1137 