### PR TITLE
Prevent NPE if client doesn't provide gradleWrapperEnabled setting

### DIFF
--- a/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
@@ -73,8 +73,8 @@ public class GradleLibraryResolver {
 		this.gradleVersion = gradleVersion;
 	}
 
-	public void setGradleWrapperEnabled(boolean gradleWrapperEnabled) {
-		this.gradleWrapperEnabled = gradleWrapperEnabled;
+	public void setGradleWrapperEnabled(Boolean gradleWrapperEnabled) {
+		this.gradleWrapperEnabled = gradleWrapperEnabled == null ? true : gradleWrapperEnabled;
 	}
 
 	public void setGradleUserHomePath(String gradleUserHome) {


### PR DESCRIPTION
Implicit boxing from `Boolean` to `boolean` caused a NPE in:

https://github.com/microsoft/vscode-gradle/blob/31c2ba0dc64e60c36db143259603d7761e3197ca/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java#L165-L166

If the `settings` map doesn't contain the `gradleWrapperEnabled`
property. The vscode extension always sets the property to true, but
other language server clients may not set a default value.
