### PR TITLE
Support 'Reload Projects'

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -85,7 +85,7 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
             return;
         }
 
-        boolean shouldUpdate = force || GradleBuildServerProjectImporter.updateConfigurationDigest(project);
+        boolean shouldUpdate = GradleBuildServerProjectImporter.updateConfigurationDigest(project) || force;
         if (shouldUpdate) {
             IPath rootPath = ProjectUtils.findBelongedWorkspaceRoot(project.getLocation());
             if (rootPath == null) {

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -39,6 +39,7 @@ import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.ResourceUtils;
 import org.eclipse.jdt.ls.core.internal.managers.IBuildSupport;
+import org.eclipse.jdt.ls.core.internal.managers.ProjectsManager.CHANGE_TYPE;
 
 import ch.epfl.scala.bsp4j.BuildServer;
 import ch.epfl.scala.bsp4j.BuildTarget;
@@ -76,6 +77,36 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
     @Override
     public boolean applies(IProject project) {
         return Utils.isGradleBuildServerProject(project);
+    }
+
+    @Override
+    public void update(IProject project, boolean force, IProgressMonitor monitor) throws CoreException {
+        if (!applies(project)) {
+            return;
+        }
+
+        boolean shouldUpdate = force || GradleBuildServerProjectImporter.updateConfigurationDigest(project);
+        if (shouldUpdate) {
+            IPath rootPath = ProjectUtils.findBelongedWorkspaceRoot(project.getLocation());
+            if (rootPath == null) {
+                JavaLanguageServerPlugin.logError("Cannot find workspace root for project: " + project.getName());
+                return;
+            }
+            BuildServer buildServer = ImporterPlugin.getBuildServerConnection(rootPath);
+            buildServer.workspaceReload().join();
+
+            Map<URI, List<BuildTarget>> buildTargetMap = Utils.getBuildTargetsMappedByProjectPath(buildServer);
+            for (URI uri : buildTargetMap.keySet()) {
+                IProject projectFromUri = ProjectUtils.getProjectFromUri(uri.toString());
+                if (projectFromUri == null || !Utils.isGradleBuildServerProject(projectFromUri)) {
+                    continue;
+                }
+                updateClasspath(projectFromUri, monitor);
+                updateProjectDependencies(projectFromUri, monitor);
+                // TODO: in case that the projects/build targets are created or removed,
+                // we can use the server->client notification: 'buildTarget/didChange' to support this case.
+            }
+        }
     }
 
     /**
@@ -153,7 +184,7 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
      * Update the project dependencies of the project.
      * @throws CoreException
      */
-    public void addProjectDependencies(IProject project, IProgressMonitor monitor) throws CoreException {
+    public void updateProjectDependencies(IProject project, IProgressMonitor monitor) throws CoreException {
         IPath rootPath = ProjectUtils.findBelongedWorkspaceRoot(project.getLocation());
         if (rootPath == null) {
             JavaLanguageServerPlugin.logError("Cannot find workspace root for project: " + project.getName());
@@ -181,6 +212,14 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
             }
         }
         return entries;
+    }
+
+    @Override
+    public boolean fileChanged(IResource resource, CHANGE_TYPE changeType, IProgressMonitor monitor) throws CoreException {
+        if (resource == null || !applies(resource.getProject())) {
+            return false;
+        }
+        return isBuildFile(resource) || IBuildSupport.super.fileChanged(resource, changeType, monitor);
     }
 
     @Override

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/ImporterPlugin.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/ImporterPlugin.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.ls.core.internal.managers.DigestStore;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.osgi.framework.BundleContext;
 
@@ -30,11 +31,17 @@ public class ImporterPlugin extends Plugin {
 
     private static ImporterPlugin instance;
 
+    /**
+     * Digest store for the gradle configuration files.
+     */
+    private DigestStore digestStore;
+
     private static String bundleDirectory;
 
     @Override
     public void start(BundleContext context) throws Exception {
         ImporterPlugin.instance = this;
+        digestStore = new DigestStore(getStateLocation().toFile());
         Optional<File> bundleFile = FileLocator.getBundleFileLocation(context.getBundle());
         if (!bundleFile.isPresent()) {
            throw new IllegalStateException("Failed to get bundle location.");
@@ -53,6 +60,10 @@ public class ImporterPlugin extends Plugin {
     public static ImporterPlugin getInstance() {
         return ImporterPlugin.instance;
     }
+
+    public static DigestStore getDigestStore() {
+        return instance.digestStore;
+	}
 
     public static BuildServer getBuildServerConnection(IPath rootPath) throws CoreException {
         Pair<BuildServer, BuildClient> pair = instance.buildServers.get(rootPath);

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
@@ -22,14 +22,12 @@ public class Utils {
     }
 
     /**
-     * Map the build targets by their paths, the paths are get from the uri.
-     * @param buildTargets
-     * @return
+     * Get build targets mapped by their paths, the paths are get from the uri.
      */
-    public static Map<URI, List<BuildTarget>> mapBuildTargetsByProjectPath(List<BuildTarget> buildTargets) {
-        return buildTargets.stream().collect(Collectors.groupingBy(target -> {
-            return getUriWithoutQuery(target.getId().getUri());
-        }));
+    public static Map<URI, List<BuildTarget>> getBuildTargetsMappedByProjectPath(BuildServer serverConnection) {
+        WorkspaceBuildTargetsResult workspaceBuildTargetsResult = serverConnection.workspaceBuildTargets().join();
+        List<BuildTarget> buildTargets = workspaceBuildTargetsResult.getTargets();
+        return buildTargets.stream().collect(Collectors.groupingBy(target -> getUriWithoutQuery(target.getId().getUri())));
     }
 
     public static URI getUriWithoutQuery(String uriString) {


### PR DESCRIPTION
Support 'Reload Projects', meanwhile, a `DigestStore` is used to persist the digest of the gradle configuration files.