### PR TITLE
fix: Resolve result in socket.end() callback

### DIFF
--- a/extension/src/util/index.ts
+++ b/extension/src/util/index.ts
@@ -19,12 +19,14 @@ function tcpExists(host: string, port: number): Promise<boolean> {
                 resolve(false);
             })
             .on("timeout", () => {
-                connection.end();
-                resolve(false);
+                connection.end(() => {
+                    resolve(false);
+                });
             })
             .on("connect", () => {
-                connection.end();
-                resolve(true);
+                connection.end(() => {
+                    resolve(true);
+                });
             });
         connection.setTimeout(tcpTimeout);
     });


### PR DESCRIPTION
may fix #1258 

see node.js API: https://nodejs.org/api/net.html#socketenddata-encoding-callback

the socket.end() function will send a FIN packet, and it might be possible the connection will not close just after it called, so it causes the debug error in #1258 

> Half-closes the socket. i.e., it sends a FIN packet. It is possible the server will still send some data.

We can move the resolve statement to the callback, since the callback will be called after the socket is finished:

> callback: Optional callback for when the socket is finished.