### PR TITLE
fix: Extension generates project with errors

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -39,7 +39,8 @@
     "workspaceContains:settings.gradle",
     "workspaceContains:build.gradle.kts",
     "workspaceContains:settings.gradle.kts",
-    "onCommand:gradle.createProject"
+    "onCommand:gradle.createProject",
+    "onCommand:gradle.createProjectAdvanced"
   ],
   "main": "./dist/index.js",
   "contributes": {

--- a/extension/src/commands/CreateProjectCommand.ts
+++ b/extension/src/commands/CreateProjectCommand.ts
@@ -40,9 +40,10 @@ export class CreateProjectCommand extends Command {
                 projectType: ProjectType.JAVA_APPLICATION,
                 targetFolder: targetFolderUri[0].fsPath,
                 projectName: path.basename(targetFolderUri[0].fsPath),
-                sourcePackageName: path.basename(targetFolderUri[0].fsPath),
+                sourcePackageName: await this.client.getNormalizedPackageName(path.basename(targetFolderUri[0].fsPath)),
                 steps: [],
                 nextStep: isAdvanced ? selectProjectTypeStep : selectScriptDSLStep,
+                client: this.client,
             };
             const success = await this.runSteps(metadata);
             if (success) {

--- a/extension/src/createProject/SpecifySourcePackageNameStep.ts
+++ b/extension/src/createProject/SpecifySourcePackageNameStep.ts
@@ -47,7 +47,7 @@ export class SpecifySourcePackageNameStep implements IProjectCreationStep {
                         resolve(StepResult.NEXT);
                     } else {
                         inputBox.enabled = false;
-                        inputBox.validationMessage = `Invalid Source Package Name, suggest Name: ${normalizedName}`;
+                        inputBox.validationMessage = `Invalid source package name, suggest name: ${normalizedName}`;
                     }
                 }),
                 inputBox.onDidHide(() => {

--- a/extension/src/createProject/SpecifySourcePackageNameStep.ts
+++ b/extension/src/createProject/SpecifySourcePackageNameStep.ts
@@ -5,22 +5,29 @@ import * as vscode from "vscode";
 import { IProjectCreationMetadata, IProjectCreationStep, StepResult } from "./types";
 
 export class SpecifySourcePackageNameStep implements IProjectCreationStep {
+    public static GET_NORMALIZED_PACKAGE_NAME = "getNormalizedPackageName";
+
     public async run(metadata: IProjectCreationMetadata): Promise<StepResult> {
+        if (!metadata.client) {
+            return StepResult.STOP;
+        }
         const disposables: vscode.Disposable[] = [];
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const specifySourcePackageNamePromise = new Promise<StepResult>(async (resolve, _reject) => {
             const inputBox = vscode.window.createInputBox();
             const defaultName = metadata.sourcePackageName || "";
+            const normalizedName = await metadata.client.getNormalizedPackageName(defaultName);
+            if (!normalizedName) {
+                return resolve(StepResult.STOP);
+            }
             inputBox.title = `Create Gradle project: Specify package name (${metadata.steps.length + 1}/${
                 metadata.totalSteps
             })`;
             inputBox.prompt = "Input source package name of your project.";
-            inputBox.placeholder = "e.g. " + defaultName;
-            inputBox.value = defaultName;
+            inputBox.placeholder = "e.g. " + normalizedName;
+            inputBox.value = normalizedName;
             inputBox.ignoreFocusOut = true;
-            const validationMessage: string | undefined = this.isValidSourcePackageName(defaultName);
-            inputBox.enabled = validationMessage === undefined;
-            inputBox.validationMessage = validationMessage;
+            inputBox.enabled = true;
             if (metadata.steps.length) {
                 inputBox.buttons = [vscode.QuickInputButtons.Back];
                 disposables.push(
@@ -32,15 +39,16 @@ export class SpecifySourcePackageNameStep implements IProjectCreationStep {
                 );
             }
             disposables.push(
-                inputBox.onDidChangeValue(() => {
-                    const validationMessage: string | undefined = this.isValidSourcePackageName(inputBox.value);
-                    inputBox.enabled = validationMessage === undefined;
-                    inputBox.validationMessage = validationMessage;
-                }),
                 inputBox.onDidAccept(async () => {
-                    metadata.sourcePackageName = inputBox.value;
-                    metadata.nextStep = undefined;
-                    resolve(StepResult.NEXT);
+                    const normalizedName = await metadata.client.getNormalizedPackageName(inputBox.value);
+                    if (normalizedName === inputBox.value) {
+                        metadata.sourcePackageName = inputBox.value;
+                        metadata.nextStep = undefined;
+                        resolve(StepResult.NEXT);
+                    } else {
+                        inputBox.enabled = false;
+                        inputBox.validationMessage = `Invalid Source Package Name, suggest Name: ${normalizedName}`;
+                    }
                 }),
                 inputBox.onDidHide(() => {
                     resolve(StepResult.STOP);
@@ -55,10 +63,6 @@ export class SpecifySourcePackageNameStep implements IProjectCreationStep {
         } finally {
             disposables.forEach((d) => d.dispose());
         }
-    }
-
-    private isValidSourcePackageName(value: string): string | undefined {
-        return /^[a-z_][a-z0-9_]*(\.[a-z_][a-z0-9_]*)*$/.test(value) ? undefined : "Invalid Source Package Name.";
     }
 }
 

--- a/extension/src/createProject/types.ts
+++ b/extension/src/createProject/types.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import { GradleClient } from "../client";
+
 export interface IProjectCreationMetadata {
     isAdvanced: boolean;
     totalSteps: number;
@@ -12,6 +14,7 @@ export interface IProjectCreationMetadata {
     targetFolder: string;
     steps: IProjectCreationStep[];
     nextStep?: IProjectCreationStep;
+    client: GradleClient;
 }
 
 export interface IProjectCreationStep {

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleService.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleService.java
@@ -2,6 +2,7 @@ package com.github.badsyntax.gradle;
 
 import com.github.badsyntax.gradle.handlers.CancelBuildHandler;
 import com.github.badsyntax.gradle.handlers.CancelBuildsHandler;
+import com.github.badsyntax.gradle.handlers.ExecuteCommandHandler;
 import com.github.badsyntax.gradle.handlers.GetBuildHandler;
 import com.github.badsyntax.gradle.handlers.GetDaemonsStatusHandler;
 import com.github.badsyntax.gradle.handlers.RunBuildHandler;
@@ -51,5 +52,11 @@ public class GradleService extends GradleGrpc.GradleImplBase {
 	public void stopDaemon(StopDaemonRequest req, StreamObserver<StopDaemonReply> responseObserver) {
 		StopDaemonHandler stopDaemonHandler = new StopDaemonHandler(req, responseObserver);
 		stopDaemonHandler.run();
+	}
+
+	@Override
+	public void executeCommand(ExecuteCommandRequest req, StreamObserver<ExecuteCommandReply> responseObserver) {
+		ExecuteCommandHandler executeCommandHandler = new ExecuteCommandHandler(req, responseObserver);
+		executeCommandHandler.run();
 	}
 }

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/ExecuteCommandHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/ExecuteCommandHandler.java
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.github.badsyntax.gradle.handlers;
+
+import com.github.badsyntax.gradle.ErrorMessageBuilder;
+import com.github.badsyntax.gradle.ExecuteCommandReply;
+import com.github.badsyntax.gradle.ExecuteCommandRequest;
+import com.github.badsyntax.gradle.utils.Utils;
+import io.grpc.stub.StreamObserver;
+import java.util.List;
+
+public class ExecuteCommandHandler {
+
+	private ExecuteCommandRequest req;
+	private StreamObserver<ExecuteCommandReply> responseObserver;
+
+	private static final String GET_NORMALIZED_PACKAGE_NAME = "getNormalizedPackageName";
+
+	public ExecuteCommandHandler(ExecuteCommandRequest req, StreamObserver<ExecuteCommandReply> responseObserver) {
+		this.req = req;
+		this.responseObserver = responseObserver;
+	}
+
+	public void run() {
+		String command = req.getCommand();
+		switch (command) {
+			case GET_NORMALIZED_PACKAGE_NAME :
+				List<String> arguments = req.getArgumentsList();
+				if (arguments == null || arguments.size() != 1) {
+					replyWithError(new Exception("illegal Arguments"));
+				}
+				try {
+					replyWithSuccess(Utils.normalizePackageName(arguments.get(0)));
+				} catch (Exception e) {
+					replyWithError(e);
+				}
+		}
+	}
+
+	private void replyWithError(Exception e) {
+		responseObserver.onError(ErrorMessageBuilder.build(e));
+	}
+
+	private void replyWithSuccess(String value) {
+		responseObserver.onNext(ExecuteCommandReply.newBuilder().setResult(value).build());
+		responseObserver.onCompleted();
+	}
+}

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/utils/Utils.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/utils/Utils.java
@@ -5,6 +5,7 @@ package com.github.badsyntax.gradle.utils;
 
 import io.github.g00fy2.versioncompare.Version;
 import java.io.File;
+import java.util.Locale;
 
 public class Utils {
 	public static boolean isValidFile(File file) {
@@ -38,5 +39,32 @@ public class Utils {
 			return new Version("4.3");
 		}
 		return new Version("2.0");
+	}
+
+	public static String normalizePackageName(String name) {
+		return Utils.toPackageName(name).toLowerCase(Locale.US);
+	}
+
+	private static String toPackageName(String name) {
+		StringBuilder result = new StringBuilder();
+		int pos = 0;
+		while (pos < name.length()) {
+			while (pos < name.length() && !Character.isJavaIdentifierStart(name.charAt(pos))) {
+				pos++;
+			}
+			if (pos == name.length()) {
+				break;
+			}
+			if (result.length() != 0) {
+				result.append('.');
+			}
+			result.append(name.charAt(pos));
+			pos++;
+			while (pos < name.length() && Character.isJavaIdentifierPart(name.charAt(pos))) {
+				result.append(name.charAt(pos));
+				pos++;
+			}
+		}
+		return result.toString();
 	}
 }

--- a/proto/gradle.proto
+++ b/proto/gradle.proto
@@ -14,6 +14,7 @@ service Gradle {
   rpc GetDaemonsStatus(GetDaemonsStatusRequest) returns (GetDaemonsStatusReply) {}
   rpc StopDaemons(StopDaemonsRequest) returns (StopDaemonsReply) {}
   rpc StopDaemon(StopDaemonRequest) returns (StopDaemonReply) {}
+  rpc executeCommand(ExecuteCommandRequest) returns (ExecuteCommandReply) {}
 }
 
 message GetBuildRequest {
@@ -208,4 +209,13 @@ message Output {
 
   OutputType output_type = 1;
   bytes output_bytes = 2;
+}
+
+message ExecuteCommandRequest {
+    string command = 1;
+    repeated string arguments = 2;
+}
+
+message ExecuteCommandReply {
+    string result = 1;
 }


### PR DESCRIPTION
fix #1170 

Now we will check & suggest the package name when creating a new Gradle project.

- In simple mode, the package name will be automatically normalized.
- In advanced mode, during specific package name step, the default name will be normalized:
![image](https://user-images.githubusercontent.com/45906942/162724057-8a0c63bd-6bbb-4e77-8bf6-276e7d2e3cfb.png)
the default package name is normalized from `cs-proj`(the folder name) to `cs.proj`
- when you try to use an invalid name, the inputbox will be disabled and show error message and suggestion.
![image](https://user-images.githubusercontent.com/45906942/162724359-01731794-c183-49d9-a978-df0c0ffab95d.png)
