### PR TITLE
chore: Check jdk version before starting server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This VS Code extension provides a visual interface for your Gradle build. You ca
 ## Requirements
 
 - [VS Code >= 1.63.0](https://code.visualstudio.com/download)
-- [Java >= 8](https://adoptopenjdk.net/)
+- [Java from 8 to 17](https://adoptopenjdk.net/)
 
 ## Project Discovery
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -934,6 +934,7 @@
   },
   "dependencies": {
     "await-lock": "^2.2.2",
+    "jdk-utils": "^0.4.4",
     "fs-extra": "^10.1.0",
     "get-port": "^5.1.1",
     "lodash": "^4.17.21",

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -15,7 +15,7 @@ import {
     getConfigJavaImportGradleUserHome,
     getConfigJavaImportGradleVersion,
     getConfigJavaImportGradleWrapperEnabled,
-    getJavaHome,
+    getSupportedJavaHome,
 } from "../util/config";
 import { prepareLanguageServerParams } from "./utils";
 const CHANNEL_NAME = "Gradle for Java (Language Server)";
@@ -54,7 +54,7 @@ export async function startLanguageServer(
                 serverOptions = awaitServerConnection.bind(null, port);
             } else {
                 // keep consistent with gRPC server
-                const javaHome = getJavaHome();
+                const javaHome = await getSupportedJavaHome();
                 let javaCommand;
                 if (javaHome) {
                     javaCommand = path.join(javaHome, "bin", "java");

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -40,7 +40,7 @@ export class GradleServer {
             this.port = await getPort();
             const cwd = this.context.asAbsolutePath("lib");
             const cmd = path.join(cwd, getGradleServerCommand());
-            const env = getGradleServerEnv();
+            const env = await getGradleServerEnv();
             if (!env) {
                 await vscode.window.showErrorMessage(NO_JAVA_EXECUTABLE);
                 return;

--- a/extension/src/server/serverUtil.ts
+++ b/extension/src/server/serverUtil.ts
@@ -1,4 +1,4 @@
-import { checkEnvJavaExecutable, getJavaHome } from "../util/config";
+import { checkEnvJavaExecutable, getSupportedJavaHome } from "../util/config";
 
 export function getGradleServerCommand(): string {
     const platform = process.platform;
@@ -15,8 +15,8 @@ export interface ProcessEnv {
     [key: string]: string | undefined;
 }
 
-export function getGradleServerEnv(): ProcessEnv | undefined {
-    const javaHome = getJavaHome();
+export async function getGradleServerEnv(): Promise<ProcessEnv | undefined> {
+    const javaHome = await getSupportedJavaHome();
     const env = { ...process.env };
     if (javaHome) {
         Object.assign(env, {


### PR DESCRIPTION
mitigate #1293, will ignore unsupported java runtime, until Gradle TAPI and groove-eclipse both provide official java 18&19 
 support.