### PR TITLE
Replace link to AdoptOpenJDK with Adoptium in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This VS Code extension provides a visual interface for your Gradle build. You ca
 ## Requirements
 
 - [VS Code >= 1.76.0](https://code.visualstudio.com/download)
-- [Java from 8 to 19](https://adoptopenjdk.net/)
+- [Java from 8 to 19](https://adoptium.net/)
 
 ## Project Discovery
 


### PR DESCRIPTION
Context: https://blog.adoptopenjdk.net/2023/02/adoptopenjdk-dns-redirect/

This PR replaces the link to AdoptOpenJDK with Adoptium (since the former redirects to the latter anyway ATM).