### PR TITLE
fix - Fallback to /tmp/ when named pipe is too long

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/NamedPipeStream.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/NamedPipeStream.java
@@ -128,7 +128,8 @@ public class NamedPipeStream {
                 randomLength = Math.min(limit - tmpDir.length() - fixedLength, randomLength);
             }
             if (randomLength < 16) {
-                throw new NamedPipeConnectionException("Unable to generate a random pipe name with character length less than 16");
+                tmpDir = "/tmp/";
+                JavaLanguageServerPlugin.logInfo("length of random pipe name too long, using /tmp/ as tmpDir");
             }
 
             String randomSuffix = generateRandomHex(randomLength/2);

--- a/extension/src/util/generateRandomPipeName.ts
+++ b/extension/src/util/generateRandomPipeName.ts
@@ -19,13 +19,16 @@ function generateRandomPipeName(): string {
 
     let randomLength = 32;
     const fixedLength = ".sock".length;
-    const tmpDir: string = fs.realpathSync(XDG_RUNTIME_DIR ?? os.tmpdir());
+    let tmpDir: string = fs.realpathSync(XDG_RUNTIME_DIR ?? os.tmpdir());
     const limit = safeIpcPathLengths.get(process.platform);
     if (limit !== undefined) {
         randomLength = Math.min(limit - tmpDir.length - fixedLength, randomLength);
     }
     if (randomLength < 16) {
-        throw new Error(`Unable to generate a random pipe name with ${randomLength} characters.`);
+        sendInfo("", {
+            kind: "tempDirTooLongWhenGenerateRandomPipeName",
+        });
+        tmpDir = "/tmp/";
     }
 
     const randomSuffix = randomBytes(Math.floor(randomLength / 2)).toString("hex");


### PR DESCRIPTION
Instead of throwing an exception when the named pipe is too long, creating it in the /tmp folder