### PR TITLE
chore: Add pre-release flag to pipeline

### DIFF
--- a/.azure-pipelines/vscode-gradle-nightly.yml
+++ b/.azure-pipelines/vscode-gradle-nightly.yml
@@ -95,7 +95,7 @@ steps:
     path: $(Build.SourcesDirectory)/extension
 - bash: |
     cd $(Build.SourcesDirectory)/extension
-    npx vsce@latest package
+    npx vsce@latest package --pre-release
   displayName: Package VSIX
 - task: CopyFiles@2
   displayName: Copy VSIX


### PR DESCRIPTION
see the reference: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions

> Alternatively, the pre-release flag can also be passed in the package step.

compared to add `--pre-release` argument during publishing, adding it during packaging in this yml file is more promising. And I just check the output bit, the `.vsixmanifest` has an attribute 

> Property Id="Microsoft.VisualStudio.Code.PreRelease" Value="true"

to show it's a correct pre-release bit.