### PR TITLE
fix: Roll back onDidConnect hook

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -196,6 +196,7 @@ export class Extension {
             )
         );
 
+        this.client.onDidConnect(() => this.refresh());
         void this.activate();
         void startLanguageServer(this.context, this.gradleBuildContentProvider, this.rootProjectsStore);
         void vscode.commands.executeCommand("setContext", "allowParallelRun", getAllowParallelRun());


### PR DESCRIPTION
initial comment: https://github.com/microsoft/vscode-gradle/issues/1191#issuecomment-1055085709. We'd better refresh the view after re-connecting to the server.

In https://github.com/microsoft/vscode-gradle/issues/903 we just remove this hook for refreshing after the client connected to the server, for a VS Code upstream bug: https://github.com/microsoft/vscode/issues/129019. Now the bug is fixed, and we can consider to rollback this change to see if the issue in #903 will appear again. This change can be kept in pre-release versions for the feedback of developers and users.