### PR TITLE
Add support for profiling Gradle tasks

### DIFF
--- a/extension/src/api/Api.ts
+++ b/extension/src/api/Api.ts
@@ -24,6 +24,7 @@ export interface RunBuildOpts {
     onOutput?: (output: Output) => void;
     showOutputColors: boolean;
     cancellationKey?: string;
+    additionalToolOptions?: string;
 }
 
 export interface CancelTaskOpts {
@@ -37,6 +38,12 @@ export interface CancelBuildOpts {
     args?: ReadonlyArray<string>;
     cancellationKey?: string;
 }
+
+export interface ToolOptionsProvider {
+    resolveToolOptions(): Promise<string>;
+}
+
+export let toolOptionsProviders: Array<ToolOptionsProvider> = [];
 
 export class Api {
     constructor(
@@ -69,7 +76,8 @@ export class Api {
             0,
             undefined,
             opts.onOutput,
-            opts.showOutputColors
+            opts.showOutputColors,
+            opts.additionalToolOptions ?? ""
         );
     }
 
@@ -116,5 +124,17 @@ export class Api {
 
     public getLogger(): Logger {
         return logger;
+    }
+
+    public registerToolOptionsProvider(provider: ToolOptionsProvider): vscode.Disposable {
+        toolOptionsProviders.push(provider);
+        return {
+            dispose: () => {
+                const index = toolOptionsProviders.indexOf(provider);
+                if (index !== -1) {
+                    toolOptionsProviders.splice(index, 1);
+                }
+            }
+        };
     }
 }

--- a/extension/src/api/Api.ts
+++ b/extension/src/api/Api.ts
@@ -43,7 +43,7 @@ export interface ToolOptionsProvider {
     resolveToolOptions(): Promise<string>;
 }
 
-export let toolOptionsProviders: Array<ToolOptionsProvider> = [];
+export const toolOptionsProviders: Array<ToolOptionsProvider> = [];
 
 export class Api {
     constructor(
@@ -134,7 +134,7 @@ export class Api {
                 if (index !== -1) {
                     toolOptionsProviders.splice(index, 1);
                 }
-            }
+            },
         };
     }
 }

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -226,8 +226,9 @@ export class TaskServerClient implements vscode.Disposable {
         task?: vscode.Task,
         onOutput?: (output: Output) => void,
         showOutputColors = true,
+        additionalToolOptions: string = "",
         title?: string,
-        location?: vscode.ProgressLocation
+        location?: vscode.ProgressLocation,
     ): Promise<void> {
         await this.waitForConnect();
         this.statusBarItem.hide();
@@ -256,6 +257,7 @@ export class TaskServerClient implements vscode.Disposable {
                 request.setShowOutputColors(showOutputColors);
                 request.setJavaDebugPort(javaDebugPort);
                 request.setInput(input);
+                request.setAdditionalToolOptions(additionalToolOptions);
 
                 if (javaDebugPort > 0) {
                     const workspaceFolder = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(projectFolder));

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -226,9 +226,9 @@ export class TaskServerClient implements vscode.Disposable {
         task?: vscode.Task,
         onOutput?: (output: Output) => void,
         showOutputColors = true,
-        additionalToolOptions: string = "",
+        additionalToolOptions = "",
         title?: string,
-        location?: vscode.ProgressLocation,
+        location?: vscode.ProgressLocation
     ): Promise<void> {
         await this.waitForConnect();
         this.statusBarItem.hide();

--- a/extension/src/commands/CreateProjectCommand.ts
+++ b/extension/src/commands/CreateProjectCommand.ts
@@ -143,8 +143,9 @@ export class CreateProjectCommand extends Command {
             undefined,
             undefined,
             true,
+            "",
             "Create Gradle project",
-            vscode.ProgressLocation.Notification
+            vscode.ProgressLocation.Notification,
         );
     }
 }

--- a/extension/src/commands/CreateProjectCommand.ts
+++ b/extension/src/commands/CreateProjectCommand.ts
@@ -145,7 +145,7 @@ export class CreateProjectCommand extends Command {
             true,
             "",
             "Create Gradle project",
-            vscode.ProgressLocation.Notification,
+            vscode.ProgressLocation.Notification
         );
     }
 }

--- a/extension/src/terminal/GradleRunnerTerminal.ts
+++ b/extension/src/terminal/GradleRunnerTerminal.ts
@@ -95,9 +95,9 @@ export class GradleRunnerTerminal implements vscode.Pseudoterminal {
             if (javaDebugEnabled) {
                 this.startJavaDebug(javaDebugPort);
             }
-            const additionalToolOptions = (await Promise.all(
-                toolOptionsProviders.map(provider => provider.resolveToolOptions())
-            )).join(" ");
+            const additionalToolOptions = (
+                await Promise.all(toolOptionsProviders.map((provider) => provider.resolveToolOptions()))
+            ).join(" ");
 
             const runTask = this.client.runBuild(
                 this.rootProject.getProjectUri().fsPath,

--- a/extension/test-fixtures/tool-options-provider-test-extension/.gitignore
+++ b/extension/test-fixtures/tool-options-provider-test-extension/.gitignore
@@ -1,0 +1,2 @@
+out/
+node_modules/

--- a/extension/test-fixtures/tool-options-provider-test-extension/.vscodeignore
+++ b/extension/test-fixtures/tool-options-provider-test-extension/.vscodeignore
@@ -1,0 +1,7 @@
+.vscode/**
+.vscode-test/**
+src/**
+**/tsconfig.json
+**/eslint.config.mjs
+**/*.map
+**/*.ts

--- a/extension/test-fixtures/tool-options-provider-test-extension/package-lock.json
+++ b/extension/test-fixtures/tool-options-provider-test-extension/package-lock.json
@@ -1,0 +1,40 @@
+{
+  "name": "tooloptionstest",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tooloptionstest",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/vscode": "^1.76.0",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "vscode": "^1.76.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.96.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
+      "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/extension/test-fixtures/tool-options-provider-test-extension/package.json
+++ b/extension/test-fixtures/tool-options-provider-test-extension/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "tooloptionstest",
+  "publisher": "vscjava",
+  "displayName": "Tool options test",
+  "engines": {
+    "vscode": "^1.76.0"
+  },
+  "version": "1.0.0",
+  "main": "./out/extension.js",
+  "activationEvents": [
+     "*"
+  ],
+  "scripts": {
+    "compile": "tsc -p ./"
+  },
+  "devDependencies": {
+    "@types/vscode": "^1.76.0",
+    "typescript": "^5.6.3"
+  },
+  "extensionDependencies": [
+    "vscjava.vscode-gradle"
+  ]
+}

--- a/extension/test-fixtures/tool-options-provider-test-extension/src/extension.ts
+++ b/extension/test-fixtures/tool-options-provider-test-extension/src/extension.ts
@@ -1,0 +1,17 @@
+import * as vscode from "vscode";
+
+export function activate(context: vscode.ExtensionContext) {
+    const extension = vscode.extensions.getExtension("vscjava.vscode-gradle");
+    if (extension) {
+        extension.activate().then((exports) => {
+            console.log(exports);
+            context.subscriptions.push(
+                exports.registerToolOptionsProvider({
+                    async resolveToolOptions(): Promise<string> {
+                        return "-DtoolOptionsTest=true";
+                    },
+                })
+            );
+        });
+    }
+}

--- a/extension/test-fixtures/tool-options-provider-test-extension/tsconfig.json
+++ b/extension/test-fixtures/tool-options-provider-test-extension/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "ES2017",
+		"outDir": "out",
+		"lib": [
+			"ES2017"
+		],
+		"sourceMap": true,
+		"rootDir": "src",
+		"declaration": true,
+		"strict": true
+	}
+}

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/RunBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/RunBuildHandler.java
@@ -62,7 +62,7 @@ public class RunBuildHandler {
 	public void run() {
 		GradleBuildRunner gradleRunner = new GradleBuildRunner(req.getProjectDir(), req.getArgsList(),
 				req.getGradleConfig(), req.getCancellationKey(), req.getShowOutputColors(), req.getJavaDebugPort(),
-				req.getJavaDebugCleanOutputCache());
+				req.getJavaDebugCleanOutputCache(), req.getAdditionalToolOptions());
 		gradleRunner.setProgressListener(progressListener).setStandardOutputStream(standardOutputListener)
 				.setStandardErrorStream(standardErrorListener);
 

--- a/proto/gradle.proto
+++ b/proto/gradle.proto
@@ -76,6 +76,7 @@ message RunBuildRequest {
   string input = 6;
   bool show_output_colors = 7;
   bool java_debug_clean_output_cache = 8;
+  string additional_tool_options = 9;
 }
 
 message RunBuildResult {


### PR DESCRIPTION
JProfiler 15 will add VS Code integration and as part of that effort we would like to support profiling Gradle tasks as well. To accomplish that, we need to add an `-agentpath` VM parameter to a Java invocation that is launcher from the Gradle build.

To allow profilers to add their VM parameters, a `registerToolOptionsProvider` function was added to the API. When a build is run, the VM parameters are queried from all registered tool option providers, concatenated and sent to the Gradle server where they are added to the JAVA_TOOL_OPTIONS along with the debugger VM parameter.