### PR TITLE
Support nested closure completions

### DIFF
--- a/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/GradleServices.java
@@ -298,15 +298,22 @@ public class GradleServices implements TextDocumentService, WorkspaceService, La
 			}
 		}
 		Set<MethodCallExpression> methodCalls = this.completionVisitor.getMethodCalls(uri);
-		MethodCallExpression containingCall = null;
+		List<MethodCallExpression> containingCallPath = new ArrayList<>();
+		MethodCallExpression lastCall = null;
 		for (MethodCallExpression call : methodCalls) {
 			Expression expression = call.getArguments();
 			Range range = LSPUtils.toRange(expression);
-			if (Ranges.containsPosition(range, params.getPosition())
-					&& (containingCall == null || Ranges.containsRange(LSPUtils.toRange(containingCall.getArguments()),
-							LSPUtils.toRange(call.getArguments())))) {
-				// find inner containing call
-				containingCall = call;
+			if (Ranges.containsPosition(range, params.getPosition())) {
+				lastCall = call;
+				if (Ranges.containsRange(LSPUtils.toRange(lastCall.getArguments()),
+						LSPUtils.toRange(call.getArguments()))) {
+					// if current call contains inside last call, nested closure.
+					containingCallPath.add(call);
+				} else if (Ranges.containsRange(LSPUtils.toRange(call.getArguments()),
+						LSPUtils.toRange(lastCall.getArguments()))) {
+					// if current call is the parent of last call, nested closure.
+					containingCallPath.add(containingCallPath.size() - 1, call);
+				}
 			}
 		}
 		this.libraryResolver.loadGradleClasses();
@@ -315,11 +322,11 @@ public class GradleServices implements TextDocumentService, WorkspaceService, La
 		CompletionHandler handler = new CompletionHandler();
 		// check again
 		String projectPath = Utils.getFolderPath(uri);
-		if (containingCall == null && isGradleRoot(uri, params.getPosition())) {
-			return CompletableFuture.completedFuture(Either.forLeft(handler.getCompletionItems(null,
+		if (containingCallPath.isEmpty() && isGradleRoot(uri, params.getPosition())) {
+			return CompletableFuture.completedFuture(Either.forLeft(handler.getCompletionItems(Collections.emptyList(),
 					Paths.get(uri).getFileName().toString(), this.libraryResolver, javaPluginsIncluded, projectPath)));
 		}
-		return CompletableFuture.completedFuture(Either.forLeft(handler.getCompletionItems(containingCall,
+		return CompletableFuture.completedFuture(Either.forLeft(handler.getCompletionItems(containingCallPath,
 				Paths.get(uri).getFileName().toString(), this.libraryResolver, javaPluginsIncluded, projectPath)));
 	}
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/CompletionHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/CompletionHandler.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.bcel.classfile.Attribute;
 import org.apache.bcel.classfile.FieldOrMethod;
 import org.apache.bcel.classfile.JavaClass;
@@ -35,12 +36,12 @@ public class CompletionHandler {
 	private static String SETTING_GRADLE = "settings.gradle";
 	private static String DEPENDENCYHANDLER_CLASS = "org.gradle.api.artifacts.dsl.DependencyHandler";
 
-	public List<CompletionItem> getCompletionItems(MethodCallExpression containingCall, String fileName,
+	public List<CompletionItem> getCompletionItems(List<MethodCallExpression> containingCallPath, String fileName,
 			GradleLibraryResolver resolver, boolean javaPluginsIncluded, String projectPath) {
 		List<CompletionItem> results = new ArrayList<>();
 		Set<String> resultSet = new HashSet<>();
 		List<String> delegateClassNames = new ArrayList<>();
-		if (containingCall == null) {
+		if (containingCallPath.isEmpty()) {
 			if (fileName.equals(BUILD_GRADLE)) {
 				delegateClassNames.add(GradleDelegate.getDefault());
 			} else if (fileName.equals(SETTING_GRADLE)) {
@@ -48,7 +49,8 @@ public class CompletionHandler {
 			}
 			results.addAll(getCompletionItemsFromExtClosures(resolver, projectPath, resultSet));
 		} else {
-			String methodName = containingCall.getMethodAsString();
+			String methodName = containingCallPath.stream().map(MethodCallExpression::getMethodAsString)
+					.collect(Collectors.joining("."));
 			List<CompletionItem> re = getCompletionItemsFromExtClosures(resolver, projectPath, methodName, resultSet);
 			results.addAll(re);
 			List<String> delegates = GradleDelegate.getDelegateMap().get(methodName);


### PR DESCRIPTION
Today the plugin only sees the root level extensions and their methods, But if such method supports closure which contains a type, completions are not supported for such closures.

This change tries to find such methods and expand closure collection based on those closure types which could be for example a extension.

Good example of a code snippet to tryout this change is spotless plugin configuration as below

```
spotless {
    json {
    }
    java {
    }
}
```

if you try to invoke completions inside json closure, you don't get any and if you try to do the same inside java you endup with config values for standard java plugin.

When this change is applied, the correct configuration values are shown from the relevant spotless extension.

**Note:**  method chaining is still not working which needs to be separately add support. 

