### PR TITLE
Gradle project view keeps project hierarchy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           JAVA_HOME: ""
           NODE_OPTIONS: "--max-old-space-size=4096"
       - name: Upload lib
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: lib
           path: |
@@ -93,7 +93,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-vscode-
       - name: Download lib
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: lib
           path: extension/

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target
@@ -22,11 +22,11 @@
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/eclipse/updates/4.33-I-builds/I20240613-1800/"/>
+            <repository location="https://download.eclipse.org/eclipse/updates/4.33/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.xtext.xbase.lib" version="0.0.0"/>
-            <repository location="https://download.eclipse.org/releases/2024-03/"/>
+            <repository location="https://download.eclipse.org/releases/2024-09/"/>
         </location>
         <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
             <unit id="org.eclipse.jdt.ls.core" version="0.0.0"/>

--- a/extension/src/views/defaultProject/DefaultProjectsTreeDataProvider.ts
+++ b/extension/src/views/defaultProject/DefaultProjectsTreeDataProvider.ts
@@ -55,7 +55,7 @@ export class DefaultProjectsTreeDataProvider implements vscode.TreeDataProvider<
 
     private async getChildrenForProjectTreeItem(element: ProjectTreeItem): Promise<vscode.TreeItem[]> {
         const projectTaskItem = new ProjectTaskTreeItem("Tasks", vscode.TreeItemCollapsibleState.Collapsed, element);
-        projectTaskItem.setChildren([...element.groups, ...element.tasks]);
+        projectTaskItem.setChildren([...element.tasks, ...element.groups]);
         const results: vscode.TreeItem[] = [projectTaskItem];
         const resourceUri = element.resourceUri;
         if (!resourceUri) {
@@ -68,6 +68,6 @@ export class DefaultProjectsTreeDataProvider implements vscode.TreeDataProvider<
             path.dirname(resourceUri.fsPath),
             typeof element.label === "string" ? element.label : resourceUri.fsPath
         );
-        return [...results, projectDependencyTreeItem];
+        return [projectDependencyTreeItem, ...results];
     }
 }

--- a/extension/src/views/gradleTasks/TreeItemWithTasksOrGroups.ts
+++ b/extension/src/views/gradleTasks/TreeItemWithTasksOrGroups.ts
@@ -1,11 +1,12 @@
 import * as vscode from "vscode";
-import { GradleTaskTreeItem } from ".";
+import { GradleTaskTreeItem, ProjectTreeItem } from ".";
 import { GroupTreeItem } from "..";
 import { treeItemSortCompareFunc, gradleTaskTreeItemSortCompareFunc } from "../viewUtil";
 
 export class TreeItemWithTasksOrGroups extends vscode.TreeItem {
     private readonly _tasks: GradleTaskTreeItem[] = [];
     private readonly _groups: GroupTreeItem[] = [];
+    private readonly _subprojects: ProjectTreeItem[] = [];
     public readonly parentTreeItem?: vscode.TreeItem;
     public readonly iconPath = new vscode.ThemeIcon("file-submodule");
     public readonly contextValue = "folder";
@@ -34,5 +35,13 @@ export class TreeItemWithTasksOrGroups extends vscode.TreeItem {
 
     public get groups(): GroupTreeItem[] {
         return this._groups.sort(treeItemSortCompareFunc);
+    }
+
+    public get subprojects(): ProjectTreeItem[] {
+        return this._subprojects;
+    }
+
+    public addSubproject(subproject: ProjectTreeItem): void {
+        this._subprojects.push(subproject);
     }
 }


### PR DESCRIPTION
Implements #945 by parsing the project path which is found in the `definition.script` property. The project path, which is unique for every subproject, is then used as key in the `projectTreeItemMap`.