### PR TITLE
fix: Render task after deleting from cancelling list

### DIFF
--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -97,6 +97,7 @@ export function removeCancellingTask(task: vscode.Task): void {
     const cancellingTask = getCancellingTask(task);
     if (cancellingTask) {
         cancellingTasks.delete(cancellingTask.definition.id);
+        vscode.commands.executeCommand(COMMAND_RENDER_TASK, task);
     }
 }
 


### PR DESCRIPTION
fix #1132 

We need to render the task to **refresh** it's status, since we have removed it from cancelling list successfully. 

This change is like what we have done in setting cancelling list: https://github.com/microsoft/vscode-gradle/blob/890ad4a75f9d8547350a9192e1e1c2b094a7f09e/extension/src/tasks/taskUtil.ts#L54-L55