### PR TITLE
Fix typo in hint

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -801,7 +801,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "description": "Unique identifoier for this task"
+            "description": "Unique identifier for this task"
           },
           "script": {
             "type": "string",


### PR DESCRIPTION
A mouse-over hint had a typo. It is now fixed. 🚀 