### PR TITLE
Allow external usage of gradle-language-server

### DIFF
--- a/gradle-language-server/build.gradle
+++ b/gradle-language-server/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id "java"
+  id "application"
 }
 
 java {
@@ -9,6 +10,11 @@ java {
 
 repositories  {
   mavenCentral()
+}
+
+application {
+  applicationName = "gradle-language-server"
+  mainClass = "com.microsoft.gradle.GradleLanguageServer"
 }
 
 dependencies {


### PR DESCRIPTION
By adding the application plugin for Gradle, we can generate a bin script that will allow the usage of gradle-language-server outside of vscode

In particular, I have this working locally with neovim and https://github.com/neovim/nvim-lspconfig, which I intend to upstream support for