### PR TITLE
Refresh the output folders after build tasks

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/builder/BuildServerBuilder.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/builder/BuildServerBuilder.java
@@ -80,8 +80,9 @@ public class BuildServerBuilder extends IncrementalProjectBuilder {
                 continue;
             }
 
-            IPath output = cp.getOutputLocation().removeFirstSegments(1);
+            IPath output = cp.getOutputLocation();
             if (output != null) {
+                output = output.removeFirstSegments(1);
                 javaProject.getProject().getFolder(output).refreshLocal(IProject.DEPTH_INFINITE, monitor);
             } else {
                 needRefreshDefaultOutput = true;

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/builder/BuildServerBuilder.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/builder/BuildServerBuilder.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
@@ -13,6 +14,8 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.ProjectUtils;
 import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
@@ -55,8 +58,42 @@ public class BuildServerBuilder extends IncrementalProjectBuilder {
                     throw new CoreException(new Status(IStatus.ERROR, ImporterPlugin.PLUGIN_ID,
                             IResourceStatus.BUILD_FAILED, "Build Failed.", null));
                 }
+                this.refreshOutputs(monitor);
             }
         }
         return null;
+    }
+
+    /**
+     * Trigger <code>.refreshLocal()</code> to all the output folders of the project.
+     * This is to make sure the changes made by the build server are reflected in the workspace.
+     */
+    private void refreshOutputs(IProgressMonitor monitor) throws CoreException {
+        IJavaProject javaProject = ProjectUtils.getJavaProject(this.getProject());
+        if (javaProject == null) {
+            return;
+        }
+
+        boolean needRefreshDefaultOutput = false;
+        for (IClasspathEntry cp : javaProject.getRawClasspath()) {
+            if (cp.getEntryKind() != IClasspathEntry.CPE_SOURCE) {
+                continue;
+            }
+
+            IPath output = cp.getOutputLocation().removeFirstSegments(1);
+            if (output != null) {
+                javaProject.getProject().getFolder(output).refreshLocal(IProject.DEPTH_INFINITE, monitor);
+            } else {
+                needRefreshDefaultOutput = true;
+            }
+        }
+
+        if (needRefreshDefaultOutput) {
+            IPath relativeOutputPath = javaProject.getOutputLocation().removeFirstSegments(1);
+            IFolder defaultOutput = javaProject.getProject().getFolder(relativeOutputPath);
+            if (defaultOutput.exists()) {
+                defaultOutput.refreshLocal(IProject.DEPTH_INFINITE, monitor);
+            }
+        }
     }
 }


### PR DESCRIPTION
Since the build server will delegate the build task to gradle. The workspace will become unsynchronized when the output files change. Thus a `.refreshLocal()` is required.