### PR TITLE
Add save participant under its own ID to avoid conflicts.

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/java/builder/BuildStateManager.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/java/builder/BuildStateManager.java
@@ -47,6 +47,7 @@ import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 
 import com.microsoft.gradle.bs.importer.GradleBuildServerProjectNature;
+import com.microsoft.gradle.bs.importer.ImporterPlugin;
 import com.microsoft.java.builder.jdtbuilder.JavaBuilder;
 
 public class BuildStateManager implements ISaveParticipant {
@@ -70,7 +71,7 @@ public class BuildStateManager implements ISaveParticipant {
 
 	public void startup() {
 		try {
-			ResourcesPlugin.getWorkspace().addSaveParticipant(JavaCore.PLUGIN_ID, this);
+			ResourcesPlugin.getWorkspace().addSaveParticipant(ImporterPlugin.PLUGIN_ID, this);
 		} catch (CoreException e) {
 			JavaLanguageServerPlugin.logException("Failed to register save participant", e);
 		}


### PR DESCRIPTION
- See https://github.com/microsoft/vscode-gradle/issues/1441#issuecomment-2683277597 for a more thorough explanation.
- Also see https://github.com/redhat-developer/vscode-java/issues/3904

- 'org.eclipse.jdt.core' has its own save participant which fails to run and produces "symptoms" like re-indexing all libraries on every project import

CC'ing @jdneo , @Eskibear for a better idea if this seems reasonable. From my testing, this improve performance by avoiding re-indexing all libraries every time.