### PR TITLE
chore(ci): Reuse built extension on tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 16.14.2
+          cache-dependency-path: extension/package-lock.json
           cache: npm
       - name: Cache npm cache directory
         uses: actions/cache@v2
@@ -68,6 +69,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache-dependency-path: extension/package-lock.json
           cache: npm
       - name: Use Java ${{ matrix.java-version }}
         uses: actions/setup-java@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,10 @@ jobs:
           java-version: "11"
           architecture: x64
       - name: Use Node 16.14.2
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 16.14.2
+          cache: npm
       - name: Cache npm cache directory
         uses: actions/cache@v2
         with:
@@ -64,9 +65,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
       - name: Use Java ${{ matrix.java-version }}
         uses: actions/setup-java@v1
         with:
@@ -115,6 +117,9 @@ jobs:
         with:
           arguments: build
           build-root-directory: extension/test-fixtures/gradle-kotlin-default-build-file
+      - name: Install extension dependencies
+        working-directory: extension/
+        run: npm ci
       - name: Test extension
         uses: gradle/gradle-build-action@v2
         continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,10 +84,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: lib
-          path: |
-            extension/lib
-            extension/dist
-            extension/out
+          path: extension/
       - name: Start Xvfb
         run: |
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,11 +39,15 @@ jobs:
           arguments: build -x test
         env:
           JAVA_HOME: ""
+          NODE_OPTIONS: "--max-old-space-size=4096"
       - name: Upload lib
         uses: actions/upload-artifact@v2
         with:
           name: lib
-          path: extension/lib
+          path: |
+            extension/lib
+            extension/dist
+            extension/out
 
   # Although the gradle build can run in all environments, we use the Java
   # lib generated in the previous step for a better real-world test.
@@ -76,17 +80,14 @@ jobs:
           key: ${{ runner.os }}-vscode-${{ hashFiles('**/vscode-version.ts') }}
           restore-keys: |
             ${{ runner.os }}-vscode-
-      - name: Build Extension
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: extension:build
-        env:
-          NODE_OPTIONS: "--max-old-space-size=4096"
       - name: Download lib
         uses: actions/download-artifact@v2
         with:
           name: lib
-          path: extension/lib
+          path: |
+            extension/lib
+            extension/dist
+            extension/out
       - name: Start Xvfb
         run: |
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &


### PR DESCRIPTION
## As discussed in #1419:

A better way to run CI is to build the extension and test it on different Java versions. We can leverage the artifacts already built on the `build-and-analyse` job to do that. We upload the required artifacts of the built extension and then download them to be reused on the `test-extension` job.