### PR TITLE
fix: Importer only return false when a Java project is imported by other importers before

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -87,7 +87,8 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
             IProject project = ProjectUtils.getProjectFromUri(directory.toUri().toString());
             // skip this importer if any of the project in workspace is already
             // imported by other importers.
-            if (project != null && !Utils.isGradleBuildServerProject(project)) {
+            if (project != null && (!Utils.isGradleBuildServerProject(project)
+                    && ProjectUtils.isJavaProject(project))) {
                 return false;
             }
         }


### PR DESCRIPTION
Current bs implementation only takes care of Java project, so in the `applies()`, limit the restriction to -- return false when a **Java** project has been imported by other project importers.