### PR TITLE
fix: GradleServer won't exit when the extension exits

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -221,7 +221,6 @@ export class Extension {
     private storeSubscriptions(): void {
         this.context.subscriptions.push(
             this.client,
-            this.server,
             this.pinnedTasksStore,
             this.recentTasksStore,
             this.taskTerminalsStore,
@@ -236,6 +235,10 @@ export class Extension {
             this.recentTasksTreeView,
             this.defaultProjectsTreeView
         );
+    }
+
+    public async deactivate() {
+        await this.server.asyncDispose();
     }
 
     private async activate(): Promise<void> {

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -237,7 +237,7 @@ export class Extension {
         );
     }
 
-    public async deactivate() {
+    public async stop() {
         await this.server.asyncDispose();
     }
 

--- a/extension/src/index.ts
+++ b/extension/src/index.ts
@@ -28,5 +28,5 @@ function initializeTelemetry(): void {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export async function deactivate(): Promise<void> {
-    await extension?.deactivate();
+    await extension?.stop();
 }

--- a/extension/src/index.ts
+++ b/extension/src/index.ts
@@ -28,5 +28,5 @@ function initializeTelemetry(): void {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export async function deactivate(): Promise<void> {
-    await extension.deactivate();
+    await extension?.deactivate();
 }

--- a/extension/src/index.ts
+++ b/extension/src/index.ts
@@ -4,13 +4,16 @@ import { initialize, instrumentOperation } from "vscode-extension-telemetry-wrap
 import { Api } from "./api";
 import { Extension } from "./Extension";
 
+let extension: Extension;
+
 export async function activate(context: vscode.ExtensionContext): Promise<Api> {
     initializeTelemetry();
     return instrumentOperation("activation", activateExtension)(context);
 }
 
 function activateExtension(_operationId: string, context: vscode.ExtensionContext): Api {
-    return new Extension(context).getApi();
+    extension = new Extension(context);
+    return extension.getApi();
 }
 
 function initializeTelemetry(): void {
@@ -24,4 +27,6 @@ function initializeTelemetry(): void {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-export function deactivate(): void {}
+export async function deactivate(): Promise<void> {
+    await extension.deactivate();
+}

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -14,7 +14,7 @@ export interface ServerOptions {
     host: string;
 }
 
-export class GradleServer implements vscode.Disposable {
+export class GradleServer {
     private readonly _onDidStart: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private readonly _onDidStop: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private ready = false;
@@ -108,9 +108,11 @@ export class GradleServer implements vscode.Disposable {
         }
     };
 
-    private killProcess(): void {
+    private async killProcess(): Promise<void> {
         if (this.process) {
-            kill(this.process.pid, "SIGTERM");
+            return new Promise((resolve, _reject) => {
+                kill(this.process!.pid, () => resolve);
+            });
         }
     }
 
@@ -123,14 +125,10 @@ export class GradleServer implements vscode.Disposable {
         this._onDidStart.fire(null);
     }
 
-    public stop(): void {
+    public async asyncDispose(): Promise<void> {
         this.process?.removeAllListeners();
-        this.killProcess();
+        await this.killProcess();
         this.ready = false;
-    }
-
-    public dispose(): void {
-        this.stop();
         this._onDidStart.dispose();
         this._onDidStop.dispose();
     }


### PR DESCRIPTION
fix #1184 

the current dispose mechanism in vscode for extension is synchronous, making it hard to finish the disposing process, see https://github.com/microsoft/vscode/issues/140697#issuecomment-1017559485. An alternative way is to put the process into async `deactivate` function.