### PR TITLE
fix: override serialize-javascript to >=7.0.3 to fix RCE vulnerability

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -5454,15 +5454,6 @@
         }
       ]
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5817,12 +5808,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -994,5 +994,8 @@
     "tree-kill": "^1.2.2",
     "vscode-extension-telemetry-wrapper": "0.14.0",
     "vscode-languageclient": "7.0.0"
+  },
+  "overrides": {
+    "serialize-javascript": ">=7.0.3"
   }
 }

--- a/extension/package.json
+++ b/extension/package.json
@@ -996,6 +996,6 @@
     "vscode-languageclient": "7.0.0"
   },
   "overrides": {
-    "serialize-javascript": ">=7.0.3"
+    "serialize-javascript": "^7.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Fix Dependabot alert #97 — `serialize-javascript` <= 7.0.2 is vulnerable to RCE via `RegExp.flags` and `Date.prototype.toISOString()` (incomplete fix for CVE-2020-7660).

## Problem

`serialize-javascript@6.0.2` is a transitive dependency introduced via:
- `mocha` → `serialize-javascript@^6.0.2`
- `webpack` → `terser-webpack-plugin` → `serialize-javascript@^6.0.2`

Both upstream packages pin to `^6.0.2` (i.e. `>=6.0.2 <7.0.0`), but the fix requires `>=7.0.3`. Neither `mocha` nor `terser-webpack-plugin` has released a version that accepts `serialize-javascript@7.x`, so Dependabot cannot auto-resolve this.

## Fix

Add an npm `overrides` field in `package.json` to force `serialize-javascript` to `>=7.0.3`, bypassing the transitive constraint from `mocha` and `terser-webpack-plugin`.

After applying the override, `npm ls serialize-javascript` confirms the resolved version is `7.0.5`.

## Verification

- `npm audit` no longer reports `serialize-javascript` vulnerability
- `npm ls serialize-javascript` shows `7.0.5 overridden` for both dependency paths