### PR TITLE
Fix SchemaStore links to use `www.schemastore.org`

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "$schema": "https://www.schemastore.org/component-detection-manifest.json",
   "Registrations": [
     {
       "Component": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -875,7 +875,7 @@
     "jsonValidation": [
       {
         "fileMatch": "package.json",
-        "url": "https://schemastore.azurewebsites.net/schemas/json/package.json"
+        "url": "https://www.schemastore.org/package.json"
       }
     ],
     "taskDefinitions": [


### PR DESCRIPTION
A day or so ago, SchemaStore moved to use GitHub pages for hosting to improve reliability. As a side-effect, redirects from `https://schemastore.azurewebsites.net/*` were temporarily broken. In the meantime until that is resolved, I sent this PR to fix the URLs to use the recommended domains/subdomains.

EDIT: The redirect has been fixed.

Closes #1673
Related: https://github.com/microsoft/vscode/issues/250824