### PR TITLE
feat: Run task when double clicking tasks

### DIFF
--- a/extension/src/commands/Commands.ts
+++ b/extension/src/commands/Commands.ts
@@ -37,8 +37,6 @@ import {
     OpenSettingsCommand,
     COMMAND_OPEN_BUILD_FILE,
     OpenBuildFileCommand,
-    COMMAND_OPEN_BUILD_FILE_DOUBLE_CLICK,
-    OpenBuildFileDoubleClickCommand,
     COMMAND_CANCELLING_TREE_ITEM_TASK,
     CancellingTreeItemTaskCommand,
     COMMAND_SHOW_LOGS,
@@ -65,6 +63,8 @@ import {
     FindTaskCommand,
     UnpinTaskCommand,
     COMMAND_UNPIN_TASK,
+    COMMAND_RUN_TASK_DOUBLE_CLICK,
+    RunTaskDoubleClickCommand,
 } from ".";
 import { GradleClient } from "../client";
 import { GradleBuildContentProvider } from "../client/GradleBuildContentProvider";
@@ -111,6 +111,10 @@ export class Commands {
     register(): void {
         this.registerCommand(COMMAND_SHOW_TASKS, new ShowTasksCommand(this.gradleTasksTreeView));
         this.registerCommand(COMMAND_RUN_TASK, new RunTaskCommand(this.rootProjectsStore, this.client));
+        this.registerCommand(
+            COMMAND_RUN_TASK_DOUBLE_CLICK,
+            new RunTaskDoubleClickCommand(this.rootProjectsStore, this.client)
+        );
         this.registerCommand(COMMAND_DEBUG_TASK, new DebugTaskCommand(this.rootProjectsStore, this.client));
         this.registerCommand(COMMAND_RESTART_TASK, new RestartTaskCommand(this.client));
         this.registerCommand(
@@ -148,7 +152,6 @@ export class Commands {
         this.registerCommand(COMMAND_OPEN_SETTINGS, new OpenSettingsCommand());
         this.registerCommand(COMMAND_OPEN_BUILD_FILE, new OpenBuildFileCommand());
 
-        this.registerCommand(COMMAND_OPEN_BUILD_FILE_DOUBLE_CLICK, new OpenBuildFileDoubleClickCommand());
         this.registerCommand(COMMAND_CANCELLING_TREE_ITEM_TASK, new CancellingTreeItemTaskCommand());
         this.registerCommand(COMMAND_SHOW_LOGS, new ShowLogsCommand());
         this.registerCommand(

--- a/extension/src/commands/OpenBuildFileCommand.ts
+++ b/extension/src/commands/OpenBuildFileCommand.ts
@@ -3,30 +3,9 @@ import { GradleTaskTreeItem } from "../views";
 import { Command } from "./Command";
 
 export const COMMAND_OPEN_BUILD_FILE = "gradle.openBuildFile";
-export const COMMAND_OPEN_BUILD_FILE_DOUBLE_CLICK = "gradle.openBuildFileDoubleClick";
-
-let lastOpenedDate: Date;
-
-function checkDoubleClick(): boolean {
-    let result = false;
-    if (lastOpenedDate) {
-        const dateDiff = new Date().getTime() - lastOpenedDate.getTime();
-        result = dateDiff < 500;
-    }
-    lastOpenedDate = new Date();
-    return result;
-}
 
 async function run(taskItem: GradleTaskTreeItem): Promise<void> {
     await vscode.commands.executeCommand("vscode.open", vscode.Uri.file(taskItem.task.definition.buildFile));
-}
-
-export class OpenBuildFileDoubleClickCommand extends Command {
-    async run(taskItem: GradleTaskTreeItem): Promise<void> {
-        if (checkDoubleClick()) {
-            return run(taskItem);
-        }
-    }
 }
 
 export class OpenBuildFileCommand extends Command {

--- a/extension/src/commands/RunTaskCommand.ts
+++ b/extension/src/commands/RunTaskCommand.ts
@@ -3,16 +3,38 @@ import { runTask } from "../tasks/taskUtil";
 import { Command } from "./Command";
 import { RootProjectsStore } from "../stores";
 import { GradleClient } from "../client";
+import { DoubleClickChecker } from "../util/DoubleClickChecker";
 
 export const COMMAND_RUN_TASK = "gradle.runTask";
+export const COMMAND_RUN_TASK_DOUBLE_CLICK = "gradle.runTaskDoubleClick";
+
+async function run(treeItem: GradleTaskTreeItem, rootProjectsStore: RootProjectsStore, client: GradleClient) {
+    if (treeItem && treeItem.task) {
+        await runTask(rootProjectsStore, treeItem.task, client);
+    }
+}
 
 export class RunTaskCommand extends Command {
     constructor(private rootProjectsStore: RootProjectsStore, private client: GradleClient) {
         super();
     }
+
     async run(treeItem: GradleTaskTreeItem): Promise<void> {
-        if (treeItem && treeItem.task) {
-            await runTask(this.rootProjectsStore, treeItem.task, this.client);
+        run(treeItem, this.rootProjectsStore, this.client);
+    }
+}
+
+export class RunTaskDoubleClickCommand extends Command {
+    private doubleClickChecker: DoubleClickChecker;
+
+    constructor(private rootProjectsStore: RootProjectsStore, private client: GradleClient) {
+        super();
+        this.doubleClickChecker = new DoubleClickChecker();
+    }
+
+    async run(treeItem: GradleTaskTreeItem): Promise<void> {
+        if (this.doubleClickChecker.checkDoubleClick(treeItem)) {
+            return run(treeItem, this.rootProjectsStore, this.client);
         }
     }
 }

--- a/extension/src/util/DoubleClickChecker.ts
+++ b/extension/src/util/DoubleClickChecker.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+
+export class DoubleClickChecker {
+    private lastDate: Date | undefined;
+    private lastItem: vscode.TreeItem | undefined;
+
+    private resetState(): void {
+        this.lastDate = undefined;
+        this.lastItem = undefined;
+    }
+
+    private setState(item: vscode.TreeItem): void {
+        this.lastDate = new Date();
+        this.lastItem = item;
+    }
+
+    public checkDoubleClick(item: vscode.TreeItem): boolean {
+        if (this.lastDate && new Date().getTime() - this.lastDate.getTime() < 500 && this.lastItem === item) {
+            this.resetState();
+            return true;
+        }
+        this.setState(item);
+        return false;
+    }
+}

--- a/extension/src/views/gradleTasks/GradleTaskTreeItem.ts
+++ b/extension/src/views/gradleTasks/GradleTaskTreeItem.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { COMMAND_RUN_TASK_DOUBLE_CLICK } from "../../commands";
 import { Icons } from "../../icons";
 import { TASK_STATE_RUNNING_REGEX } from "../constants";
 import { getTreeItemState } from "../viewUtil";
@@ -16,7 +17,7 @@ export class GradleTaskTreeItem extends vscode.TreeItem {
         super(label, vscode.TreeItemCollapsibleState.None);
         this.command = {
             title: "Run Task",
-            command: "gradle.openBuildFileDoubleClick",
+            command: COMMAND_RUN_TASK_DOUBLE_CLICK,
             arguments: [this],
         };
     }


### PR DESCRIPTION
fix #1124 

previously: double click task will open the corresponding build file
current: double click task will run this task
![clicktask](https://user-images.githubusercontent.com/45906942/153322476-e5671eed-ac0e-40ce-ac29-ed5276cd67a1.gif)

