### PR TITLE
fix: Duplicates Tasks for multiple level projects

### DIFF
--- a/gradle-plugin/src/main/java/com/microsoft/gradle/GradleProjectModelBuilder.java
+++ b/gradle-plugin/src/main/java/com/microsoft/gradle/GradleProjectModelBuilder.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import org.gradle.api.Project;
@@ -90,9 +91,9 @@ public class GradleProjectModelBuilder implements ToolingModelBuilder {
 		List<String> plugins = getPlugins(project);
 		List<GradleClosure> closures = getPluginClosures(project);
 		List<GradleProjectModel> subModels = new ArrayList<>();
-		Set<Project> subProjects = project.getSubprojects();
-		for (Project subProject : subProjects) {
-			GradleProjectModel subModel = buildModel(rootProject, subProject);
+		Map<String, Project> childProjects = project.getChildProjects();
+		for (Project childProject : childProjects.values()) {
+			GradleProjectModel subModel = buildModel(rootProject, childProject);
 			if (subModel != null) {
 				subModels.add(subModel);
 			}


### PR DESCRIPTION
fix #1194 

The difference between the two methods:

- `Project.getSubprojects()` returns all sub projects
- `Project.getChildprojects()` returns **direct** children (sub projects)

See https://docs.gradle.org/current/dsl/org.gradle.api.Project.html for the details. Since we use recursive calls to get the hierarchical projects, here we should use `Project.getChildprojects()` to avoid duplicating.