### PR TITLE
fix: increase JAXP limits

### DIFF
--- a/extension/build.gradle
+++ b/extension/build.gradle
@@ -200,6 +200,7 @@ task prepareForBetaRelease() {
 
 task buildJdtlsPlugin(type: CrossPlatformExec) {
   workingDir file('./jdtls.ext')
+  environment 'MAVEN_OPTS', '-Djdk.xml.totalEntitySizeLimit=1000000 -Djdk.xml.maxGeneralEntitySizeLimit=1000000'
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     commandLine 'mvnw', 'clean', 'package'
   } else {

--- a/extension/build.gradle
+++ b/extension/build.gradle
@@ -200,7 +200,7 @@ task prepareForBetaRelease() {
 
 task buildJdtlsPlugin(type: CrossPlatformExec) {
   workingDir file('./jdtls.ext')
-  environment 'MAVEN_OPTS', '-Djdk.xml.totalEntitySizeLimit=1000000 -Djdk.xml.maxGeneralEntitySizeLimit=1000000'
+  environment 'MAVEN_OPTS', '-Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.maxGeneralEntitySizeLimit=0'
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     commandLine 'mvnw', 'clean', 'package'
   } else {


### PR DESCRIPTION
Fix the below errors when using Java 24+ to build the project:

[ERROR] Failed to resolve target definition file:/C:/Users/chagon/dev/java/vscode-gradle/extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target: Failed to load p2 metadata repository from location https://download.eclipse.org/releases/2025-03/: Unable to read repository at https://download.eclipse.org/releases/2025-03. Unable to read repository at file:/C:/Users/chagon/.m2/repository/.cache/tycho/https/download.eclipse.org/releases/2025-03/202503121000/content.xml.xz. JAXP00010003: The length of entity "[xml]" is "100,001" that exceeds the "100,000" limit set by "jdk.xml.maxGeneralEntitySizeLimit".