### PR TITLE
Feat: Support for vscode settings expansions like ${workspaceFolder}

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -18,7 +18,8 @@
         "string-argv": "^0.3.1",
         "tree-kill": "^1.2.2",
         "vscode-extension-telemetry-wrapper": "0.14.0",
-        "vscode-languageclient": "7.0.0"
+        "vscode-languageclient": "7.0.0",
+        "vscode-variables": "^1.0.1"
       },
       "devDependencies": {
         "@grpc/grpc-js": "^1.8.22",
@@ -6822,6 +6823,12 @@
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
+    "node_modules/vscode-variables": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-variables/-/vscode-variables-1.0.1.tgz",
+      "integrity": "sha512-iZ1d08I30ktqv4mMszGz2Y2o53r+PBpF5tEnwf8NNzKoxeuo0thoaFRG98uJkNVhOtiDmH4HJ3KlqfjM6XIxbA==",
+      "license": "MIT"
     },
     "node_modules/watchpack": {
       "version": "2.5.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -986,6 +986,7 @@
   "dependencies": {
     "await-lock": "^2.2.2",
     "jdk-utils": "^0.4.4",
+    "vscode-variables": "^1.0.1",
     "fs-extra": "^11.1.0",
     "get-port": "^5.1.1",
     "lodash": "^4.17.23",

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -6,7 +6,16 @@ import { RootProject } from "../rootProject/RootProject";
 import * as fse from "fs-extra";
 import * as path from "path";
 import { findDefaultRuntimeFromSettings, getMajorVersion, listJdks } from "./jdkUtils";
+const vscodeVariables = require('vscode-variables');
 type AutoDetect = "on" | "off";
+
+export function resolvePathVariables(pathStr: string | null): string | null {
+    if (!pathStr) {
+        return pathStr;
+    }
+    return vscodeVariables(pathStr);
+}
+
 export const REQUIRED_JDK_VERSION = 17;
 
 export function getConfigIsAutoDetectionEnabled(rootProject: RootProject): boolean {
@@ -26,7 +35,7 @@ export function getJdtlsConfigJavaHome(): string | null {
 }
 
 export function getConfigJavaImportGradleJavaHome(): string | null {
-    return vscode.workspace.getConfiguration("java").get<string | null>("import.gradle.java.home", null);
+    return resolvePathVariables(vscode.workspace.getConfiguration("java").get<string | null>("import.gradle.java.home", null));
 }
 
 export function getJavaExecutablePathFromJavaHome(javaHome: string): string {
@@ -105,7 +114,7 @@ export function checkEnvJavaExecutable(): boolean {
 }
 
 export function getConfigJavaImportGradleUserHome(): string | null {
-    return vscode.workspace.getConfiguration("java").get<string | null>("import.gradle.user.home", null);
+    return resolvePathVariables(vscode.workspace.getConfiguration("java").get<string | null>("import.gradle.user.home", null));
 }
 
 export function getConfigJavaImportGradleJvmArguments(): string | null {
@@ -121,7 +130,7 @@ export function getConfigJavaImportGradleVersion(): string | null {
 }
 
 export function getConfigJavaImportGradleHome(): string | null {
-    return vscode.workspace.getConfiguration("java").get<string | null>("import.gradle.home", null);
+    return resolvePathVariables(vscode.workspace.getConfiguration("java").get<string | null>("import.gradle.home", null));
 }
 
 export function getConfigIsDebugEnabled(): boolean {


### PR DESCRIPTION
Allows setting vscode settings with variable substitutions such as:

```json
"java.import.gradle.java.home": "${workspaceFolder}/.vscode/mise-tools/java",
"java.import.gradle.user.home": "${workspaceFolder}/somewhere",
"java.import.gradle.home": "${workspaceFolder}/../../somewhereFarAway",
```

Also supports other substitutions available in [vscode-variables](https://www.npmjs.com/package/vscode-variables) package

PR currently open on [vscode-java](https://github.com/redhat-developer/vscode-java/pull/4376) for same feature