### PR TITLE
UX: Allow switching mode when creating new project

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -327,11 +327,6 @@
         "title": "Create a Gradle Java Project..."
       },
       {
-        "command": "gradle.createProjectAdvanced",
-        "category": "Gradle",
-        "title": "Create a Gradle Java Project... (Advanced)"
-      },
-      {
         "command": "gradle.runTasks",
         "category": "Gradle",
         "title": "Run Gradle Tasks..."

--- a/extension/src/commands/Commands.ts
+++ b/extension/src/commands/Commands.ts
@@ -73,7 +73,7 @@ import { GradleTaskProvider } from "../tasks";
 import { isJavaExtEnabled } from "../util/javaExtension";
 import { GradleDaemonsTreeDataProvider, GradleTasksTreeDataProvider, RecentTasksTreeDataProvider } from "../views";
 import { Command } from "./Command";
-import { COMMAND_CREATE_PROJECT, COMMAND_CREATE_PROJECT_ADVANCED, CreateProjectCommand } from "./CreateProjectCommand";
+import { COMMAND_CREATE_PROJECT, CreateProjectCommand } from "./CreateProjectCommand";
 import { HideStoppedDaemonsCommand, HIDE_STOPPED_DAEMONS } from "./HideStoppedDaemonsCommand";
 import { COMMAND_RELOAD_JAVA_PROJECT, ReloadJavaProjectsCommand } from "./ReloadJavaProjectsCommand";
 import { COMMAND_RUN_TASKS, RunTasksCommand } from "./RunTasksCommand";
@@ -186,7 +186,6 @@ export class Commands {
         this.registerCommand(SHOW_STOPPED_DAEMONS, new ShowStoppedDaemonsCommand(this.gradleDaemonsTreeDataProvider));
         this.registerCommand(HIDE_STOPPED_DAEMONS, new HideStoppedDaemonsCommand(this.gradleDaemonsTreeDataProvider));
         this.registerCommand(COMMAND_CREATE_PROJECT, new CreateProjectCommand(this.client), [false]);
-        this.registerCommand(COMMAND_CREATE_PROJECT_ADVANCED, new CreateProjectCommand(this.client), [true]);
         this.registerCommand(COMMAND_RUN_TASKS, new RunTasksCommand(this.gradleTaskProvider));
         if (isJavaExtEnabled()) {
             this.registerCommand(COMMAND_RELOAD_JAVA_PROJECT, new ReloadJavaProjectsCommand());

--- a/extension/src/createProject/SelectProjectTypeStep.ts
+++ b/extension/src/createProject/SelectProjectTypeStep.ts
@@ -4,6 +4,7 @@
 import * as vscode from "vscode";
 import { selectScriptDSLStep } from "./SelectScriptDSLStep";
 import { IProjectCreationMetadata, IProjectCreationStep, ProjectType, StepResult } from "./types";
+import { updateTotalSteps } from "./utils";
 
 export class SelectProjectTypeStep implements IProjectCreationStep {
     public async run(metadata: IProjectCreationMetadata): Promise<StepResult> {
@@ -25,19 +26,17 @@ export class SelectProjectTypeStep implements IProjectCreationStep {
                         switch (selectedType.label) {
                             case "application":
                                 metadata.projectType = ProjectType.JAVA_APPLICATION;
-                                metadata.totalSteps = 5;
                                 break;
                             case "library":
                                 metadata.projectType = ProjectType.JAVA_LIBRARY;
-                                metadata.totalSteps = 5;
                                 break;
                             case "Gradle plugin":
                                 metadata.projectType = ProjectType.JAVA_GRADLE_PLUGIN;
-                                metadata.totalSteps = 4; // when creating gradle plugin, we shouldn't specify test framework
                                 break;
                             default:
                                 resolve(StepResult.STOP);
                         }
+                        updateTotalSteps(metadata);
                         metadata.steps.push(selectProjectTypeStep);
                         metadata.nextStep = selectScriptDSLStep;
                         resolve(StepResult.NEXT);

--- a/extension/src/createProject/SelectTestFrameworkStep.ts
+++ b/extension/src/createProject/SelectTestFrameworkStep.ts
@@ -4,6 +4,7 @@
 import * as vscode from "vscode";
 import { specifyProjectNameStep } from "./SpecifyProjectNameStep";
 import { IProjectCreationMetadata, IProjectCreationStep, StepResult, TestFramework } from "./types";
+import { createQuickInputButtons } from "./utils";
 
 export class SelectTestFrameworkStep implements IProjectCreationStep {
     public async run(metadata: IProjectCreationMetadata): Promise<StepResult> {
@@ -18,16 +19,7 @@ export class SelectTestFrameworkStep implements IProjectCreationStep {
             pickBox.matchOnDescription = true;
             pickBox.ignoreFocusOut = true;
             pickBox.items = this.getTestFrameworkPickItems();
-            if (metadata.steps.length) {
-                pickBox.buttons = [vscode.QuickInputButtons.Back];
-                disposables.push(
-                    pickBox.onDidTriggerButton((item) => {
-                        if (item === vscode.QuickInputButtons.Back) {
-                            resolve(StepResult.PREVIOUS);
-                        }
-                    })
-                );
-            }
+            pickBox.buttons = createQuickInputButtons(metadata);
             disposables.push(
                 pickBox.onDidAccept(() => {
                     const selectedTestFramework = pickBox.selectedItems[0];
@@ -52,6 +44,11 @@ export class SelectTestFrameworkStep implements IProjectCreationStep {
                         metadata.steps.push(selectTestFrameworkStep);
                         metadata.nextStep = specifyProjectNameStep;
                         resolve(StepResult.NEXT);
+                    }
+                }),
+                pickBox.onDidTriggerButton((item) => {
+                    if (item === vscode.QuickInputButtons.Back) {
+                        resolve(StepResult.PREVIOUS);
                     }
                 }),
                 pickBox.onDidHide(() => {

--- a/extension/src/createProject/SpecifySourcePackageNameStep.ts
+++ b/extension/src/createProject/SpecifySourcePackageNameStep.ts
@@ -3,7 +3,7 @@
 
 import * as vscode from "vscode";
 import { IProjectCreationMetadata, IProjectCreationStep, StepResult } from "./types";
-import { asyncDebounce } from "./utils";
+import { asyncDebounce, createQuickInputButtons } from "./utils";
 
 export class SpecifySourcePackageNameStep implements IProjectCreationStep {
     public static GET_NORMALIZED_PACKAGE_NAME = "getNormalizedPackageName";
@@ -33,16 +33,7 @@ export class SpecifySourcePackageNameStep implements IProjectCreationStep {
             inputBox.placeholder = "e.g. " + normalizedName;
             inputBox.value = normalizedName as string;
             inputBox.ignoreFocusOut = true;
-            if (metadata.steps.length) {
-                inputBox.buttons = [vscode.QuickInputButtons.Back];
-                disposables.push(
-                    inputBox.onDidTriggerButton((item) => {
-                        if (item === vscode.QuickInputButtons.Back) {
-                            resolve(StepResult.PREVIOUS);
-                        }
-                    })
-                );
-            }
+            inputBox.buttons = createQuickInputButtons(metadata);
             disposables.push(
                 inputBox.onDidChangeValue(async () => {
                     const normalizedName = await getNormalizedPackageNameTrigger(inputBox.value);
@@ -64,6 +55,11 @@ export class SpecifySourcePackageNameStep implements IProjectCreationStep {
                         metadata.sourcePackageName = inputBox.value;
                         metadata.nextStep = undefined;
                         resolve(StepResult.NEXT);
+                    }
+                }),
+                inputBox.onDidTriggerButton((item) => {
+                    if (item === vscode.QuickInputButtons.Back) {
+                        resolve(StepResult.PREVIOUS);
                     }
                 }),
                 inputBox.onDidHide(() => {

--- a/extension/src/createProject/types.ts
+++ b/extension/src/createProject/types.ts
@@ -25,6 +25,8 @@ export enum StepResult {
     NEXT,
     STOP,
     PREVIOUS,
+    // used for switching mode and restart all steps
+    RESTART,
 }
 
 export enum ProjectType {

--- a/extension/src/createProject/utils.ts
+++ b/extension/src/createProject/utils.ts
@@ -3,6 +3,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { debounce } from "lodash";
+import { QuickInputButton, QuickInputButtons, ThemeIcon } from "vscode";
+import { IProjectCreationMetadata, ProjectType } from "./types";
+
+export const switchToAdvancedLabel = "Switch to advanced mode...";
 
 export function asyncDebounce(func: any, wait: any, bind: any) {
     const debounced = debounce(async (resolve, reject, bindSelf, args) => {
@@ -21,4 +25,29 @@ export function asyncDebounce(func: any, wait: any, bind: any) {
     }
 
     return returnFunc;
+}
+
+export function updateTotalSteps(metadata: IProjectCreationMetadata): void {
+    if (!metadata.isAdvanced) {
+        metadata.totalSteps = 2;
+    } else if (metadata.projectType === ProjectType.JAVA_GRADLE_PLUGIN) {
+        // when creating gradle plugin, we shouldn't specify test framework
+        metadata.totalSteps = 4;
+    } else {
+        metadata.totalSteps = 5;
+    }
+}
+
+export function createQuickInputButtons(metadata: IProjectCreationMetadata): QuickInputButton[] {
+    const buttons: QuickInputButton[] = [];
+    if (metadata.steps.length) {
+        buttons.push(QuickInputButtons.Back);
+    }
+    if (!metadata.isAdvanced) {
+        buttons.push({
+            iconPath: new ThemeIcon("settings-gear"),
+            tooltip: switchToAdvancedLabel,
+        });
+    }
+    return buttons;
 }


### PR DESCRIPTION
fix #1153 

with this PR, we will not expose creating new project in advanced mode in the command palette but allow users to switch to them during the creating process.

This PR adds the buttons to switch to advanced mode in simple mode steps and refactor some parts with new util `createQuickInputButtons()`.

https://user-images.githubusercontent.com/45906942/190959254-e76776a9-33a6-4fa5-a67d-b2035faf20cb.mp4

