### PR TITLE
Add support for subfolder gradle projects

### DIFF
--- a/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
@@ -309,7 +309,7 @@ public class GradleServices implements TextDocumentService, WorkspaceService, La
 				containingCall = call;
 			}
 		}
-		this.libraryResolver.loadGradleClasses();
+		this.libraryResolver.loadGradleClasses(uri);
 		boolean javaPluginsIncluded = this.libraryResolver.isJavaPluginsIncluded(uri,
 				this.completionVisitor.getPlugins(uri));
 		CompletionHandler handler = new CompletionHandler();

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
@@ -103,12 +103,12 @@ public class GradleLibraryResolver {
 		return resolveGradleAPI(null);
 	}
 
-	public boolean resolveGradleAPI(URI relativeToGradleFile) {
+	public boolean resolveGradleAPI(URI gradleFilePath) {
 		this.needToLoadClasses = true;
 		// step 1: find "lib" folder
 		File libFolder = null;
 		if (this.gradleWrapperEnabled) {
-			DistInfo info = getWrapperPropertiesInfo(relativeToGradleFile);
+			DistInfo info = getWrapperPropertiesInfo(gradleFilePath);
 			if (info == null) {
 				return false;
 			}
@@ -158,14 +158,14 @@ public class GradleLibraryResolver {
 		}
 	}
 
-	private DistInfo getWrapperPropertiesInfo(URI relativeToGradleFile) {
-		if (this.workspacePath == null && relativeToGradleFile == null) {
+	private DistInfo getWrapperPropertiesInfo(URI gradleFilePath) {
+		if (this.workspacePath == null && gradleFilePath == null) {
 			return null;
 		}
 		Path propertiesRelativePath = Paths.get("gradle", "wrapper", "gradle-wrapper.properties");
 		Path propertiesPath = null;
-		if (relativeToGradleFile != null) {
-			propertiesPath = Paths.get(relativeToGradleFile).getParent().resolve(propertiesRelativePath);
+		if (gradleFilePath != null) {
+			propertiesPath = Paths.get(gradleFilePath).getParent().resolve(propertiesRelativePath);
 		} else {
 			propertiesPath = this.workspacePath.resolve(propertiesRelativePath);
 		}

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/resolver/GradleLibraryResolver.java
@@ -100,11 +100,15 @@ public class GradleLibraryResolver {
 	}
 
 	public boolean resolveGradleAPI() {
+		return resolveGradleAPI(null);
+	}
+
+	public boolean resolveGradleAPI(URI relativeToGradleFile) {
 		this.needToLoadClasses = true;
 		// step 1: find "lib" folder
 		File libFolder = null;
 		if (this.gradleWrapperEnabled) {
-			DistInfo info = getWrapperPropertiesInfo();
+			DistInfo info = getWrapperPropertiesInfo(relativeToGradleFile);
 			if (info == null) {
 				return false;
 			}
@@ -119,20 +123,27 @@ public class GradleLibraryResolver {
 		if (!Utils.isValidFolder(libFolder)) {
 			return false;
 		}
-		this.gradleFilesManager.setGradleLibraries(Utils.listAllFiles(libFolder));
-		// step 2: find core API jar file
-		this.coreAPI = findCoreAPI(libFolder);
-		if (!Utils.isValidFile(this.coreAPI)) {
+		File newAPI = findCoreAPI(libFolder);
+		if (!Utils.isValidFile(newAPI)) {
 			return false;
 		}
+		if (this.coreAPI != null && this.coreAPI.equals(newAPI)) {
+			// same gradle dist so reuse.
+			this.needToLoadClasses = false;
+			return false;
+		}
+
+		this.gradleFilesManager.setGradleLibraries(Utils.listAllFiles(libFolder));
+		// step 2: find core API jar file
+		this.coreAPI = newAPI;
 		// step 3: find plugin API jar file
 		this.pluginAPI = findPluginAPI(this.coreAPI.toPath().getParent().resolve(Paths.get("plugins")).toFile());
 		return Utils.isValidFile(this.pluginAPI);
 	}
 
-	public void loadGradleClasses() {
+	public void loadGradleClasses(URI uri) {
 		boolean isAPIValid = Utils.isValidFile(this.coreAPI) && Utils.isValidFile(this.pluginAPI);
-		if (!this.needToLoadClasses || (!isAPIValid && !this.resolveGradleAPI())) {
+		if (!this.needToLoadClasses || (!isAPIValid && !this.resolveGradleAPI(uri))) {
 			return;
 		}
 		try {
@@ -147,12 +158,18 @@ public class GradleLibraryResolver {
 		}
 	}
 
-	private DistInfo getWrapperPropertiesInfo() {
-		if (this.workspacePath == null) {
+	private DistInfo getWrapperPropertiesInfo(URI relativeToGradleFile) {
+		if (this.workspacePath == null && relativeToGradleFile == null) {
 			return null;
 		}
 		Path propertiesRelativePath = Paths.get("gradle", "wrapper", "gradle-wrapper.properties");
-		Path propertiesPath = this.workspacePath.resolve(propertiesRelativePath);
+		Path propertiesPath = null;
+		if (relativeToGradleFile != null) {
+			propertiesPath = Paths.get(relativeToGradleFile).getParent().resolve(propertiesRelativePath);
+		} else {
+			propertiesPath = this.workspacePath.resolve(propertiesRelativePath);
+		}
+
 		File propertiesFile = propertiesPath.toFile();
 		if (!propertiesFile.exists()) {
 			return null;


### PR DESCRIPTION
In the multi module setup where the parent folder is open by vscode, when wrapper is enabled, the LS fails the resolved the wrapper since it looks in workspace folder which is the root folder of the multi module project structure. The wrapper folders are actually in leaf level folders where the gradle files are found. So this fix try to resolve wrapper consider the current gradle file path to resolve it first, if that fails it falls back to workspace folder as before.