### PR TITLE
Improve the project JDK detection.

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/ch/epfl/scala/bsp4j/extended/JvmBuildTargetEx.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/ch/epfl/scala/bsp4j/extended/JvmBuildTargetEx.java
@@ -1,0 +1,52 @@
+package ch.epfl.scala.bsp4j.extended;
+
+import java.util.Objects;
+
+import ch.epfl.scala.bsp4j.JvmBuildTarget;
+
+/**
+ * Extended {@link JvmBuildTarget}, which contains the Gradle version.
+ * The client can use the Gradle version to find compatible JDKs according to
+ * https://docs.gradle.org/current/userguide/compatibility.html.
+ */
+public class JvmBuildTargetEx extends JvmBuildTarget {
+
+  private String gradleVersion;
+
+  public JvmBuildTargetEx(String javaHome, String javaVersion,
+      String gradleVersion) {
+    super(javaHome, javaVersion);
+    this.gradleVersion = gradleVersion;
+  }
+
+  public String getGradleVersion() {
+    return gradleVersion;
+  }
+
+  public void setGradleVersion(String gradleVersion) {
+    this.gradleVersion = gradleVersion;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + Objects.hash(gradleVersion);
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!super.equals(obj)) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    JvmBuildTargetEx other = (JvmBuildTargetEx) obj;
+    return Objects.equals(gradleVersion, other.gradleVersion);
+  }
+}

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/EclipseVmUtil.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/EclipseVmUtil.java
@@ -1,55 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Gradle Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copied from org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/EclipseVmUtil.java
+ *
+ * Contributors:
+ *     Microsoft Corporation - Get compatible VM with highest version.
+ ******************************************************************************/
+
 package com.microsoft.gradle.bs.importer;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.Optional;
 
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.internal.launching.StandardVMType;
 import org.eclipse.jdt.launching.IVMInstall;
+import org.eclipse.jdt.launching.IVMInstall2;
 import org.eclipse.jdt.launching.IVMInstallType;
 import org.eclipse.jdt.launching.JavaRuntime;
 import org.eclipse.jdt.launching.VMStandin;
 import org.eclipse.jdt.launching.environments.IExecutionEnvironment;
 
 /**
- * Copied from org.eclipse.buildship.core/src/main/java/org/eclipse/buildship/core/internal/workspace/EclipseVmUtil.java
+ *
  */
 public class EclipseVmUtil {
 
     private static final String VM_ID_PREFIX = "com.microsoft.gradle.bs.vm.";
 
     /**
-     * Finds a Java VM in the Eclipse VM registry or registers a new one if none was available with
+     * Finds a Java VM in the Eclipse VM registry. The version of the vm is among
+     * [{@code lowestVersion}, {@code highestVersion}]. Or registers a new one if none was available with
      * the selected version.
      *
-     * @param version  the VM's supported Java version
+     * @param lowestVersion  the lowest supported Java version
+     * @param highestVersion the highest supported Java version
      * @param location the location of the VM
      * @return the reference of an existing or newly created VM
      */
-    public static IVMInstall findOrRegisterStandardVM(String version, File location) {
-        return findOrRegisterVM(version, location);
+    public static IVMInstall findOrRegisterStandardVM(String lowestVersion, String highestVersion, File location) {
+        Optional<IVMInstall> vm = findRegisteredVM(lowestVersion, highestVersion);
+        return vm.isPresent() ? vm.get() : registerNewVM("Java SE", location);
     }
 
-    private static IVMInstall findOrRegisterVM(String version, File location) {
-        Optional<IVMInstall> vm = findRegisteredVM(version);
-        return vm.isPresent() ? vm.get() : registerNewVM("Java SE " + version, location);
-    }
-
-    private static Optional<IVMInstall> findRegisteredVM(String version) {
-        Optional<IExecutionEnvironment> possibleExecutionEnvironment = findExecutionEnvironment(version);
+    private static Optional<IVMInstall> findRegisteredVM(String lowestVersion, String highestVersion) {
+        Optional<IExecutionEnvironment> possibleExecutionEnvironment = findExecutionEnvironment(lowestVersion);
         if (!possibleExecutionEnvironment.isPresent()) {
             return Optional.empty();
         }
 
         IExecutionEnvironment executionEnvironment = possibleExecutionEnvironment.get();
-        IVMInstall defaultVm = executionEnvironment.getDefaultVM();
-        if (defaultVm != null) {
-            return Optional.of(defaultVm);
-        } else {
-            IVMInstall[] compatibleVMs = executionEnvironment.getCompatibleVMs();
-            IVMInstall firstVm = compatibleVMs.length > 0 ? compatibleVMs[0] : null;
-            return Optional.ofNullable(firstVm);
+        IVMInstall vm = getCompatibleVMWithHighestVersion(lowestVersion, highestVersion, executionEnvironment);
+        return Optional.ofNullable(vm);
+    }
+
+    private static IVMInstall getCompatibleVMWithHighestVersion(String lowestVersion, String highestVersion,
+            IExecutionEnvironment executionEnvironment) {
+        IVMInstall vm = null;
+        IVMInstall[] compatibleVMs = executionEnvironment.getCompatibleVMs();
+        for (IVMInstall compatibleVm : compatibleVMs) {
+            File installLocation = compatibleVm.getInstallLocation();
+            if (installLocation == null || !installLocation.exists() || isEmbeddedJre(installLocation.getAbsolutePath())) {
+                continue;
+            }
+
+            if (compatibleVm instanceof IVMInstall2 vm2) {
+                String javaVersion = vm2.getJavaVersion();
+                if (javaVersion == null || JavaCore.compareJavaVersions(lowestVersion, javaVersion) > 0
+                        || JavaCore.compareJavaVersions(highestVersion, javaVersion) < 0) {
+                    continue;
+                }
+                if (vm == null || JavaCore.compareJavaVersions(
+                        ((IVMInstall2)vm).getJavaVersion(), javaVersion) < 0) {
+                    vm = compatibleVm;
+                }
+            }
         }
+        return vm;
+    }
+
+    /**
+     * Whether the location points to the embedded JRE of Java extension.
+     */
+    private static boolean isEmbeddedJre(String path) {
+        return path.contains("extensions") && path.contains("redhat.java") && path.contains("jre");
     }
 
     /**

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/model/GradleVersion.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/model/GradleVersion.java
@@ -1,0 +1,244 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Gradle Inc. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copied from org/eclipse/buildship/core/internal/util/gradle/GradleVersion.java
+ ******************************************************************************/
+
+package com.microsoft.gradle.bs.importer.model;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Represents a released version of Gradle
+ * <p>
+ * The implementation is a slimmed down version of the {@code org.gradle.util.GradleVersion}
+ * internal class from Gradle 4.6. The source URL:
+ * <a href="https://github.com/gradle/gradle/blob/v4.6.0/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java" >
+ * https://github.com/gradle/gradle/blob/v4.6.0/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+ * </a>
+ *
+ * @author Donat Csikos
+ */
+public final class GradleVersion implements Comparable<GradleVersion> {
+
+    private static final Pattern VERSION_PATTERN = Pattern.compile("((\\d+)(\\.\\d+)+)(-(\\p{Alpha}+)-(\\d+[a-z]?))?(-(SNAPSHOT|\\d{14}([-+]\\d{4})?))?");
+    private static final int STAGE_MILESTONE = 0;
+
+    private final String version;
+    private final Long snapshot;
+    private final String versionPart;
+    private final Stage stage;
+
+    /**
+     * Parses the given string into a GradleVersion.
+     *
+     * @throws IllegalArgumentException On unrecognized version string.
+     */
+    public static GradleVersion version(String version) throws IllegalArgumentException {
+        return new GradleVersion(version);
+    }
+
+    private GradleVersion(String version) {
+        this.version = version;
+        Matcher matcher = VERSION_PATTERN.matcher(version);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException(String.format("'%s' is not a valid Gradle version string (examples: '1.0', '1.0-rc-1')", version));
+        }
+
+        this.versionPart = matcher.group(1);
+
+        if (matcher.group(4) != null) {
+            int stageNumber;
+            if (matcher.group(5).equals("milestone")) {
+                stageNumber = STAGE_MILESTONE;
+            } else if (matcher.group(5).equals("preview")) {
+                stageNumber = 2;
+            } else if (matcher.group(5).equals("rc")) {
+                stageNumber = 3;
+            } else {
+                stageNumber = 1;
+            }
+            String stageString = matcher.group(6);
+            this.stage = new Stage(stageNumber, stageString);
+        } else {
+            this.stage = null;
+        }
+
+        if ("snapshot".equals(matcher.group(5))) {
+            this.snapshot = 0L;
+        } else if (matcher.group(8) == null) {
+            this.snapshot = null;
+        } else if ("SNAPSHOT".equals(matcher.group(8))) {
+            this.snapshot = 0L;
+        } else {
+            try {
+                if (matcher.group(9) != null) {
+                    this.snapshot = new SimpleDateFormat("yyyyMMddHHmmssZ").parse(matcher.group(8)).getTime();
+                } else {
+                    SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmss");
+                    format.setTimeZone(TimeZone.getTimeZone("UTC"));
+                    this.snapshot = format.parse(matcher.group(8)).getTime();
+                }
+            } catch (ParseException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "Gradle " + this.version;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public boolean isSnapshot() {
+        return this.snapshot != null;
+    }
+
+    /**
+     * The base version of this version. For pre-release versions, this is the target version.
+     *
+     * For example, the version base of '1.2-rc-1' is '1.2'.
+     *
+     * @return The version base
+     */
+    public GradleVersion getBaseVersion() {
+        if (this.stage == null && this.snapshot == null) {
+            return this;
+        }
+        return version(this.versionPart);
+    }
+
+    @Override
+    public int compareTo(GradleVersion gradleVersion) {
+        String[] majorVersionParts = this.versionPart.split("\\.");
+        String[] otherMajorVersionParts = gradleVersion.versionPart.split("\\.");
+
+        for (int i = 0; i < majorVersionParts.length && i < otherMajorVersionParts.length; i++) {
+            int part = Integer.parseInt(majorVersionParts[i]);
+            int otherPart = Integer.parseInt(otherMajorVersionParts[i]);
+
+            if (part > otherPart) {
+                return 1;
+            }
+            if (otherPart > part) {
+                return -1;
+            }
+        }
+        if (majorVersionParts.length > otherMajorVersionParts.length) {
+            return 1;
+        }
+        if (majorVersionParts.length < otherMajorVersionParts.length) {
+            return -1;
+        }
+
+        if (this.stage != null && gradleVersion.stage != null) {
+            int diff = this.stage.compareTo(gradleVersion.stage);
+            if (diff != 0) {
+                return diff;
+            }
+        }
+        if (this.stage == null && gradleVersion.stage != null) {
+            return 1;
+        }
+        if (this.stage != null && gradleVersion.stage == null) {
+            return -1;
+        }
+
+        if (this.snapshot != null && gradleVersion.snapshot != null) {
+            return this.snapshot.compareTo(gradleVersion.snapshot);
+        }
+        if (this.snapshot == null && gradleVersion.snapshot != null) {
+            return 1;
+        }
+        if (this.snapshot != null && gradleVersion.snapshot == null) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        if (o == null || o.getClass() != getClass()) {
+            return false;
+        }
+        GradleVersion other = (GradleVersion) o;
+        return this.version.equals(other.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.version.hashCode();
+    }
+
+    public boolean isValid() {
+        return this.versionPart != null;
+    }
+
+    /**
+     * Utility class to compare snapshot/milesone/rc releases.
+     */
+    static final class Stage implements Comparable<Stage> {
+
+        final int stage;
+        final int number;
+        final Character patchNo;
+
+        Stage(int stage, String number) {
+            this.stage = stage;
+            Matcher m = Pattern.compile("(\\d+)([a-z])?").matcher(number);
+            try {
+                m.matches();
+                this.number = Integer.parseInt(m.group(1));
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Invalid stage small number: " + number, e);
+            }
+
+            if (m.groupCount() == 2 && m.group(2) != null) {
+                this.patchNo = m.group(2).charAt(0);
+            } else {
+                this.patchNo = '_';
+            }
+        }
+
+        @Override
+        public int compareTo(Stage other) {
+            if (this.stage > other.stage) {
+                return 1;
+            }
+            if (this.stage < other.stage) {
+                return -1;
+            }
+            if (this.number > other.number) {
+                return 1;
+            }
+            if (this.number < other.number) {
+                return -1;
+            }
+            if (this.patchNo > other.patchNo) {
+                return 1;
+            }
+            if (this.patchNo < other.patchNo) {
+                return -1;
+            }
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
- Try to find all the JDKs which are compatible to the source level and the gradle version.
- Among those JDKs, find the latest one and set to classpath.
- If no JDK is found, use the JDK which is used to launch the Gradle daemon. This JDK might be the embedded JDK, so it is only a fallbak.

requires: https://github.com/microsoft/build-server-for-gradle/pull/66