### PR TITLE
Fix buildJars task

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target
@@ -22,7 +22,7 @@
             <repository location="https://download.eclipse.org/jdtls/snapshots/repository/latest/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.21.1/"/>
+           <repository location="https://download.eclipse.org/lsp4j/updates/releases/0.22.0/"/>
            <unit id="org.eclipse.lsp4j" version="0.0.0"/>
         </location>
     </locations>


### PR DESCRIPTION
The `buildJars` task failed with the following exception

```
[ERROR] Cannot resolve target definition:
[ERROR]   Software being installed: org.eclipse.jdt.ls.core 1.35.0.202404090315
[ERROR]   Missing requirement: org.eclipse.jdt.ls.core 1.35.0.202404090315 requires 'osgi.bundle; org.eclipse.lsp4j [0.22.0.0,0.23.0)' but it could not be found
[ERROR]
[ERROR] Failed to resolve target definition file:/Users/donat/Development/git/donat/vscode-gradle/extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target: See log for details -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MavenExecutionException
```


I adjusted the target definition file that made that resolved the missing requirement problem and made the task work again.