### PR TITLE
fix: Turn on 'callOnEmptyDelta' for builder

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/plugin.xml
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/plugin.xml
@@ -27,7 +27,7 @@
         point="org.eclipse.core.resources.builders"
         id="com.microsoft.gradle.bs.importer.builder.BuildServerBuilder"
         name="Build Server Builder">
-        <builder>
+        <builder callOnEmptyDelta="true">
             <run class="com.microsoft.gradle.bs.importer.builder.BuildServerBuilder">
             </run>
         </builder>

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/plugin.xml
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/plugin.xml
@@ -27,7 +27,7 @@
         point="org.eclipse.core.resources.builders"
         id="com.microsoft.gradle.bs.importer.builder.BuildServerBuilder"
         name="Build Server Builder">
-        <builder callOnEmptyDelta="true">
+        <builder callOnEmptyDelta="true" isConfigurable="true">
             <run class="com.microsoft.gradle.bs.importer.builder.BuildServerBuilder">
             </run>
         </builder>

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -189,8 +189,7 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
         IProjectDescription projectDescription = workspace.newProjectDescription(projectName);
         projectDescription.setLocation(Path.fromOSString(directory.getPath()));
         projectDescription.setNatureIds(new String[]{ GradleBuildServerProjectNature.NATURE_ID });
-        ICommand buildSpec = projectDescription.newCommand();
-        buildSpec.setBuilderName(BuildServerBuilder.BUILDER_ID);
+        ICommand buildSpec = Utils.getBuildServerBuildSpec(projectDescription);
         projectDescription.setBuildSpec(new ICommand[]{buildSpec});
         IProject project = workspace.getRoot().getProject(projectName);
         project.create(projectDescription, monitor);
@@ -200,7 +199,8 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
     }
 
     private void updateProjectDescription(IProject project, IProgressMonitor monitor) throws CoreException {
-        Utils.addBuildSpec(project, BuildServerBuilder.BUILDER_ID, monitor);
+        IProjectDescription projectDescription = project.getDescription();
+        Utils.addBuildSpec(project, Utils.getBuildServerBuildSpec(projectDescription), monitor);
     }
 
     private String findFreeProjectName(String baseName) {

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/builder/BuildServerBuilder.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/builder/BuildServerBuilder.java
@@ -42,8 +42,8 @@ public class BuildServerBuilder extends IncrementalProjectBuilder {
         if (buildServer != null) {
             List<BuildTarget> targets = Utils.getBuildTargetsByProjectUri(buildServer, project.getLocationURI());
             List<BuildTargetIdentifier> ids = targets.stream().map(BuildTarget::getId).collect(Collectors.toList());
-            if (ids != null && requiresBuild(kind)) {
-                // TODO: support clean build?
+            if (ids != null) {
+                // TODO: support clean build
                 CompileResult result = buildServer.buildTargetCompile(new CompileParams(ids)).join();
                 if (Objects.equals(result.getStatusCode(), StatusCode.ERROR)) {
                     throw new CoreException(new Status(IStatus.ERROR, ImporterPlugin.PLUGIN_ID,
@@ -52,9 +52,5 @@ public class BuildServerBuilder extends IncrementalProjectBuilder {
             }
         }
         return null;
-    }
-
-    private boolean requiresBuild(int kind) {
-        return kind == FULL_BUILD || kind == INCREMENTAL_BUILD;
     }
 }


### PR DESCRIPTION
- Because the build server builder ignores the auto builds, so we need to turn on the 'callOnEmptyDelta' - Auto build will do nothing but update the state tree.