### PR TITLE
fix: Task selectors should execute script in root project

### DIFF
--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -116,7 +116,7 @@ export function buildTaskId(projectFolder: string, script: string, project: stri
 
 export function buildTaskName(definition: GradleTaskDefinition): string {
     const argsLabel = definition.args ? ` ${definition.args}` : "";
-    return `${definition.project}${definition.script}${argsLabel}`;
+    return `${definition.script}${argsLabel}`;
 }
 
 export function createTaskFromDefinition(

--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -116,7 +116,7 @@ export function buildTaskId(projectFolder: string, script: string, project: stri
 
 export function buildTaskName(definition: GradleTaskDefinition): string {
     const argsLabel = definition.args ? ` ${definition.args}` : "";
-    return `${definition.script}${argsLabel}`;
+    return `${definition.project}${definition.script}${argsLabel}`;
 }
 
 export function createTaskFromDefinition(

--- a/gradle-plugin/src/main/java/com/microsoft/gradle/GradleProjectModelBuilder.java
+++ b/gradle-plugin/src/main/java/com/microsoft/gradle/GradleProjectModelBuilder.java
@@ -58,9 +58,15 @@ public class GradleProjectModelBuilder implements ToolingModelBuilder {
 		for (GradleTask task : cachedTasks) {
 			if (!taskNames.contains(task.getName())) {
 				taskNames.add(task.getName());
-				GradleTask newTask = new DefaultGradleTask(task.getName(), task.getGroup(), task.getPath(),
-						project.getName(), project.getBuildscript().getSourceFile().getAbsolutePath(),
-						task.getRootProject(), task.getDescription(), task.getDebuggable());
+				String path = task.getPath();
+				int index = path.lastIndexOf(":");
+				if (index > -1) {
+					// use task selector to run a task for all subprojects
+					path = path.substring(index);
+				}
+				GradleTask newTask = new DefaultGradleTask(task.getName(), task.getGroup(), path, project.getName(),
+						project.getBuildscript().getSourceFile().getAbsolutePath(), task.getRootProject(),
+						task.getDescription(), task.getDebuggable());
 				rootModel.getTasks().add(newTask);
 			}
 		}


### PR DESCRIPTION
fix #1185, more information can be found in that issue.

Now the current implementation uses just the first found script as the task selector's script, which would result in some error when multiple projects have a same task. So, I think a better way to solve this issue is to re-generate tasks in the root project, here to make this pr draft for future implementation.

---

The solution here would be fix the path of task selectors with just the script itself. for example, for task selectors, all tasks with path:
`:a:build` should be `:build`.