### PR TITLE
fix: Pre-relase CI failed

### DIFF
--- a/extension/build.gradle
+++ b/extension/build.gradle
@@ -77,6 +77,7 @@ clean {
 
 task copyProtoJs(type: Copy) {
   dependsOn ':extension:generateProto'
+  dependsOn ':extension:copyDocs'
   group 'copy'
   description 'Copies proto JavaScript files into src dir'
   from "$protobuf.generatedFilesBaseDir/main/js"
@@ -173,6 +174,10 @@ task testVsCode(type: CrossPlatformExec) {
 }
 
 task copyDocs(type: Copy) {
+  dependsOn ':extension:generateProto'
+  dependsOn ':extension:npmInstall'
+  dependsOn ':extension:copyProtoTs'
+  dependsOn ':gradle-server:serverStartScripts'
   group 'copy'
   description 'Copies docs from the root project into the extension'
   from docsFiles.collect { "$rootProject.projectDir/" + it }


### PR DESCRIPTION
This PR is a follow-up of https://github.com/microsoft/vscode-gradle/pull/1317, the publish CI executes `prepareForRelease` task which contains serveral sub tasks that don't declare task dependency explicitly, which is required in Gradle 8.0.