### PR TITLE
Only add module attribute for non-test entries

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -515,12 +515,15 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
                 List<IClasspathAttribute> attributes = new LinkedList<>();
                 if (isTest) {
                     attributes.add(testAttribute);
+                } else if (isModular) {
+                    // Assume that a test-only dependency is not a module, which corresponds
+                    // to how Eclipse does test running for modules:
+                    // It patches the main module with the tests and expects test dependencies
+                    // to be part of the unnamed module (classpath).
+                    attributes.add(modularAttribute);
                 }
                 if (!artifact.exists()) {
                     attributes.add(optionalAttribute);
-                }
-                if (isModular) {
-                    attributes.add(modularAttribute);
                 }
 
                 dependencyEntries.add(JavaCore.newLibraryEntry(


### PR DESCRIPTION
Assume that a test-only dependency is not a module, which correspond to how Eclipse does test running for modules:
It patches the main module with the tests and expects test dependencies to be part of the unnamed module (classpath).