### PR TITLE
Batch BSP calls during import to reduce round-trips from ~4400 to 6

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -304,11 +304,14 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
      */
     public void updateAllClasspaths(BuildServerConnection connection, List<IProject> projects,
             WorkspaceBuildTargetsResult cachedTargets, IProgressMonitor monitor) throws CoreException {
-        // Collect all build targets across all projects
+        // Group all build targets by project URI once (O(T)) instead of
+        // filtering per-project (O(P*T)) for large workspaces.
+        Map<URI, List<BuildTarget>> targetsByProjectUri = Utils.getBuildTargetsMappedByProjectPath(cachedTargets);
         Map<IProject, List<BuildTarget>> projectBuildTargetsMap = new LinkedHashMap<>();
         List<BuildTargetIdentifier> allTargetIds = new ArrayList<>();
         for (IProject project : projects) {
-            List<BuildTarget> buildTargets = Utils.getBuildTargetsByProjectUri(cachedTargets, project.getLocationURI());
+            List<BuildTarget> buildTargets = targetsByProjectUri.getOrDefault(
+                    Utils.getUriWithoutQuery(project.getLocationURI().toString()), Collections.emptyList());
             moveTestTargetsToEnd(buildTargets);
             projectBuildTargetsMap.put(project, buildTargets);
             for (BuildTarget bt : buildTargets) {

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -322,17 +322,33 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
             return;
         }
 
-        // Make batched BSP calls for all targets at once
-        OutputPathsResult allOutputPaths = connection.buildTargetOutputPaths(
+        JavaLanguageServerPlugin.logInfo(String.format(
+            "Updating classpaths for %d projects (%d build targets) using batched BSP calls.",
+            projects.size(), allTargetIds.size()));
+
+        OutputPathsResult allOutputPaths;
+        SourcesResult allSources;
+        ResourcesResult allResources;
+        DependencyModulesResult allDependencyModules;
+        JavacOptionsResult allJavacOptions;
+        try {
+            // Make batched BSP calls for all targets at once.
+            allOutputPaths = connection.buildTargetOutputPaths(
                 new OutputPathsParams(allTargetIds)).join();
-        SourcesResult allSources = connection.buildTargetSources(
+            allSources = connection.buildTargetSources(
                 new SourcesParams(allTargetIds)).join();
-        ResourcesResult allResources = connection.buildTargetResources(
+            allResources = connection.buildTargetResources(
                 new ResourcesParams(allTargetIds)).join();
-        DependencyModulesResult allDependencyModules = connection.buildTargetDependencyModules(
+            allDependencyModules = connection.buildTargetDependencyModules(
                 new DependencyModulesParams(allTargetIds)).join();
-        JavacOptionsResult allJavacOptions = connection.buildTargetJavacOptions(
+            allJavacOptions = connection.buildTargetJavacOptions(
                 new JavacOptionsParams(allTargetIds)).join();
+        } catch (RuntimeException e) {
+            JavaLanguageServerPlugin.logException(String.format(
+                "Failed batched BSP classpath update for %d projects (%d build targets).",
+                projects.size(), allTargetIds.size()), e);
+            throw e;
+        }
 
         // Index results by build target identifier for fast lookup
         Map<String, List<OutputPathsItem>> outputPathsByTarget = new HashMap<>();

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -310,8 +310,7 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
         Map<IProject, List<BuildTarget>> projectBuildTargetsMap = new LinkedHashMap<>();
         List<BuildTargetIdentifier> allTargetIds = new ArrayList<>();
         for (IProject project : projects) {
-            List<BuildTarget> buildTargets = targetsByProjectUri.getOrDefault(
-                    Utils.getUriWithoutQuery(project.getLocationURI().toString()), Collections.emptyList());
+            List<BuildTarget> buildTargets = Utils.getBuildTargetsByProjectUri(targetsByProjectUri, project.getLocationURI());
             moveTestTargetsToEnd(buildTargets);
             projectBuildTargetsMap.put(project, buildTargets);
             for (BuildTarget bt : buildTargets) {
@@ -500,6 +499,9 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
             projectDependencies.addAll(buildTarget.getDependencies());
         }
         IJavaProject javaProject = JavaCore.create(project);
+        if (!javaProject.exists()) {
+            return;
+        }
         IClasspathEntry[] oldClasspath = javaProject.getRawClasspath();
         List<IClasspathEntry> classpath = new LinkedList<>(Arrays.asList(oldClasspath));
         classpath.addAll(getProjectDependencyEntries(project, projectDependencies));

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -71,6 +72,7 @@ import ch.epfl.scala.bsp4j.SourceItem;
 import ch.epfl.scala.bsp4j.SourcesItem;
 import ch.epfl.scala.bsp4j.SourcesParams;
 import ch.epfl.scala.bsp4j.SourcesResult;
+import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 import ch.epfl.scala.bsp4j.extended.JvmBuildTargetEx;
 
 public class GradleBuildServerBuildSupport implements IBuildSupport {
@@ -289,16 +291,207 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
     }
 
     /**
-     * Update the project dependencies of the project.
+     * Update the classpaths of all projects using batched BSP calls. Instead of making
+     * per-target BSP calls (4N calls for N build targets), this method collects all build
+     * target IDs and makes only 4 batched calls total, then distributes the results back
+     * to per-project processing.
+     *
+     * @param connection the build server connection.
+     * @param projects the list of projects to update.
+     * @param cachedTargets the pre-fetched workspace build targets result.
+     * @param monitor the progress monitor.
      * @throws CoreException
      */
-    public void updateProjectDependencies(BuildServerConnection connection, IProject project, IProgressMonitor monitor) throws CoreException {
+    public void updateAllClasspaths(BuildServerConnection connection, List<IProject> projects,
+            WorkspaceBuildTargetsResult cachedTargets, IProgressMonitor monitor) throws CoreException {
+        // Collect all build targets across all projects
+        Map<IProject, List<BuildTarget>> projectBuildTargetsMap = new LinkedHashMap<>();
+        List<BuildTargetIdentifier> allTargetIds = new ArrayList<>();
+        for (IProject project : projects) {
+            List<BuildTarget> buildTargets = Utils.getBuildTargetsByProjectUri(cachedTargets, project.getLocationURI());
+            moveTestTargetsToEnd(buildTargets);
+            projectBuildTargetsMap.put(project, buildTargets);
+            for (BuildTarget bt : buildTargets) {
+                allTargetIds.add(bt.getId());
+            }
+        }
+
+        if (allTargetIds.isEmpty()) {
+            return;
+        }
+
+        // Make batched BSP calls for all targets at once
+        OutputPathsResult allOutputPaths = connection.buildTargetOutputPaths(
+                new OutputPathsParams(allTargetIds)).join();
+        SourcesResult allSources = connection.buildTargetSources(
+                new SourcesParams(allTargetIds)).join();
+        ResourcesResult allResources = connection.buildTargetResources(
+                new ResourcesParams(allTargetIds)).join();
+        DependencyModulesResult allDependencyModules = connection.buildTargetDependencyModules(
+                new DependencyModulesParams(allTargetIds)).join();
+        JavacOptionsResult allJavacOptions = connection.buildTargetJavacOptions(
+                new JavacOptionsParams(allTargetIds)).join();
+
+        // Index results by build target identifier for fast lookup
+        Map<String, List<OutputPathsItem>> outputPathsByTarget = new HashMap<>();
+        for (OutputPathsItem item : allOutputPaths.getItems()) {
+            outputPathsByTarget.computeIfAbsent(item.getTarget().getUri(), k -> new ArrayList<>()).add(item);
+        }
+        Map<String, List<SourcesItem>> sourcesByTarget = new HashMap<>();
+        for (SourcesItem item : allSources.getItems()) {
+            sourcesByTarget.computeIfAbsent(item.getTarget().getUri(), k -> new ArrayList<>()).add(item);
+        }
+        Map<String, List<ResourcesItem>> resourcesByTarget = new HashMap<>();
+        for (ResourcesItem item : allResources.getItems()) {
+            resourcesByTarget.computeIfAbsent(item.getTarget().getUri(), k -> new ArrayList<>()).add(item);
+        }
+        Map<String, List<DependencyModulesItem>> depModulesByTarget = new HashMap<>();
+        for (DependencyModulesItem item : allDependencyModules.getItems()) {
+            depModulesByTarget.computeIfAbsent(item.getTarget().getUri(), k -> new ArrayList<>()).add(item);
+        }
+        Map<String, List<JavacOptionsItem>> javacOptionsByTarget = new HashMap<>();
+        for (JavacOptionsItem item : allJavacOptions.getItems()) {
+            javacOptionsByTarget.computeIfAbsent(item.getTarget().getUri(), k -> new ArrayList<>()).add(item);
+        }
+
+        // Process each project using the pre-fetched, indexed results
+        for (IProject project : projects) {
+            List<BuildTarget> buildTargets = projectBuildTargetsMap.get(project);
+            if (buildTargets == null || buildTargets.isEmpty()) {
+                continue;
+            }
+            updateClasspathFromBatchedResults(project, buildTargets, outputPathsByTarget,
+                    sourcesByTarget, resourcesByTarget, depModulesByTarget, javacOptionsByTarget, monitor);
+        }
+    }
+
+    /**
+     * Update the classpath of a single project using pre-fetched batched BSP results.
+     */
+    private void updateClasspathFromBatchedResults(IProject project, List<BuildTarget> buildTargets,
+            Map<String, List<OutputPathsItem>> outputPathsByTarget,
+            Map<String, List<SourcesItem>> sourcesByTarget,
+            Map<String, List<ResourcesItem>> resourcesByTarget,
+            Map<String, List<DependencyModulesItem>> depModulesByTarget,
+            Map<String, List<JavacOptionsItem>> javacOptionsByTarget,
+            IProgressMonitor monitor) throws CoreException {
         IPath rootPath = ProjectUtils.findBelongedWorkspaceRoot(project.getLocation());
         if (rootPath == null) {
             JavaLanguageServerPlugin.logError("Cannot find workspace root for project: " + project.getName());
             return;
         }
+        Map<IPath, IClasspathEntry> classpathMap = new LinkedHashMap<>();
+
+        for (BuildTarget buildTarget : buildTargets) {
+            boolean isTest = buildTarget.getTags().contains(BuildTargetTag.TEST);
+            String targetUri = buildTarget.getId().getUri();
+
+            // Use pre-fetched output paths
+            List<OutputPathsItem> outputItems = outputPathsByTarget.getOrDefault(targetUri, Collections.emptyList());
+            String sourceOutputUri = getOutputUriByKind(outputItems, OUTPUT_KIND_SOURCE);
+            IPath sourceOutputFullPath = getOutputFullPath(sourceOutputUri, project);
+            if (sourceOutputFullPath == null) {
+                JavaLanguageServerPlugin.logError("Cannot find source output path for build target: " + buildTarget.getId());
+            } else {
+                // Use pre-fetched sources
+                List<SourcesItem> sourcesItems = sourcesByTarget.getOrDefault(targetUri, Collections.emptyList());
+                SourcesResult sourcesResult = new SourcesResult(sourcesItems);
+                List<IClasspathEntry> sourceEntries = getSourceEntries(rootPath, project, sourcesResult, sourceOutputFullPath, isTest, monitor);
+                for (IClasspathEntry entry : sourceEntries) {
+                    classpathMap.putIfAbsent(entry.getPath(), entry);
+                }
+            }
+
+            String resourceOutputUri = getOutputUriByKind(outputItems, OUTPUT_KIND_RESOURCE);
+            IPath resourceOutputFullPath = getOutputFullPath(resourceOutputUri, project);
+            if (resourceOutputFullPath != null) {
+                // Use pre-fetched resources
+                List<ResourcesItem> resourceItems = resourcesByTarget.getOrDefault(targetUri, Collections.emptyList());
+                ResourcesResult resourcesResult = new ResourcesResult(resourceItems);
+                List<IClasspathEntry> resourceEntries = getResourceEntries(rootPath, project, resourcesResult, resourceOutputFullPath, isTest, monitor);
+                for (IClasspathEntry entry : resourceEntries) {
+                    classpathMap.putIfAbsent(entry.getPath(), entry);
+                }
+            }
+        }
+
+        if (classpathMap.isEmpty()) {
+            return;
+        }
+
+        Utils.addNature(project, JavaCore.NATURE_ID, monitor);
+        IJavaProject javaProject = JavaCore.create(project);
+        javaProject.setOption(JavaCore.CORE_OUTPUT_LOCATION_OVERLAPPING_ANOTHER_SOURCE, "ignore");
+
+        classpathMap = getSourceCpeWithExclusions(new LinkedList<>(classpathMap.values()))
+            .stream()
+            .collect(Collectors.toMap(IClasspathEntry::getPath, Function.identity(), (e1, e2) -> e1, LinkedHashMap::new));
+        IClasspathEntry[] newSourceEntries = classpathMap.values().toArray(new IClasspathEntry[0]);
+        if (!Arrays.equals(javaProject.getRawClasspath(), newSourceEntries)) {
+            javaProject.setRawClasspath(newSourceEntries, monitor);
+        }
+        boolean isModular = javaProject.getOwnModuleDescription() != null;
+
+        setProjectJdk(classpathMap, buildTargets, javaProject, isModular);
+
+        for (BuildTarget buildTarget : buildTargets) {
+            boolean isTest = buildTarget.getTags().contains(BuildTargetTag.TEST);
+            String targetUri = buildTarget.getId().getUri();
+
+            // Use pre-fetched dependency modules
+            List<DependencyModulesItem> depItems = depModulesByTarget.getOrDefault(targetUri, Collections.emptyList());
+            DependencyModulesResult dependencyModuleResult = new DependencyModulesResult(depItems);
+            List<IClasspathEntry> dependencyEntries = getDependencyJars(dependencyModuleResult, isTest, isModular);
+            for (IClasspathEntry entry : dependencyEntries) {
+                classpathMap.putIfAbsent(entry.getPath(), entry);
+            }
+        }
+
+        IClasspathEntry[] newEntriesWithDeps = classpathMap.values().toArray(new IClasspathEntry[0]);
+        if (!Arrays.equals(javaProject.getRawClasspath(), newEntriesWithDeps)) {
+            javaProject.setRawClasspath(newEntriesWithDeps, monitor);
+        }
+
+        // Process JPMS arguments from pre-fetched javac options
+        List<String> compilerArgs = new LinkedList<>();
+        for (BuildTarget buildTarget : buildTargets) {
+            List<JavacOptionsItem> javacItems = javacOptionsByTarget.getOrDefault(
+                    buildTarget.getId().getUri(), Collections.emptyList());
+            for (JavacOptionsItem item : javacItems) {
+                compilerArgs.addAll(item.getOptions());
+            }
+        }
+
+        JpmsArguments jpmsArgs = JpmsUtils.categorizeJpmsArguments(compilerArgs);
+        if (jpmsArgs.isEmpty()) {
+            return;
+        }
+        JpmsUtils.appendJpmsAttributesToEntries(javaProject, classpathMap, jpmsArgs);
+        IClasspathEntry[] newEntriesWithJpms = classpathMap.values().toArray(new IClasspathEntry[0]);
+        if (!Arrays.equals(javaProject.getRawClasspath(), newEntriesWithJpms)) {
+            javaProject.setRawClasspath(newEntriesWithJpms, monitor);
+        }
+    }
+
+    /**
+     * Update the project dependencies of the project.
+     * @throws CoreException
+     */
+    public void updateProjectDependencies(BuildServerConnection connection, IProject project, IProgressMonitor monitor) throws CoreException {
         List<BuildTarget> buildTargets = Utils.getBuildTargetsByProjectUri(connection, project.getLocationURI());
+        updateProjectDependencies(project, buildTargets, monitor);
+    }
+
+    /**
+     * Update the project dependencies of the project using pre-fetched build targets.
+     * @throws CoreException
+     */
+    public void updateProjectDependencies(IProject project, List<BuildTarget> buildTargets, IProgressMonitor monitor) throws CoreException {
+        IPath rootPath = ProjectUtils.findBelongedWorkspaceRoot(project.getLocation());
+        if (rootPath == null) {
+            JavaLanguageServerPlugin.logError("Cannot find workspace root for project: " + project.getName());
+            return;
+        }
         Set<BuildTargetIdentifier> projectDependencies = new LinkedHashSet<>();
         for (BuildTarget buildTarget : buildTargets) {
             projectDependencies.addAll(buildTarget.getDependencies());

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -46,6 +46,7 @@ import ch.epfl.scala.bsp4j.BuildClientCapabilities;
 import ch.epfl.scala.bsp4j.BuildTarget;
 import ch.epfl.scala.bsp4j.InitializeBuildParams;
 import ch.epfl.scala.bsp4j.InitializeBuildResult;
+import ch.epfl.scala.bsp4j.WorkspaceBuildTargetsResult;
 
 public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
 
@@ -225,21 +226,29 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
             return;
         }
 
-        List<IProject> projects = importProjects(buildServer, monitor);
+        // Cache the workspace build targets result to avoid redundant BSP calls.
+        // Previously, importProjects(), updateClasspath(), and updateProjectDependencies()
+        // each independently called workspaceBuildTargets(), resulting in ~2N+1 calls
+        // for N projects. Now we fetch once and pass the cached result everywhere.
+        WorkspaceBuildTargetsResult cachedTargets = buildServer.workspaceBuildTargets().join();
+
+        List<IProject> projects = importProjects(cachedTargets, monitor);
         if (projects.isEmpty()) {
             return;
         }
 
         GradleBuildServerBuildSupport buildSupport = new GradleBuildServerBuildSupport();
-        for (IProject project : projects) {
-            buildSupport.updateClasspath(buildServer, project, monitor);
-        }
+
+        // Use batched BSP calls: instead of making per-target calls (4N round-trips
+        // for N build targets), batch all target IDs into single calls (4 total).
+        buildSupport.updateAllClasspaths(buildServer, projects, cachedTargets, monitor);
 
         // We need to add the project dependencies after the Java nature is set to all
-        // the projects, which is done in 'updateClasspath(IProject, IProgressMonitor)',
+        // the projects, which is done in 'updateAllClasspaths()',
         // otherwise JDT will thrown exception when adding projects as dependencies.
         for (IProject project : projects) {
-            buildSupport.updateProjectDependencies(buildServer, project, monitor);
+            List<BuildTarget> buildTargets = Utils.getBuildTargetsByProjectUri(cachedTargets, project.getLocationURI());
+            buildSupport.updateProjectDependencies(project, buildTargets, monitor);
         }
 
         for (IProject project : projects) {
@@ -320,10 +329,10 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
      *
      * @throws CoreException
      */
-    private List<IProject> importProjects(BuildServerConnection buildServer, IProgressMonitor monitor) throws CoreException {
+    private List<IProject> importProjects(WorkspaceBuildTargetsResult cachedTargets, IProgressMonitor monitor) throws CoreException {
         Map<URI, List<BuildTarget>> buildTargetMap;
         try {
-            buildTargetMap = Utils.getBuildTargetsMappedByProjectPath(buildServer);
+            buildTargetMap = Utils.getBuildTargetsMappedByProjectPath(cachedTargets);
         } catch (CompletionException e) {
             JavaLanguageServerPlugin.logException(
                     "Failed to get build targets from Gradle Build Server. "

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -230,7 +231,16 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
         // Previously, importProjects(), updateClasspath(), and updateProjectDependencies()
         // each independently called workspaceBuildTargets(), resulting in ~2N+1 calls
         // for N projects. Now we fetch once and pass the cached result everywhere.
-        WorkspaceBuildTargetsResult cachedTargets = buildServer.workspaceBuildTargets().join();
+        WorkspaceBuildTargetsResult cachedTargets;
+        try {
+            cachedTargets = buildServer.workspaceBuildTargets().join();
+        } catch (CompletionException e) {
+            JavaLanguageServerPlugin.logException(
+                    "Failed to get build targets from Gradle Build Server. "
+                    + "If another Gradle process is running, please stop it and retry.", e);
+            this.isResolved = false;
+            return;
+        }
 
         List<IProject> projects = importProjects(cachedTargets, monitor);
         if (projects.isEmpty()) {
@@ -245,9 +255,11 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
 
         // We need to add the project dependencies after the Java nature is set to all
         // the projects, which is done in 'updateAllClasspaths()',
-        // otherwise JDT will thrown exception when adding projects as dependencies.
+        // otherwise JDT will throw an exception when adding projects as dependencies.
+        Map<URI, List<BuildTarget>> targetsByProjectUri = Utils.getBuildTargetsMappedByProjectPath(cachedTargets);
         for (IProject project : projects) {
-            List<BuildTarget> buildTargets = Utils.getBuildTargetsByProjectUri(cachedTargets, project.getLocationURI());
+            List<BuildTarget> buildTargets = targetsByProjectUri.getOrDefault(
+                    Utils.getUriWithoutQuery(project.getLocationURI().toString()), Collections.emptyList());
             buildSupport.updateProjectDependencies(project, buildTargets, monitor);
         }
 

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -258,8 +258,7 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
         // otherwise JDT will throw an exception when adding projects as dependencies.
         Map<URI, List<BuildTarget>> targetsByProjectUri = Utils.getBuildTargetsMappedByProjectPath(cachedTargets);
         for (IProject project : projects) {
-            List<BuildTarget> buildTargets = targetsByProjectUri.getOrDefault(
-                    Utils.getUriWithoutQuery(project.getLocationURI().toString()), Collections.emptyList());
+            List<BuildTarget> buildTargets = Utils.getBuildTargetsByProjectUri(targetsByProjectUri, project.getLocationURI());
             buildSupport.updateProjectDependencies(project, buildTargets, monitor);
         }
 

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
@@ -64,6 +64,29 @@ public class Utils {
         return buildTargets.stream().collect(Collectors.groupingBy(target -> getUriWithoutQuery(target.getId().getUri())));
     }
 
+    /**
+     * Get build targets for a specific project URI from a pre-grouped map.
+     *
+     * <p>The fast path uses exact URI equality, but we fall back to URIUtil.sameURI
+     * to preserve the previous matching behavior for equivalent file URIs on Windows
+     * such as different drive-letter casing.
+     */
+    public static List<BuildTarget> getBuildTargetsByProjectUri(Map<URI, List<BuildTarget>> targetsByProjectUri, URI projectUri) {
+      if (projectUri == null) {
+        throw new IllegalArgumentException("projectUri cannot be null.");
+      }
+
+      List<BuildTarget> exactMatch = targetsByProjectUri.get(projectUri);
+      if (exactMatch != null) {
+        return exactMatch;
+      }
+
+      return targetsByProjectUri.entrySet().stream()
+          .filter(entry -> URIUtil.sameURI(projectUri, entry.getKey()))
+          .flatMap(entry -> entry.getValue().stream())
+          .collect(Collectors.toList());
+    }
+
     public static URI getUriWithoutQuery(String uriString) {
         try {
             URI uri = new URI(uriString);
@@ -90,11 +113,7 @@ public class Utils {
             throw new IllegalArgumentException("projectUri cannot be null.");
         }
 
-        List<BuildTarget> buildTargets = result.getTargets();
-
-        return buildTargets.stream().filter(target ->
-                URIUtil.sameURI(projectUri, getUriWithoutQuery(target.getId().getUri()))
-        ).collect(Collectors.toList());
+      return getBuildTargetsByProjectUri(getBuildTargetsMappedByProjectPath(result), projectUri);
     }
 
     /**

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
@@ -75,7 +75,7 @@ public class Utils {
 
     public static List<BuildTarget> getBuildTargetsByProjectUri(BuildServerConnection serverConnection, URI projectUri) {
         if (projectUri == null) {
-            throw new IllegalArgumentException("projectPath cannot be null.");
+            throw new IllegalArgumentException("projectUri cannot be null.");
         }
 
         WorkspaceBuildTargetsResult workspaceBuildTargetsResult = serverConnection.workspaceBuildTargets().join();
@@ -87,7 +87,7 @@ public class Utils {
      */
     public static List<BuildTarget> getBuildTargetsByProjectUri(WorkspaceBuildTargetsResult result, URI projectUri) {
         if (projectUri == null) {
-            throw new IllegalArgumentException("projectPath cannot be null.");
+            throw new IllegalArgumentException("projectUri cannot be null.");
         }
 
         List<BuildTarget> buildTargets = result.getTargets();

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
@@ -53,7 +53,14 @@ public class Utils {
      */
     public static Map<URI, List<BuildTarget>> getBuildTargetsMappedByProjectPath(BuildServerConnection serverConnection) {
         WorkspaceBuildTargetsResult workspaceBuildTargetsResult = serverConnection.workspaceBuildTargets().join();
-        List<BuildTarget> buildTargets = workspaceBuildTargetsResult.getTargets();
+        return getBuildTargetsMappedByProjectPath(workspaceBuildTargetsResult);
+    }
+
+    /**
+     * Get build targets mapped by their paths from a pre-fetched result.
+     */
+    public static Map<URI, List<BuildTarget>> getBuildTargetsMappedByProjectPath(WorkspaceBuildTargetsResult result) {
+        List<BuildTarget> buildTargets = result.getTargets();
         return buildTargets.stream().collect(Collectors.groupingBy(target -> getUriWithoutQuery(target.getId().getUri())));
     }
 
@@ -72,7 +79,18 @@ public class Utils {
         }
 
         WorkspaceBuildTargetsResult workspaceBuildTargetsResult = serverConnection.workspaceBuildTargets().join();
-        List<BuildTarget> buildTargets = workspaceBuildTargetsResult.getTargets();
+        return getBuildTargetsByProjectUri(workspaceBuildTargetsResult, projectUri);
+    }
+
+    /**
+     * Get build targets for a specific project URI from a pre-fetched result.
+     */
+    public static List<BuildTarget> getBuildTargetsByProjectUri(WorkspaceBuildTargetsResult result, URI projectUri) {
+        if (projectUri == null) {
+            throw new IllegalArgumentException("projectPath cannot be null.");
+        }
+
+        List<BuildTarget> buildTargets = result.getTargets();
 
         return buildTargets.stream().filter(target ->
                 URIUtil.sameURI(projectUri, getUriWithoutQuery(target.getId().getUri()))


### PR DESCRIPTION
## Problem

During Gradle project import, BSP calls (`buildTargetOutputPaths`, `buildTargetSources`, `buildTargetResources`, `buildTargetDependencyModules`, `buildTargetJavacOptions`) were made **per-target sequentially**, and `workspaceBuildTargets()` was called **redundantly per-project**.

For a workspace like **spring-boot** with 400 projects (~800 build targets), this resulted in **~4,400 sequential blocking BSP round-trips**, contributing an estimated 30–90 seconds to the total import time.

### Root Causes

| BSP Call | Before | Issue |
|---|---|---|
| `workspaceBuildTargets()` | ~801 calls | Called independently in `importProjects()`, each `updateClasspath()`, and each `updateProjectDependencies()` |
| `buildTargetOutputPaths()` | ~800 calls | 1 call per build target |
| `buildTargetSources()` | ~800 calls | 1 call per build target |
| `buildTargetResources()` | ~800 calls | 1 call per build target (conditional) |
| `buildTargetDependencyModules()` | ~800 calls | 1 call per build target |
| `buildTargetJavacOptions()` | ~400 calls | 1 call per project (already batched per-project) |

## Solution

Two complementary optimizations:

### 1. Cache `workspaceBuildTargets()` result (eliminates ~800 redundant calls)

Fetch `workspaceBuildTargets()` once in `importToWorkspace()` and pass the cached `WorkspaceBuildTargetsResult` to all downstream methods via new overloads in `Utils.java`.

### 2. Batch per-target BSP calls across ALL projects (4N → 5 total calls)

New `updateAllClasspaths()` method in `GradleBuildServerBuildSupport.java`:
1. Collects **all** build target IDs from **all** projects
2. Makes **5 batched BSP calls** (one per operation type) with the full target list
3. Indexes results into `HashMap<targetUri, items>` for O(1) lookup
4. Processes each project using the indexed results with **zero additional BSP calls**

### Result

| | Before | After |
|---|---|---|
| `workspaceBuildTargets()` | ~801 | **1** |
| `buildTargetOutputPaths/Sources/Resources/DependencyModules` | ~3,200 | **4** |
| `buildTargetJavacOptions` | ~400 | **1** |
| **Total BSP round-trips** | **~4,400** | **6** |

**Estimated saving: 30–90 seconds** for large multi-project workspaces.

## Files Changed

- **`Utils.java`** — Added overloads of `getBuildTargetsMappedByProjectPath()` and `getBuildTargetsByProjectUri()` that accept pre-fetched `WorkspaceBuildTargetsResult`
- **`GradleBuildServerBuildSupport.java`** — Added `updateAllClasspaths()` (batched) and `updateClasspathFromBatchedResults()` (per-project from indexed data); added `updateProjectDependencies()` overload accepting pre-fetched build targets
- **`GradleBuildServerProjectImporter.java`** — `importToWorkspace()` now fetches `workspaceBuildTargets()` once and uses the batched `updateAllClasspaths()` path

## Backward Compatibility

- The original `updateClasspath()` and `updateProjectDependencies(connection, project, monitor)` methods are **unchanged** and still used by the `update()` code path (single-project refresh triggered by file changes)
- Only the bulk import path (`importToWorkspace()`) uses the new batched flow

Before: 
<img width="1621" height="1157" alt="image" src="https://github.com/user-attachments/assets/1a054e76-e68a-4bde-adec-af74505a8117" />
After:
<img width="1493" height="442" alt="Screenshot 2026-03-31 130423" src="https://github.com/user-attachments/assets/1330c2f0-9706-4632-a771-8c4175cd5326" />
