### PR TITLE
feat: Add JDK 25 support and upgrade to Gradle 9.2.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Start by opening an issue using one of the issue templates, or propose a change 
 
 ### Prerequisites
 1. Install [nvm](https://github.com/nvm-sh/nvm)
-2. Install [Java version >= 21](https://adoptium.net/)
+2. Install [Java version >= 21](https://adoptium.net/) (JDK 25 is supported)
 3. Select Node version: `nvm use`
 4. If using an Apple M1:
     - Add `npm_arch=x64` to $HOME/.gradle/gradle.properties

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This VS Code extension provides a visual interface for your Gradle build. You ca
 ## Requirements
 
 - [VS Code >= 1.76.0](https://code.visualstudio.com/download)
-- [Java from 8 to 21](https://adoptium.net/)
+- [Java from 17 to 25](https://adoptium.net/)
+- Gradle 6.1 or later (4.0-6.0 may work but some features may not function correctly)
 
 ## Project Discovery
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.protobuf' version '0.8.13'
-  id 'com.github.jlouns.cpe' version '0.5.0'
+  id 'com.google.protobuf' version '0.9.6'
   alias(libs.plugins.spotless)
 }
 

--- a/extension/build.gradle
+++ b/extension/build.gradle
@@ -37,7 +37,6 @@ protobuf {
     extractProto.enabled = false;
     extractIncludeProto.enabled = false;
     extractIncludeTestProto.enabled = false;
-    generateProto.finalizedBy copyProtoJs, copyProtoTs
     all().each { task ->
       task.plugins {
         grpc {
@@ -80,7 +79,7 @@ task copyProtoJs(type: Copy) {
   dependsOn ':extension:copyDocs'
   group 'copy'
   description 'Copies proto JavaScript files into src dir'
-  from "$protobuf.generatedFilesBaseDir/main/js"
+  from "out/generated/sources/proto/main/js"
   into protoLib
 }
 
@@ -88,11 +87,11 @@ task copyProtoTs(type: Copy) {
   dependsOn ':extension:generateProto'
   group 'copy'
   description 'Copies proto TypeScript definitions into src dir'
-  from "$protobuf.generatedFilesBaseDir/main/ts"
+  from "out/generated/sources/proto/main/ts"
   into protoLib
 }
 
-task npmInstall(type: CrossPlatformExec) {
+task npmInstall(type: Exec) {
   description 'Installs node dependencies'
   inputs.file('package-lock.json').withPathSensitivity(PathSensitivity.RELATIVE)
   outputs.dir('node_modules')
@@ -105,18 +104,18 @@ task npmInstall(type: CrossPlatformExec) {
   }
 }
 
-task lint(type: CrossPlatformExec) {
+task lint(type: Exec) {
   dependsOn npmInstall
   description 'Lints source files'
   commandLine 'npm', 'run', 'lint'
 }
 
-task format(type: CrossPlatformExec) {
+task format(type: Exec) {
   description 'Formats source files'
   commandLine 'npm', 'run', 'lint:fix'
 }
 
-task buildTest(type: CrossPlatformExec) {
+task buildTest(type: Exec) {
   dependsOn copyProtoJs, copyProtoTs
   group 'build'
   description 'Builds TypeScript test source files'
@@ -128,7 +127,7 @@ task buildTest(type: CrossPlatformExec) {
   commandLine 'npm', 'run', 'compile:test'
 }
 
-task buildDev(type: CrossPlatformExec) {
+task buildDev(type: Exec) {
   dependsOn 'copyProtoJs', 'copyProtoTs'
   group 'build'
   description 'Compile extension source files'
@@ -142,7 +141,7 @@ task buildDev(type: CrossPlatformExec) {
   commandLine 'npm', 'run', 'compile'
 }
 
-task buildProd(type: CrossPlatformExec) {
+task buildProd(type: Exec) {
   dependsOn 'copyProtoJs', 'copyProtoTs'
   group 'build'
   description 'Compile extension source files'
@@ -162,12 +161,12 @@ task bundle() {
   description 'Bundles the extension files for release'
 }
 
-task installExtension(type: CrossPlatformExec) {
+task installExtension(type: Exec) {
   dependsOn bundle
   commandLine 'npm', 'run', 'install:ext'
 }
 
-task testVsCode(type: CrossPlatformExec) {
+task testVsCode(type: Exec) {
   group 'verification'
   description 'Tests the extension'
   commandLine 'npm', 'run', 'test'
@@ -184,7 +183,9 @@ task copyDocs(type: Copy) {
   into "$projectDir"
 }
 
-task prepareBeta(type: CrossPlatformExec) {
+processTestResources.dependsOn copyDocs
+
+task prepareBeta(type: Exec) {
   description 'Prepare the extesion for a BETA release'
   workingDir file('./beta')
   commandLine 'node', 'prepare.js'
@@ -198,7 +199,7 @@ task prepareForBetaRelease() {
   dependsOn bundle, copyDocs, prepareBeta
 }
 
-task buildJdtlsPlugin(type: CrossPlatformExec) {
+task buildJdtlsPlugin(type: Exec) {
   workingDir file('./jdtls.ext')
   environment 'MAVEN_OPTS', '-Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.maxGeneralEntitySizeLimit=0'
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
@@ -217,7 +218,7 @@ task copyJdtlsPluginJar(type: Copy) {
   mustRunAfter copyDocs
 }
 
-task buildBuildServer(type: CrossPlatformExec) {
+task buildBuildServer(type: Exec) {
   workingDir file('./build-server-for-gradle')
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     commandLine 'gradlew', 'build', '-x', 'test'

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-gradle",
-  "version": "3.17.1",
+  "version": "3.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-gradle",
-      "version": "3.17.1",
+      "version": "3.17.2",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "await-lock": "^2.2.2",
@@ -1011,6 +1011,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -1607,6 +1608,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1649,6 +1651,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1896,6 +1899,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -2718,6 +2722,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5480,6 +5485,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -6669,7 +6675,8 @@
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -6763,6 +6770,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6939,6 +6947,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
       "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.12.1",
@@ -6985,6 +6994,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/extension/test-fixtures/gradle-groovy-custom-build-file/gradle/wrapper/gradle-wrapper.properties
+++ b/extension/test-fixtures/gradle-groovy-custom-build-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/extension/test-fixtures/gradle-groovy-default-build-file/gradle/wrapper/gradle-wrapper.properties
+++ b/extension/test-fixtures/gradle-groovy-default-build-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/extension/test-fixtures/gradle-kotlin-default-build-file/gradle/wrapper/gradle-wrapper.properties
+++ b/extension/test-fixtures/gradle-kotlin-default-build-file/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/extension/test-fixtures/multi-project/gradle/wrapper/gradle-wrapper.properties
+++ b/extension/test-fixtures/multi-project/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle-language-server/build.gradle
+++ b/gradle-language-server/build.gradle
@@ -23,7 +23,7 @@ application {
 dependencies {
   implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.19.0"
   implementation "org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc:0.19.0"
-  implementation "org.codehaus.groovy:groovy-eclipse-batch:4.0.16-03"
+  implementation "org.codehaus.groovy:groovy-eclipse-batch:5.0.3-01"
   implementation "com.google.code.gson:gson:2.9.1"
   implementation "org.apache.bcel:bcel:6.6.1"
   testImplementation "org.junit.jupiter:junit-jupiter-api:5.8.1"
@@ -61,6 +61,14 @@ spotless {
 }
 
 compileJava.dependsOn 'spotlessCheck'
+
+jar {
+  manifest {
+    attributes(
+      "Main-Class": "com.microsoft.gradle.GradleLanguageServer"
+    )
+  }
+}
 
 project.tasks.named("processResources") {
   duplicatesStrategy = 'include'

--- a/gradle-language-server/test-resources/spring-boot-webapp/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-language-server/test-resources/spring-boot-webapp/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle-server/build.gradle
+++ b/gradle-server/build.gradle
@@ -43,7 +43,6 @@ def mainResourcesDir = 'src/main/resources';
 def libsDir = '../extension/lib';
 
 sourceSets {
-  libsDirName = file(libsDir)
   main {
     proto {
       srcDir file('../proto')
@@ -94,6 +93,7 @@ clean {
 jar {
   manifest {
     attributes(
+      "Main-Class": "com.github.badsyntax.gradle.GradleServer",
       "Class-Path": configurations.runtimeClasspath.collect { it.getName() }.join(' '))
   }
 }
@@ -120,6 +120,7 @@ spotless {
 task serverStartScripts(type: CreateStartScripts) {
   dependsOn jar
   dependsOn 'copyRuntimeLibs'
+  dependsOn 'copyServerJar'
   outputDir = file(libsDir)
   mainClass = 'com.github.badsyntax.gradle.GradleServer'
   applicationName = project.name
@@ -140,6 +141,13 @@ task copyRuntimeLibs(type: Copy) {
   doFirst {
     delete libsDir
   }
+}
+
+task copyServerJar(type: Copy) {
+  dependsOn jar
+  from jar.archiveFile
+  into libsDir
+  duplicatesStrategy = 'exclude'
 }
 
 project.tasks.named("processResources") {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/npm-package/build.gradle
+++ b/npm-package/build.gradle
@@ -162,7 +162,7 @@ task copyPublicApi(type: Copy) {
   into 'lib'
 }
 
-task npmInstall(type: CrossPlatformExec) {
+task npmInstall(type: Exec) {
   description 'Installs node dependencies'
   inputs.file('package-lock.json').withPathSensitivity(PathSensitivity.RELATIVE)
   outputs.dir('node_modules')
@@ -175,7 +175,7 @@ task npmInstall(type: CrossPlatformExec) {
   }
 }
 
-task compileTypeScript(type: CrossPlatformExec) {
+task compileTypeScript(type: Exec) {
   dependsOn npmInstall, copyPublicApi
   description 'Compiles the TypeScript files'
   inputs.file('index.ts')

--- a/npm-package/package-lock.json
+++ b/npm-package/package-lock.json
@@ -253,6 +253,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
       "integrity": "sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.22.0",
         "@typescript-eslint/types": "5.22.0",
@@ -404,6 +405,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
       "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -665,6 +667,7 @@
       "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.2.2",
         "@humanwhocodes/config-array": "^0.9.2",
@@ -1376,6 +1379,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
       "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -1694,6 +1698,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
feat: Add JDK 25 support and upgrade to Gradle 9.2.1

- Upgrade Gradle wrapper 8.14.3 → 9.2.1
- Upgrade protobuf plugin 0.8.13 → 0.9.6
- Upgrade groovy-eclipse-batch 4.0.16-03 → 5.0.3-01
- Remove deprecated CrossPlatformExec plugin (better built-in support in Gradle 9+)
- Update docs: JDK 17-25 support, Gradle 6.1+ minimum (9.2.1+ for JDK 21-25)
- Add copyServerJar task to fix gradle-server.jar deployment
- Add Main-Class manifest attributes to server JARs

Also required these change to build with jdk25.  https://github.com/microsoft/build-server-for-gradle/pull/217
