### PR TITLE
Fix various NPEs caused by dynamically computed method calls

### DIFF
--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/CompletionVisitor.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/CompletionVisitor.java
@@ -104,13 +104,14 @@ public class CompletionVisitor extends ClassCodeVisitorSupport {
 	@Override
 	public void visitMethodCallExpression(MethodCallExpression node) {
 		this.methodCalls.get(this.currentUri).add(node);
-		if (node.getMethodAsString().equals("dependencies")) {
+		String methodName = node.getMethodAsString();
+		if ("dependencies".equals(methodName)) {
 			this.dependencies.get(this.currentUri).addAll(getDependencies(node));
-		} else if (node.getMethodAsString().equals("plugins")) {
+		} else if ("plugins".equals(methodName)) {
 			// match plugins { id: ${id} }
 			List<String> plugins = getPluginFromPlugins(node);
 			this.plugins.get(this.currentUri).addAll(plugins);
-		} else if (node.getMethodAsString().equals("apply")) {
+		} else if ("apply".equals(methodName)) {
 			// match apply plugins: '${id}'
 			String plugin = getPluginFromApply(node);
 			if (plugin != null) {
@@ -203,7 +204,7 @@ public class CompletionVisitor extends ClassCodeVisitorSupport {
 		if (argument instanceof ArgumentListExpression) {
 			List<Expression> expressions = ((ArgumentListExpression) argument).getExpressions();
 			for (Expression expression : expressions) {
-				if (expression instanceof ConstantExpression && node.getMethodAsString().equals("id")) {
+				if (expression instanceof ConstantExpression && "id".equals(node.getMethodAsString())) {
 					results.add(expression.getText());
 				} else if (expression instanceof ClosureExpression) {
 					Statement code = ((ClosureExpression) expression).getCode();

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
@@ -131,7 +131,7 @@ public class DocumentSymbolVisitor {
 				builder.append(objectText);
 				builder.append(".");
 			}
-			builder.append(expression.getMethodAsString());
+			builder.append(expression.getMethod().getText());
 			Expression arguments = expression.getArguments();
 			if (arguments instanceof ArgumentListExpression) {
 				List<Expression> expressions = ((ArgumentListExpression) arguments).getExpressions();
@@ -149,7 +149,7 @@ public class DocumentSymbolVisitor {
 			StringBuilder builder = new StringBuilder();
 			builder.append(getSymbolName((PropertyExpression) objectExpression));
 			builder.append(".");
-			builder.append(expression.getMethodAsString());
+			builder.append(expression.getMethod().getText());
 			return builder.toString();
 		}
 		return null;
@@ -205,23 +205,21 @@ public class DocumentSymbolVisitor {
 
 	private List<DocumentSymbol> getDependencies(MethodCallExpression expression) {
 		Expression argument = expression.getArguments();
-		String name = expression.getMethodAsString();
+		String name = expression.getMethod().getText();
 		if ("dependencies".equals(name)) {
 			return getDependencies((ArgumentListExpression) argument);
 		}
 		List<DocumentSymbol> results = new ArrayList<>();
-		if (name != null) { // avoid NPE in case of dynamic method calls
-			DocumentSymbol symbol = new DocumentSymbol();
-			symbol.setName(name);
-			String detail = getDetail(expression);
-			if (detail != null) {
-				symbol.setDetail(detail);
-			}
-			symbol.setKind(SymbolKind.Constant);
-			symbol.setRange(LSPUtils.toRange(expression));
-			symbol.setSelectionRange(LSPUtils.toRange(expression));
-			results.add(symbol);
+		DocumentSymbol symbol = new DocumentSymbol();
+		symbol.setName(name);
+		String detail = getDetail(expression);
+		if (detail != null) {
+			symbol.setDetail(detail);
 		}
+		symbol.setKind(SymbolKind.Constant);
+		symbol.setRange(LSPUtils.toRange(expression));
+		symbol.setSelectionRange(LSPUtils.toRange(expression));
+		results.add(symbol);
 		return results;
 	}
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
@@ -205,21 +205,23 @@ public class DocumentSymbolVisitor {
 
 	private List<DocumentSymbol> getDependencies(MethodCallExpression expression) {
 		Expression argument = expression.getArguments();
-		if ("dependencies".equals(expression.getMethodAsString())) {
+		String name = expression.getMethodAsString();
+		if ("dependencies".equals(name)) {
 			return getDependencies((ArgumentListExpression) argument);
 		}
 		List<DocumentSymbol> results = new ArrayList<>();
-		DocumentSymbol symbol = new DocumentSymbol();
-		String name = expression.getMethodAsString();
-		symbol.setName(name);
-		String detail = getDetail(expression);
-		if (detail != null) {
-			symbol.setDetail(detail);
+		if (name != null) { // avoid NPE in case of dynamic method calls
+			DocumentSymbol symbol = new DocumentSymbol();
+			symbol.setName(name);
+			String detail = getDetail(expression);
+			if (detail != null) {
+				symbol.setDetail(detail);
+			}
+			symbol.setKind(SymbolKind.Constant);
+			symbol.setRange(LSPUtils.toRange(expression));
+			symbol.setSelectionRange(LSPUtils.toRange(expression));
+			results.add(symbol);
 		}
-		symbol.setKind(SymbolKind.Constant);
-		symbol.setRange(LSPUtils.toRange(expression));
-		symbol.setSelectionRange(LSPUtils.toRange(expression));
-		results.add(symbol);
 		return results;
 	}
 

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/compile/DocumentSymbolVisitor.java
@@ -113,7 +113,7 @@ public class DocumentSymbolVisitor {
 		}
 		symbol.setSelectionRange(LSPUtils.toRange(expression));
 		symbol.setRange(LSPUtils.toRange(expression));
-		if (expression.getMethodAsString().equals("dependencies")) {
+		if ("dependencies".equals(expression.getMethodAsString())) {
 			List<DocumentSymbol> dependencySymbols = getDependencies(expression);
 			symbol.setChildren(dependencySymbols);
 			this.dependencies.get(currentUri).addAll(dependencySymbols);
@@ -205,7 +205,7 @@ public class DocumentSymbolVisitor {
 
 	private List<DocumentSymbol> getDependencies(MethodCallExpression expression) {
 		Expression argument = expression.getArguments();
-		if (expression.getMethodAsString().equals("dependencies")) {
+		if ("dependencies".equals(expression.getMethodAsString())) {
 			return getDependencies((ArgumentListExpression) argument);
 		}
 		List<DocumentSymbol> results = new ArrayList<>();

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/CompletionHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/CompletionHandler.java
@@ -49,6 +49,9 @@ public class CompletionHandler {
 			results.addAll(getCompletionItemsFromExtClosures(resolver, projectPath, resultSet));
 		} else {
 			String methodName = containingCall.getMethodAsString();
+			if (methodName == null) {
+				return Collections.emptyList();
+			}
 			List<CompletionItem> re = getCompletionItemsFromExtClosures(resolver, projectPath, methodName, resultSet);
 			results.addAll(re);
 			List<String> delegates = GradleDelegate.getDelegateMap().get(methodName);


### PR DESCRIPTION
Groovy method calls where the method name is an interpolated string (for example `"${foo}"(...)`) are currently causing NPEs in various places. Autocompletion doesn't work in the entire file when such a call is used anywhere in a build.gradle file. The problem is that "MethodCallExpression.getMethodAsString()" returns null for these dynamic method calls.

I have mostly moved constant strings to the front of equals comparisons to avoid the NPEs. In some cases I have replaced "getMethodAsString()" by "getMethod().getText()", which is not null.

This fixes #1562.