### PR TITLE
fix: Duplicate tasks are found in the projects with the same name

### DIFF
--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -268,7 +268,7 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
                 let parentTreeItem: ProjectTreeItem | GroupTreeItem = projectTreeItem;
 
                 if (!collapsed) {
-                    const groupId = definition.group + definition.project;
+                    const groupId = definition.group + definition.project + definition.projectFolder;
                     let groupTreeItem = groupTreeItemMap.get(groupId);
                     if (!groupTreeItem) {
                         groupTreeItem = new GroupTreeItem(definition.group, projectTreeItem, undefined);


### PR DESCRIPTION
fix #1262 , we add the project folder to construct `groupId` here to make sure its uniqueness.