### PR TITLE
Allow the linked target folder does not exist when creating

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -281,7 +281,7 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
                     }
                     IFolder linkFolder = project.getFolder(String.join("_", relativeSourcePath.segments()));
                     if (!linkFolder.exists()) {
-                        linkFolder.createLink(sourcePath, IResource.REPLACE, monitor);
+                        linkFolder.createLink(sourcePath, IResource.REPLACE | IResource.ALLOW_MISSING_LOCAL, monitor);
                     }
                     sourceFullPath = linkFolder.getFullPath();
                 }


### PR DESCRIPTION
For example:

https://github.com/web3j/web3j/blob/master/integration-tests/build.gradle#L60 this project linked a source set to a folder out of it's root. But that target folder will not be generated unless executing some Gradle tasks.

So we should add `ALLOW_MISSING_LOCAL` flag when creating linked folder.