### PR TITLE
Discover Gradle builds by looking for setting.gradle(.kts)

### DIFF
--- a/extension/src/stores/RootProjectsStore.ts
+++ b/extension/src/stores/RootProjectsStore.ts
@@ -7,7 +7,7 @@ import { RootProject } from "../rootProject/RootProject";
 import { GRADLE_BUILD_FILE_NAMES } from "../constant";
 
 async function getNestedRootProjectFolders(): Promise<string[]> {
-    const matchingNestedWrapperFiles = await vscode.workspace.findFiles("**/{gradlew,gradlew.bat}");
+    const matchingNestedWrapperFiles = await vscode.workspace.findFiles("**/{settings.gradle,settings.gradle.kts}");
     return [...new Set(matchingNestedWrapperFiles.map((uri) => path.dirname(uri.fsPath)))];
 }
 

--- a/extension/src/test/testUtil.ts
+++ b/extension/src/test/testUtil.ts
@@ -86,13 +86,13 @@ export function stubWorkspaceFolders(workspaceFolders: vscode.WorkspaceFolder[])
     const getWorkspaceFolderStub = sinon.stub(vscode.workspace, "getWorkspaceFolder");
     const dirnameStub = sinon.stub(path, "dirname");
     workspaceFolders.forEach((workspaceFolder) => {
-        existsSyncStub.withArgs(path.join(workspaceFolder.uri.fsPath, "gradlew")).returns(true);
+        existsSyncStub.withArgs(path.join(workspaceFolder.uri.fsPath, "settings.gradle")).returns(true);
         getWorkspaceFolderStub.withArgs(sinon.match.has("fsPath", workspaceFolder.uri.fsPath)).returns(workspaceFolder);
         dirnameStub.withArgs(workspaceFolder.uri.fsPath).returns(workspaceFolder.uri.fsPath);
     });
     sinon
         .stub(vscode.workspace, "findFiles")
-        .withArgs("**/{gradlew,gradlew.bat}")
+        .withArgs("**/{settings.gradle,settings.gradle.kts}")
         .returns(Promise.resolve(workspaceFolders.map((folder) => folder.uri)));
 }
 

--- a/extension/src/util/index.ts
+++ b/extension/src/util/index.ts
@@ -57,8 +57,8 @@ export function waitOnTcp(host: string, port: number): Promise<void> {
 
 export function isGradleRootProject(rootProject: RootProject): boolean {
     return (
-        fs.existsSync(path.join(rootProject.getProjectUri().fsPath, "gradlew")) ||
-        fs.existsSync(path.join(rootProject.getProjectUri().fsPath, "gradlew.bat"))
+        fs.existsSync(path.join(rootProject.getProjectUri().fsPath, "settings.gradle")) ||
+        fs.existsSync(path.join(rootProject.getProjectUri().fsPath, "settings.gradle.kts"))
     );
 }
 


### PR DESCRIPTION
When the option `gradle.nestedProjects: true` is set, the build roots are currently discovered by looking for the wrapper scripts. These however are completely optional for a build.

But there is one thing each Gradle build definitely needs to have: A `settings.gradle` or `setting.gradle.kts` file.
Gradle itself searches for these files to accept a folder as a Gradle build/project.

This change proposes to check for these files instead of the gradlw scripts.

A good project to test this with is
https://github.com/microsoft/build-server-for-gradle which contains a lot of Gradle builds in the `testProjects` folder.