### PR TITLE
fix: Run debuggable tasks always start debugging it

### DIFF
--- a/extension/src/tasks/GradleTaskDefinition.ts
+++ b/extension/src/tasks/GradleTaskDefinition.ts
@@ -10,7 +10,10 @@ export interface GradleTaskDefinition extends vscode.TaskDefinition {
     buildFile: string;
     projectFolder: string;
     workspaceFolder: string;
+    // the task can be debugged or not
+    debugEnabled: boolean;
     args: string;
+    // this run session of the task should be debugged or not
     javaDebug: boolean;
     isPinned: boolean;
 }

--- a/extension/src/tasks/GradleTaskDefinition.ts
+++ b/extension/src/tasks/GradleTaskDefinition.ts
@@ -11,7 +11,7 @@ export interface GradleTaskDefinition extends vscode.TaskDefinition {
     projectFolder: string;
     workspaceFolder: string;
     // the task can be debugged or not
-    debugEnabled: boolean;
+    debuggable: boolean;
     args: string;
     // this run session of the task should be debugged or not
     javaDebug: boolean;

--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -234,9 +234,10 @@ function createVSCodeTaskFromGradleTask(
         rootProject: gradleTask.getRootproject(),
         projectFolder: rootProject.getProjectUri().fsPath,
         workspaceFolder: rootProject.getWorkspaceFolder().uri.fsPath,
+        debugEnabled: gradleTask.getDebuggable(),
         args,
-        javaDebug: gradleTask.getDebuggable(),
         isPinned: false,
+        javaDebug: false,
     };
     return createTaskFromDefinition(definition, rootProject, client);
 }
@@ -347,7 +348,7 @@ export function cloneTask(
     const definition: Required<GradleTaskDefinition> = {
         ...(task.definition as GradleTaskDefinition),
         args,
-        javaDebug,
+        javaDebug: javaDebug,
     };
     const rootProject = rootProjectsStore.get(definition.projectFolder);
     return createTaskFromDefinition(definition, rootProject!, client, useUniqueId);

--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -234,7 +234,7 @@ function createVSCodeTaskFromGradleTask(
         rootProject: gradleTask.getRootproject(),
         projectFolder: rootProject.getProjectUri().fsPath,
         workspaceFolder: rootProject.getWorkspaceFolder().uri.fsPath,
-        debugEnabled: gradleTask.getDebuggable(),
+        debuggable: gradleTask.getDebuggable(),
         args,
         isPinned: false,
         javaDebug: false,

--- a/extension/src/test/testUtil.ts
+++ b/extension/src/test/testUtil.ts
@@ -164,7 +164,7 @@ export function buildMockTaskDefinition(
         rootProject: project,
         projectFolder: workspaceFolder.uri.fsPath,
         workspaceFolder: workspaceFolder.uri.fsPath,
-        debugEnabled: false,
+        debuggable: false,
         args,
         javaDebug: false,
         isPinned: false,

--- a/extension/src/test/testUtil.ts
+++ b/extension/src/test/testUtil.ts
@@ -164,6 +164,7 @@ export function buildMockTaskDefinition(
         rootProject: project,
         projectFolder: workspaceFolder.uri.fsPath,
         workspaceFolder: workspaceFolder.uri.fsPath,
+        debugEnabled: false,
         args,
         javaDebug: false,
         isPinned: false,

--- a/extension/src/views/defaultProject/DefaultProjectProvider.ts
+++ b/extension/src/views/defaultProject/DefaultProjectProvider.ts
@@ -76,7 +76,7 @@ export class DefaultProjectProvider {
             rootProject: projectName,
             projectFolder: rootProject.getProjectUri().fsPath,
             workspaceFolder: rootProject.getWorkspaceFolder().uri.fsPath,
-            debugEnabled: false,
+            debuggable: false,
             args: "",
             javaDebug: false,
             isPinned: false,

--- a/extension/src/views/defaultProject/DefaultProjectProvider.ts
+++ b/extension/src/views/defaultProject/DefaultProjectProvider.ts
@@ -76,6 +76,7 @@ export class DefaultProjectProvider {
             rootProject: projectName,
             projectFolder: rootProject.getProjectUri().fsPath,
             workspaceFolder: rootProject.getWorkspaceFolder().uri.fsPath,
+            debugEnabled: false,
             args: "",
             javaDebug: false,
             isPinned: false,

--- a/extension/src/views/gradleTasks/GradleTaskTreeItem.ts
+++ b/extension/src/views/gradleTasks/GradleTaskTreeItem.ts
@@ -12,7 +12,7 @@ export class GradleTaskTreeItem extends vscode.TreeItem {
         public tooltip: string,
         public description: string,
         protected readonly icons: Icons,
-        protected readonly javaDebug: boolean
+        protected readonly debugEnabled: boolean
     ) {
         super(label, vscode.TreeItemCollapsibleState.None);
         this.command = {

--- a/extension/src/views/gradleTasks/GradleTaskTreeItem.ts
+++ b/extension/src/views/gradleTasks/GradleTaskTreeItem.ts
@@ -12,7 +12,7 @@ export class GradleTaskTreeItem extends vscode.TreeItem {
         public tooltip: string,
         public description: string,
         protected readonly icons: Icons,
-        protected readonly debugEnabled: boolean
+        protected readonly debuggable: boolean
     ) {
         super(label, vscode.TreeItemCollapsibleState.None);
         this.command = {

--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -253,7 +253,7 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
                     definition.description || taskName,
                     "",
                     icons,
-                    definition.javaDebug
+                    definition.debugEnabled
                 );
                 taskTreeItem.setContext();
 

--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -253,7 +253,7 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
                     definition.description || taskName,
                     "",
                     icons,
-                    definition.debugEnabled
+                    definition.debuggable
                 );
                 taskTreeItem.setContext();
 

--- a/extension/src/views/recentTasks/RecentTaskTreeItem.ts
+++ b/extension/src/views/recentTasks/RecentTaskTreeItem.ts
@@ -17,10 +17,10 @@ export class RecentTaskTreeItem extends GradleTaskTreeItem {
         description: string,
         icons: Icons,
         private readonly taskTerminalsStore: TaskTerminalsStore,
-        protected readonly debugEnabled: boolean
+        protected readonly debuggable: boolean
     ) {
         // On construction, don't set a description, this will be set in setContext
-        super(parentTreeItem, task, label, description || label, "", icons, debugEnabled);
+        super(parentTreeItem, task, label, description || label, "", icons, debuggable);
     }
 
     public setContext(): void {

--- a/extension/src/views/recentTasks/RecentTaskTreeItem.ts
+++ b/extension/src/views/recentTasks/RecentTaskTreeItem.ts
@@ -17,10 +17,10 @@ export class RecentTaskTreeItem extends GradleTaskTreeItem {
         description: string,
         icons: Icons,
         private readonly taskTerminalsStore: TaskTerminalsStore,
-        protected readonly javaDebug: boolean
+        protected readonly debugEnabled: boolean
     ) {
         // On construction, don't set a description, this will be set in setContext
-        super(parentTreeItem, task, label, description || label, "", icons, javaDebug);
+        super(parentTreeItem, task, label, description || label, "", icons, debugEnabled);
     }
 
     public setContext(): void {

--- a/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
+++ b/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
@@ -33,7 +33,7 @@ function buildTaskTreeItem(
         definition.description || taskName, // used for tooltip
         icons,
         taskTerminalsStore,
-        definition.javaDebug
+        definition.debugEnabled
     );
     recentTaskTreeItem.setContext();
     return recentTaskTreeItem;
@@ -148,7 +148,13 @@ export class RecentTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
             const taskArgs = recentTasks.get(taskId) || "";
             if (taskArgs) {
                 Array.from(taskArgs.values()).forEach((args: TaskArgs) => {
-                    const recentTask = cloneTask(this.rootProjectsStore, task, args, this.client, definition.javaDebug);
+                    const recentTask = cloneTask(
+                        this.rootProjectsStore,
+                        task,
+                        args,
+                        this.client,
+                        definition.debugEnabled
+                    );
                     buildGradleProjectTreeItem(recentTask, this.taskTerminalsStore, this.icons);
                 });
             }

--- a/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
+++ b/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
@@ -33,7 +33,7 @@ function buildTaskTreeItem(
         definition.description || taskName, // used for tooltip
         icons,
         taskTerminalsStore,
-        definition.debugEnabled
+        definition.debuggable
     );
     recentTaskTreeItem.setContext();
     return recentTaskTreeItem;
@@ -153,7 +153,7 @@ export class RecentTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
                         task,
                         args,
                         this.client,
-                        definition.debugEnabled
+                        definition.debuggable
                     );
                     buildGradleProjectTreeItem(recentTask, this.taskTerminalsStore, this.icons);
                 });

--- a/extension/src/views/viewUtil.ts
+++ b/extension/src/views/viewUtil.ts
@@ -114,7 +114,7 @@ export async function focusProjectInGradleTasksTree(
 function getTreeItemRunningState(task: vscode.Task, args?: TaskArgs): string {
     let state = "";
     const definition = task.definition as GradleTaskDefinition;
-    const isDebug = definition.javaDebug;
+    const isDebug = definition.debugEnabled;
     if (isTaskCancelling(task, args)) {
         return state + TREE_ITEM_STATE_TASK_CANCELLING;
     }

--- a/extension/src/views/viewUtil.ts
+++ b/extension/src/views/viewUtil.ts
@@ -114,7 +114,7 @@ export async function focusProjectInGradleTasksTree(
 function getTreeItemRunningState(task: vscode.Task, args?: TaskArgs): string {
     let state = "";
     const definition = task.definition as GradleTaskDefinition;
-    const isDebug = definition.debugEnabled;
+    const isDebug = definition.debuggable;
     if (isTaskCancelling(task, args)) {
         return state + TREE_ITEM_STATE_TASK_CANCELLING;
     }


### PR DESCRIPTION
fix #1181 

create a new property ~`debugEnabled`~ `debuggable` in `GradleTaskDefinition`:

~`debugEnabled`~ `debuggable`: indicates the task can be debugged or not
`javaDebug`: indicates this run session of the task should be debugged or not