### PR TITLE
fix: Use built-in model to query lazy tasks

### DIFF
--- a/gradle-plugin/src/main/java/com/microsoft/gradle/DefaultGradleTask.java
+++ b/gradle-plugin/src/main/java/com/microsoft/gradle/DefaultGradleTask.java
@@ -59,4 +59,8 @@ public class DefaultGradleTask implements Serializable, GradleTask {
 	public boolean getDebuggable() {
 		return debuggable;
 	}
+
+	public void setDebuggable(boolean debuggable) {
+		this.debuggable = debuggable;
+	}
 }

--- a/gradle-plugin/src/main/java/com/microsoft/gradle/GradlePlugin.java
+++ b/gradle-plugin/src/main/java/com/microsoft/gradle/GradlePlugin.java
@@ -19,6 +19,6 @@ public class GradlePlugin implements Plugin<Project> {
 
 	@Override
 	public void apply(Project project) {
-		registry.register(new GradleProjectModelBuilder());
+		registry.register(new GradleProjectModelBuilder(registry));
 	}
 }

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -122,6 +122,9 @@ public class GetBuildHandler {
 					.setStandardOutput(standardOutputListener).setStandardError(standardErrorListener)
 					.setColorOutput(req.getShowOutputColors());
 			GradleProjectModel gradleModel = action.run();
+			if (gradleModel == null) {
+				throw new Exception("Error occurs in querying custom model.");
+			}
 			GradleProject project = getProjectData(gradleModel);
 			replyWithProject(project);
 		} catch (BuildCancelledException e) {


### PR DESCRIPTION
fix #1275 

Now we use custom model to fetch/query tasks, which has a limitation in lazy resolve tasks. As for lazy resolve tasks we will get an exception when trying to reach them via `TaskContainerInternal`, but Gradle itself has its own logics to fetch such information without any error. A typical scenario is #1275:
```
> Cannot change dependencies of dependency configuration ':xxx' after it has been resolved.
```

So, I'd like to use Gradle built-in model to get tasks information (e.g., name, group, path, project name and so on), and we can get Gradle's further enhancement and bug fix. Besides, we use custom model as its additional part, to get the information does not exist in built-in model (e.g., debuggable information). 