### PR TITLE
Enable Gradle build server by default

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -24,6 +24,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jdt.ls.core.internal.AbstractProjectImporter;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
@@ -211,13 +212,17 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
     }
 
     private void updateProjectDescription(IProject project, IProgressMonitor monitor) throws CoreException {
+        SubMonitor progress = SubMonitor.convert(monitor, 1);
         IProjectDescription projectDescription = project.getDescription();
+        Utils.removeBuildshipConfigurations(projectDescription);
+
         ICommand problemReporter = projectDescription.newCommand();
         problemReporter.setBuilderName(JavaProblemChecker.BUILDER_ID);
-        Utils.addBuildSpec(project, new ICommand[] {
+        Utils.addBuildSpec(projectDescription, new ICommand[] {
             Utils.getBuildServerBuildSpec(projectDescription),
             problemReporter
-        }, monitor);
+        });
+        project.setDescription(projectDescription, IResource.AVOID_NATURE_CONFIG, progress.newChild(1));
 
         // Here we don't use the public API: {@code project.setDescription()} to update the project,
         // because that API will ignore the variable descriptions.
@@ -254,19 +259,6 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
     private boolean isBuildServerEnabled() {
         Preferences preferences = getPreferences();
         String bspImporterEnabled = getString(preferences.asMap(), JAVA_BUILD_SERVER_GRADLE_ENABLED);
-        if (bspImporterEnabled == null) {
-            return false;
-        }
-
-        if ("on".equalsIgnoreCase(bspImporterEnabled)) {
-            return true;
-        } else if ("auto".equalsIgnoreCase(bspImporterEnabled)){
-            // Rely on the workspace storage path to determine if the client is VSCode Insiders.
-            // This may not always true if user changes the storage path manually, but should
-            // work in most cases.
-            return ResourcesPlugin.getPlugin().getStateLocation().toString().contains("Code - Insiders");
-        }
-
-        return false;
+        return "on".equalsIgnoreCase(bspImporterEnabled);
     }
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -831,12 +831,11 @@
         "java.gradle.buildServer.enabled": {
           "type": "string",
           "enum": [
-            "auto",
             "on",
             "off"
           ],
-          "markdownDescription": "[Experimental] Use build server to synchronize Gradle project when enabled. When set to `auto`, the build server will be enabled in Visual Studio Code - Insiders.",
-          "default": "auto"
+          "markdownDescription": "Whether to use build server to synchronize Gradle project. It will replace the original Buildship to import the Gradle when enabled.",
+          "default": "on"
         },
         "java.gradle.buildServer.openBuildOutput": {
           "type": "string",

--- a/extension/src/bs/BuildServerController.ts
+++ b/extension/src/bs/BuildServerController.ts
@@ -1,7 +1,12 @@
-import { Disposable, ExtensionContext, OutputChannel, commands, languages, window } from "vscode";
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { ConfigurationChangeEvent, Disposable, ExtensionContext, OutputChannel, commands, languages, window, workspace } from "vscode";
 import { GradleBuildLinkProvider } from "./GradleBuildLinkProvider";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { OpenBuildOutputValue, getOpenBuildOutput } from "../util/config";
+import * as path from "path";
+import * as fse from "fs-extra";
 
 const APPEND_BUILD_LOG_CMD = "_java.gradle.buildServer.appendBuildLog";
 const LOG_CMD = "_java.gradle.buildServer.log";
@@ -48,6 +53,28 @@ export class BuildServerController implements Disposable {
             commands.registerCommand(SEND_TELEMETRY_CMD, (jsonString: string) => {
                 const log = JSON.parse(jsonString);
                 sendInfo("", log);
+            }),
+            workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
+                if ((e.affectsConfiguration("java.gradle.buildServer.enabled"))) {
+                    const storagePath = context.storageUri?.fsPath;
+                    if (!storagePath) {
+                        return;
+                    }
+
+                    const msg = "Please reload to make the change of 'java.gradle.buildServer.enabled' take effect. Reload now?";
+                    const action = 'Reload';
+                    window.showWarningMessage(msg, action).then(async (selection) => {
+                        if (action === selection) {
+                            // generate a flag file to make it a clean reload.
+                            // https://github.com/redhat-developer/vscode-java/blob/d02cf8ecfee1f3f528770a51ada825d522356967/src/settings.ts#L46
+                            const jlsWorkspacePath = path.resolve(storagePath, "..", "redhat.java", "jdt_ws");
+                            await fse.ensureDir(jlsWorkspacePath);
+                            const flagFile = path.resolve(jlsWorkspacePath, ".cleanWorkspace");
+                            await fse.writeFile(flagFile, "");
+                            commands.executeCommand("workbench.action.reloadWindow");
+                        }
+                    });
+                }
             })
         );
     }

--- a/extension/src/bs/BuildServerController.ts
+++ b/extension/src/bs/BuildServerController.ts
@@ -1,7 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { ConfigurationChangeEvent, Disposable, ExtensionContext, OutputChannel, commands, languages, window, workspace } from "vscode";
+import {
+    ConfigurationChangeEvent,
+    Disposable,
+    ExtensionContext,
+    OutputChannel,
+    commands,
+    languages,
+    window,
+    workspace,
+} from "vscode";
 import { GradleBuildLinkProvider } from "./GradleBuildLinkProvider";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { OpenBuildOutputValue, getOpenBuildOutput } from "../util/config";
@@ -55,14 +64,15 @@ export class BuildServerController implements Disposable {
                 sendInfo("", log);
             }),
             workspace.onDidChangeConfiguration((e: ConfigurationChangeEvent) => {
-                if ((e.affectsConfiguration("java.gradle.buildServer.enabled"))) {
+                if (e.affectsConfiguration("java.gradle.buildServer.enabled")) {
                     const storagePath = context.storageUri?.fsPath;
                     if (!storagePath) {
                         return;
                     }
 
-                    const msg = "Please reload to make the change of 'java.gradle.buildServer.enabled' take effect. Reload now?";
-                    const action = 'Reload';
+                    const msg =
+                        "Please reload to make the change of 'java.gradle.buildServer.enabled' take effect. Reload now?";
+                    const action = "Reload";
                     window.showWarningMessage(msg, action).then(async (selection) => {
                         if (action === selection) {
                             // generate a flag file to make it a clean reload.

--- a/extension/src/bs/GradleBuildLinkProvider.ts
+++ b/extension/src/bs/GradleBuildLinkProvider.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 import { DocumentLink, DocumentLinkProvider, ProviderResult, Range, TextDocument, Uri } from "vscode";
 
 export class GradleBuildLinkProvider implements DocumentLinkProvider {


### PR DESCRIPTION
- Set the default value of 'java.gradle.buildServer.enabled' to 'on'.
- Hint users to reload if the 'java.gradle.buildServer.enabled' changes.
- Remove Buildship configuration from the project description if the project already has the build server nature.