### PR TITLE
Add root project folder to each key in projectTreeItemMap

### DIFF
--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -254,13 +254,14 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
                 }
 
                 const projectPath = definition.script.split(":").slice(0, -1);
-                let projectTreeItem = projectTreeItemMap.get(projectPath.join(":"));
+                const projectMapKey = definition.projectFolder + "_" + projectPath.join(":");
+                let projectTreeItem = projectTreeItemMap.get(projectMapKey);
                 if (!projectTreeItem) {
                     const parentProjectPath = projectPath.length == 0 ? null : projectPath.slice(0, -1);
                     const parentProject =
                         parentProjectPath === null
                             ? gradleProjectTreeItem
-                            : projectTreeItemMap.get(parentProjectPath.join(":"));
+                            : projectTreeItemMap.get(definition.projectFolder + "_" + parentProjectPath.join(":"));
                     projectTreeItem = new ProjectTreeItem(
                         definition.project,
                         parentProject,
@@ -271,7 +272,7 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
                     } else {
                         gradleProjectTreeItem.addProject(projectTreeItem);
                     }
-                    projectTreeItemMap.set(projectPath.join(":"), projectTreeItem);
+                    projectTreeItemMap.set(projectMapKey, projectTreeItem);
                 }
 
                 const taskName = definition.script.slice(definition.script.lastIndexOf(":") + 1);


### PR DESCRIPTION
In #1612, the keys of this map were changed to the Gradle project path. This path is unique for each project within one Gradle build, but not if there are multiple Gradle builds loaded in one workspace by using: `'gradle.nestedProjects': true`

This change combined the old and new behavior by creating the Map key from two parts:
1. The root project folder which uniquely identifies the build (accessible via definition.projectFolder)
2. The Gradle project path that uniquely identifies a project inside the build

Fixes #1614 by adjusting a change made in #1612