### PR TITLE
chore: Send telemetry for manual refresh

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -264,6 +264,11 @@
       {
         "command": "gradle.refresh",
         "category": "Gradle",
+        "title": "Refresh Gradle Projects View"
+      },
+      {
+        "command": "gradle.refresh.external",
+        "category": "Gradle",
         "title": "Refresh Gradle Projects View",
         "icon": {
           "light": "resources/light/refresh.svg",
@@ -466,8 +471,12 @@
           "when": "false"
         },
         {
-          "command": "gradle.refresh",
+          "command": "gradle.refresh.external",
           "when": "gradle:extensionActivated"
+        },
+        {
+          "command": "gradle.refresh",
+          "when": "false"
         },
         {
           "command": "gradle.runBuild",
@@ -520,7 +529,7 @@
           "group": "navigation@2"
         },
         {
-          "command": "gradle.refresh",
+          "command": "gradle.refresh.external",
           "when": "view == gradleTasksView || view == gradleDefaultProjectsView",
           "group": "overflow@3"
         },

--- a/extension/src/commands/Commands.ts
+++ b/extension/src/commands/Commands.ts
@@ -77,6 +77,7 @@ import { COMMAND_CREATE_PROJECT, COMMAND_CREATE_PROJECT_ADVANCED, CreateProjectC
 import { HideStoppedDaemonsCommand, HIDE_STOPPED_DAEMONS } from "./HideStoppedDaemonsCommand";
 import { COMMAND_RELOAD_JAVA_PROJECT, ReloadJavaProjectsCommand } from "./ReloadJavaProjectsCommand";
 import { COMMAND_RUN_TASKS, RunTasksCommand } from "./RunTasksCommand";
+import { COMMAND_REFRESH_EXTERNAL, RefreshExternalCommand } from "./RefreshExternalCommand";
 import { ShowStoppedDaemonsCommand, SHOW_STOPPED_DAEMONS } from "./ShowStoppedDaemonsCommand";
 
 export class Commands {
@@ -134,15 +135,14 @@ export class Commands {
         );
         this.registerCommand(COMMAND_CANCEL_BUILD, new CancelBuildCommand(this.client));
         this.registerCommand(COMMAND_CANCEL_TREE_ITEM_TASK, new CancelTreeItemTaskCommand());
-        this.registerCommandWithoutInstrument(
-            COMMAND_REFRESH,
-            new RefreshCommand(
-                this.gradleTaskProvider,
-                this.gradleBuildContentProvider,
-                this.gradleTasksTreeDataProvider,
-                this.recentTasksTreeDataProvider
-            )
+        const refreshCommand = new RefreshCommand(
+            this.gradleTaskProvider,
+            this.gradleBuildContentProvider,
+            this.gradleTasksTreeDataProvider,
+            this.recentTasksTreeDataProvider
         );
+        this.registerCommandWithoutInstrument(COMMAND_REFRESH, refreshCommand);
+        this.registerCommand(COMMAND_REFRESH_EXTERNAL, new RefreshExternalCommand(refreshCommand));
         this.registerCommand(COMMAND_LOAD_TASKS, new LoadTasksCommand(this.gradleTaskProvider));
         this.registerCommandWithoutInstrument(
             COMMAND_REFRESH_DAEMON_STATUS,

--- a/extension/src/commands/RefreshExternalCommand.ts
+++ b/extension/src/commands/RefreshExternalCommand.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { Command } from "./Command";
+import { RefreshCommand } from "./RefreshCommand";
+
+export const COMMAND_REFRESH_EXTERNAL = "gradle.refresh.external";
+
+/**
+ * Used for collecting telemetry of refresh command from external UI.
+ */
+export class RefreshExternalCommand extends Command {
+    constructor(private refreshCommand: RefreshCommand) {
+        super();
+    }
+    async run(): Promise<void> {
+        this.refreshCommand.run();
+    }
+}


### PR DESCRIPTION
now we just dismiss telemetry for command `gradle.refresh`. https://github.com/microsoft/vscode-gradle/blob/a9d5977d0a8505ddc5bf55000046e0e96428e4d3/extension/src/commands/Commands.ts#L134-L142

since changing the build file will trigger a refresh command, but we should still collect manual refresh commands via view title and command palette.