### PR TITLE
fix: Allow to use environment executable java to launch servers

### DIFF
--- a/extension/src/constant.ts
+++ b/extension/src/constant.ts
@@ -18,6 +18,9 @@ export const VSCODE_TRIGGER_COMPLETION = "editor.action.triggerSuggest";
 
 export const GRADLE_BUILD_FILE_NAMES = ["build.gradle", "settings.gradle", "build.gradle.kts", "settings.gradle.kts"];
 
+export const NO_JAVA_EXECUTABLE =
+    "No Java executable found, please consider to configure your 'java.jdt.ls.java.home' setting or set JAVA_HOME in your path or put a Java executable in your path.";
+
 export enum CompletionKinds {
     DEPENDENCY_GROUP = "dependency_group",
     DEPENDENCY_ARTIFACT = "dependency_artifact",

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -56,14 +56,14 @@ export async function startLanguageServer(
                 // keep consistent with gRPC server
                 const javaHome = getJavaHome();
                 let javaCommand;
-                if (!javaHome) {
-                    if (!(await checkEnvJavaExecutable())) {
+                if (javaHome) {
+                    javaCommand = path.join(javaHome, "bin", "java");
+                } else {
+                    if (!checkEnvJavaExecutable()) {
                         // we have already show error message in gRPC server for no java executable found, so here we will just reject and return
                         return reject();
                     }
                     javaCommand = "java";
-                } else {
-                    javaCommand = path.join(javaHome, "bin", "java");
                 }
                 const args = [
                     ...prepareLanguageServerParams(),

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -6,6 +6,7 @@ import * as kill from "tree-kill";
 import { getGradleServerCommand, getGradleServerEnv } from "./serverUtil";
 import { isDebuggingServer } from "../util";
 import { Logger } from "../logger/index";
+import { NO_JAVA_EXECUTABLE } from "../constant";
 
 const SERVER_LOGLEVEL_REGEX = /^\[([A-Z]+)\](.*)$/;
 const DOWNLOAD_PROGRESS_CHAR = ".";
@@ -39,7 +40,11 @@ export class GradleServer {
             this.port = await getPort();
             const cwd = this.context.asAbsolutePath("lib");
             const cmd = path.join(cwd, getGradleServerCommand());
-            const env = getGradleServerEnv();
+            const env = await getGradleServerEnv();
+            if (!env) {
+                await vscode.window.showErrorMessage(NO_JAVA_EXECUTABLE);
+                return;
+            }
             const args = [String(this.port)];
 
             this.logger.debug("Starting server");

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -40,7 +40,7 @@ export class GradleServer {
             this.port = await getPort();
             const cwd = this.context.asAbsolutePath("lib");
             const cmd = path.join(cwd, getGradleServerCommand());
-            const env = await getGradleServerEnv();
+            const env = getGradleServerEnv();
             if (!env) {
                 await vscode.window.showErrorMessage(NO_JAVA_EXECUTABLE);
                 return;

--- a/extension/src/server/serverUtil.ts
+++ b/extension/src/server/serverUtil.ts
@@ -1,4 +1,4 @@
-import { getConfigGradleJavaHome } from "../util/config";
+import { checkEnvJavaExecutable, getJavaHome } from "../util/config";
 
 export function getGradleServerCommand(): string {
     const platform = process.platform;
@@ -15,13 +15,15 @@ export interface ProcessEnv {
     [key: string]: string | undefined;
 }
 
-export function getGradleServerEnv(): ProcessEnv {
-    const javaHome = getConfigGradleJavaHome();
+export async function getGradleServerEnv(): Promise<ProcessEnv | undefined> {
+    const javaHome = getJavaHome();
     const env = { ...process.env };
     if (javaHome) {
         Object.assign(env, {
             VSCODE_JAVA_HOME: javaHome,
         });
+    } else if (!(await checkEnvJavaExecutable())) {
+        return undefined;
     }
     return env;
 }

--- a/extension/src/server/serverUtil.ts
+++ b/extension/src/server/serverUtil.ts
@@ -15,14 +15,14 @@ export interface ProcessEnv {
     [key: string]: string | undefined;
 }
 
-export async function getGradleServerEnv(): Promise<ProcessEnv | undefined> {
+export function getGradleServerEnv(): ProcessEnv | undefined {
     const javaHome = getJavaHome();
     const env = { ...process.env };
     if (javaHome) {
         Object.assign(env, {
             VSCODE_JAVA_HOME: javaHome,
         });
-    } else if (!(await checkEnvJavaExecutable())) {
+    } else if (!checkEnvJavaExecutable()) {
         return undefined;
     }
     return env;

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -33,7 +33,7 @@ export function getJavaHome(): string | undefined {
     return getConfigGradleJavaHome() || process.env.JAVA_HOME;
 }
 
-export async function checkEnvJavaExecutable(): Promise<boolean> {
+export function checkEnvJavaExecutable(): boolean {
     try {
         execSync("java -version", { stdio: "pipe" });
     } catch (e) {

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -1,3 +1,4 @@
+import { execSync } from "child_process";
 import * as vscode from "vscode";
 import { GradleConfig } from "../proto/gradle_pb";
 import { RootProject } from "../rootProject/RootProject";
@@ -26,6 +27,19 @@ export function getConfigJavaImportGradleJavaHome(): string | null {
 
 export function getConfigGradleJavaHome(): string | null {
     return getConfigJavaImportGradleJavaHome() || getJdtlsConfigJavaHome() || getConfigJavaHome();
+}
+
+export function getJavaHome(): string | undefined {
+    return getConfigGradleJavaHome() || process.env.JAVA_HOME;
+}
+
+export async function checkEnvJavaExecutable(): Promise<boolean> {
+    try {
+        execSync("java -version", { stdio: "pipe" });
+    } catch (e) {
+        return false;
+    }
+    return true;
 }
 
 export function getConfigJavaImportGradleUserHome(): string | null {


### PR DESCRIPTION
fix #1249 

This pr checks and keeps the consistent of the two servers (Gradle server and Gradle language server), and follow Gradle behavior.

We will check the following ones (with descent priority), Beside VS Code configuration, we use step 4-5 to keep consistent with Gradle itself behavior.

1. config "java.import.gradle.java.home"
2. config "java.jdt.ls.java.home"
3. config "java.home" (deprecated)
4. environment JAVA_HOME
5. environment executable java(.exe)