### PR TITLE
Add 'needs more info' issue label

### DIFF
--- a/.github/llms.md
+++ b/.github/llms.md
@@ -35,4 +35,5 @@ When labeling an issue, follow the rules below per label category:
 - [bug]: Primary label for real bug issues 
 - [enhancement]: Primary label for enhancement issues 
 - [documentation]: Primary label for documentation issues 
-- [question]: Primary label for question issues 
+- [question]: Primary label for question issues
+- [needs more info]: Apply when the issue lacks sufficient information for proper triage or resolution. Use this label when the issue description is too vague or ambiguous to understand the problem


### PR DESCRIPTION
Added 'needs more info' label for issues lacking details.