### PR TITLE
chore: Support JDK 17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [14.15.4]
-        java-version: ["8", "11", "15"]
+        java-version: ["8", "11", "17"]
         os: [ubuntu-20.04, windows-2019, macos-10.15]
     steps:
       - uses: actions/checkout@v2

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java'
   id 'com.google.protobuf' version '0.8.13'
   id 'com.github.jlouns.cpe' version '0.5.0'
-  id 'com.diffplug.spotless' version '5.7.0'
+  id 'com.diffplug.spotless' version '6.7.2'
 }
 
 project.ext.set('grpcVersion', '1.45.0')

--- a/extension/test-fixtures/gradle-groovy-custom-build-file/gradle/wrapper/gradle-wrapper.properties
+++ b/extension/test-fixtures/gradle-groovy-custom-build-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/extension/test-fixtures/gradle-groovy-default-build-file/gradle/wrapper/gradle-wrapper.properties
+++ b/extension/test-fixtures/gradle-groovy-default-build-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/extension/test-fixtures/gradle-kotlin-default-build-file/gradle/wrapper/gradle-wrapper.properties
+++ b/extension/test-fixtures/gradle-kotlin-default-build-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/extension/test-fixtures/multi-project/gradle/wrapper/gradle-wrapper.properties
+++ b/extension/test-fixtures/multi-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
We should support JDK 17 in development side and production side.

- development: plugin `com.diffplug.spotless` is outdated and has a bug when formatting. See: https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#671---2022-06-10, here will update this plugin
- production: change test environment from Java 8,11,15 to Java 8,11,17 to verify if it works