### PR TITLE
chore: Update azure pipeline env to node 16

### DIFF
--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -38,9 +38,9 @@ jobs:
         jdkArchitectureOption: 'x64'
         jdkSourceOption: 'PreInstalled'
     - task: NodeTool@0
-      displayName: Install Node 14.15.4
+      displayName: Install Node 16.14.2
       inputs:
-        versionSpec: '14.15.4'
+        versionSpec: '16.14.2'
     - task: Gradle@2
       displayName: Build
       inputs:

--- a/.azure-pipelines/vscode-gradle-nightly.yml
+++ b/.azure-pipelines/vscode-gradle-nightly.yml
@@ -24,9 +24,9 @@ steps:
     jdkArchitectureOption: 'x64'
     jdkSourceOption: 'PreInstalled'
 - task: NodeTool@0
-  displayName: Install Node 14.15.4
+  displayName: Install Node 16.14.2
   inputs:
-    versionSpec: '14.15.4'
+    versionSpec: '16.14.2'
 - task: Gradle@2
   displayName: Build
   inputs:

--- a/.azure-pipelines/vscode-gradle-rc.yml
+++ b/.azure-pipelines/vscode-gradle-rc.yml
@@ -17,9 +17,9 @@ steps:
     jdkArchitectureOption: 'x64'
     jdkSourceOption: 'PreInstalled'
 - task: NodeTool@0
-  displayName: Install Node 14.15.4
+  displayName: Install Node 16.14.2
   inputs:
-    versionSpec: '14.15.4'
+    versionSpec: '16.14.2'
 - task: Gradle@2
   displayName: Build
   inputs:


### PR DESCRIPTION
since our dependencies are updated, `@vscode/test-electron` version 2.2.2 require node 16 now.