### PR TITLE
fix - Cannot see Delegate Test to Gradle option in VS Code

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -389,8 +389,9 @@ export class Extension {
 
     private async registerGradleTestRunner(): Promise<void> {
         // To register the Gradle test runner, we need to wait for the Test Runner extension to be activated.
-        // The Test Runner extension is dependent on the Java extension, VS Code has an issue that it doesn't
-        // activate the Java extension before the Test Runner extension if we call testExtension.activate().
+        // The Test Runner extension depends on the Java extension, VS Code has an issue that it doesn't
+        // activate the Java extension before the Test Runner extension if we call activate() for the test extension.
+        // Thus here we need to activate the Java extension first.
         const javaLsExtension = vscode.extensions.getExtension("redhat.java");
         if (!javaLsExtension) {
             return;

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -239,20 +239,7 @@ export class Extension {
     }
 
     private async activate(): Promise<void> {
-        const testExtension = vscode.extensions.getExtension("vscjava.vscode-java-test");
-        if (testExtension) {
-            testExtension.activate().then((api: any) => {
-                if (api) {
-                    const testRunner: GradleTestRunner = this.buildServerController.getGradleTestRunner(api);
-                    api.registerTestProfile("Delegate Test to Gradle", vscode.TestRunProfileKind.Run, testRunner);
-                    api.registerTestProfile(
-                        "Delegate Test to Gradle (Debug)",
-                        vscode.TestRunProfileKind.Debug,
-                        testRunner
-                    );
-                }
-            });
-        }
+        this.registerGradleTestRunner();
         const activated = !!(await this.rootProjectsStore.getProjectRoots()).length;
         if (!this.server.isReady()) {
             await this.server.start();
@@ -398,5 +385,35 @@ export class Extension {
 
     public getApi(): Api {
         return this.api;
+    }
+
+    private async registerGradleTestRunner(): Promise<void> {
+        // To register the Gradle test runner, we need to wait for the Test Runner extension to be activated.
+        // The Test Runner extension is dependent on the Java extension, VS Code has an issue that it doesn't
+        // activate the Java extension before the Test Runner extension if we call testExtension.activate().
+        const javaLsExtension = vscode.extensions.getExtension("redhat.java");
+        if (!javaLsExtension) {
+            return;
+        }
+
+        const javaLsApi = await javaLsExtension.activate();
+        if (!javaLsApi.serverReady) {
+            return;
+        }
+
+        await javaLsApi.serverReady();
+        const testExtension = vscode.extensions.getExtension("vscjava.vscode-java-test");
+        if (testExtension) {
+            const testRunnerApi = await testExtension.activate();
+            if (testRunnerApi) {
+                const testRunner: GradleTestRunner = this.buildServerController.getGradleTestRunner(testRunnerApi);
+                testRunnerApi.registerTestProfile("Delegate Test to Gradle", vscode.TestRunProfileKind.Run, testRunner);
+                testRunnerApi.registerTestProfile(
+                    "Delegate Test to Gradle (Debug)",
+                    vscode.TestRunProfileKind.Debug,
+                    testRunner
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
See: https://github.com/microsoft/vscode-gradle/issues/1606#issuecomment-2461671077

fix #1606 