### PR TITLE
Fix: Gradle local installation should invoke <gradle.home>/bin/gradle(.bat)

### DIFF
--- a/extension/src/views/gradleDaemons/services/GradleLocalInstallation.ts
+++ b/extension/src/views/gradleDaemons/services/GradleLocalInstallation.ts
@@ -2,12 +2,15 @@ import { GradleExecution } from "./GradleExecution";
 import { execAsync } from "../../../util/execAsync";
 import { getConfigJavaImportGradleJavaHome } from "../../../util/config";
 import { logger } from "../../../logger";
+import * as path from "path";
 
 export class GradleLocalInstallation implements GradleExecution {
-    private gradleHomePath: string;
+    private gradleExecPath: string;
 
     constructor(gradleHomePath: string) {
-        this.gradleHomePath = `"${gradleHomePath}"`;
+        const exeName = process.platform === "win32" ? "gradle.bat" : "gradle";
+        // Resolve the executable inside the Gradle home "bin" directory.
+        this.gradleExecPath = `"${path.join(gradleHomePath, "bin", exeName)}"`;
     }
 
     public async exec(args: string[]): Promise<string> {
@@ -16,7 +19,7 @@ export class GradleLocalInstallation implements GradleExecution {
         }
 
         const quotedArgs = args.map((arg) => `"${arg}"`).join(" ");
-        const command = `${this.gradleHomePath} ${quotedArgs}`;
+        const command = `${this.gradleExecPath} ${quotedArgs}`;
 
         try {
             const jdkPath = getConfigJavaImportGradleJavaHome();


### PR DESCRIPTION
## Summary
When `java.import.gradle.wrapper.enabled` is false and `java.import.gradle.home` is set, the Gradle daemons view attempted to execute the `gradle.home` directory path directly. On Windows this raised errors like:

> "C:\\ktapp\\gradle" is not recognized as an internal or external command

This PR resolves the Gradle executable from `<gradle.home>/bin/gradle(.bat)` and executes that instead.

## Changes
- extension/src/views/gradleDaemons/services/GradleLocalInstallation.ts
  - Build the executable path as `<gradle.home>/bin/gradle(.bat)` (Windows uses `gradle.bat`, others `gradle`).
  - Keep existing `JAVA_HOME` env propagation.

## Rationale
- Matches how the Gradle wrapper path is constructed in `GradleWrapper`.
- Fixes #1613 and aligns with the maintainer’s guidance to find the executable inside the Gradle home folder.

## Test Plan
- On Windows with a local Gradle install:
  - Set `java.import.gradle.home` to the Gradle installation directory.
  - Set `java.import.gradle.wrapper.enabled` to false.
  - Open the Gradle Daemons view; it should run `--status` via `<gradle.home>\bin\gradle.bat` successfully (no error notification).

Fixes #1613