### PR TITLE
fix: suppress auto-build during BSP didChange to prevent infinite rebuild loop

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildClient.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildClient.java
@@ -15,6 +15,9 @@ import java.util.concurrent.CompletableFuture;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRunnable;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
@@ -51,6 +54,13 @@ import ch.epfl.scala.bsp4j.extended.TestName;
 import ch.epfl.scala.bsp4j.extended.TestStartEx;
 
 public class GradleBuildClient implements BuildClient {
+
+    /**
+     * Guard flag to prevent re-entrant didChange → update → auto-build →
+     * compile → didChange loops. When true, incoming didChange notifications
+     * are ignored because a previous update cycle is still in progress.
+     */
+    private static volatile boolean isUpdating = false;
 
     /**
      * The task name for the build server.
@@ -117,6 +127,13 @@ public class GradleBuildClient implements BuildClient {
 
     @Override
     public void onBuildTargetDidChange(DidChangeBuildTarget params) {
+        // Skip if an update cycle is already in progress to prevent re-entrant loops:
+        // didChange → update → auto-build → compile → reloadWorkspace → didChange → ...
+        if (isUpdating) {
+            JavaLanguageServerPlugin.logInfo("Skipping didChange notification: update already in progress.");
+            return;
+        }
+
         Set<IProject> projects = new HashSet<>();
         for (BuildTargetEvent event : params.getChanges()) {
             BuildTargetIdentifier id = event.getTarget();
@@ -134,13 +151,29 @@ public class GradleBuildClient implements BuildClient {
         // Update projects in a new thread to avoid blocking the IO queue,
         // since some BSP requests will be sent during project updates.
         CompletableFuture.runAsync(() -> {
-            GradleBuildServerBuildSupport buildSupport = new GradleBuildServerBuildSupport();
-            for (IProject project : projects) {
-                try {
-                    buildSupport.update(project, true, new NullProgressMonitor());
-                } catch (CoreException e) {
-                    JavaLanguageServerPlugin.log(e);
-                }
+            isUpdating = true;
+            try {
+                // Wrap all classpath updates in a single workspace operation to prevent
+                // intermediate setRawClasspath() calls from each triggering auto-build.
+                // With workspace.run(), all changes are batched into one operation and
+                // endTopLevel() is called only once at the end, triggering at most one auto-build.
+                JavaLanguageServerPlugin.logInfo("Batching classpath updates for "
+                        + projects.size() + " project(s) in a single workspace operation.");
+                ResourcesPlugin.getWorkspace().run((IWorkspaceRunnable) monitor -> {
+                    GradleBuildServerBuildSupport buildSupport = new GradleBuildServerBuildSupport();
+                    for (IProject project : projects) {
+                        try {
+                            JavaLanguageServerPlugin.logInfo("Updating classpath for project: " + project.getName());
+                            buildSupport.update(project, true, monitor);
+                        } catch (CoreException e) {
+                            JavaLanguageServerPlugin.log(e);
+                        }
+                    }
+                }, null, IWorkspace.AVOID_UPDATE, new NullProgressMonitor());
+            } catch (CoreException e) {
+                JavaLanguageServerPlugin.logException("Failed to batch classpath updates", e);
+            } finally {
+                isUpdating = false;
             }
         });
     }

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -166,17 +166,9 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
                 JavaLanguageServerPlugin.logError("Cannot find build server connection for root: " + rootPath);
                 return;
             }
-            Map<URI, List<BuildTarget>> buildTargetMap = Utils.getBuildTargetsMappedByProjectPath(connection);
-            for (URI uri : buildTargetMap.keySet()) {
-                IProject projectFromUri = ProjectUtils.getProjectFromUri(uri.toString());
-                if (projectFromUri == null || !Utils.isGradleBuildServerProject(projectFromUri)) {
-                    continue;
-                }
-                updateClasspath(connection, projectFromUri, monitor);
-                updateProjectDependencies(connection, projectFromUri, monitor);
-                // TODO: in case that the projects/build targets are created or removed,
-                // we can use the server->client notification: 'buildTarget/didChange' to support this case.
-            }
+            // updateClasspath now includes project dependencies in the same
+            // setRawClasspath() call, so no separate updateProjectDependencies needed.
+            updateClasspath(connection, project, monitor);
         }
     }
 
@@ -242,16 +234,14 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
         // In Gradle, output of a source set may be overlapping with the source dir of another source set.
         javaProject.setOption(JavaCore.CORE_OUTPUT_LOCATION_OVERLAPPING_ANOTHER_SOURCE, "ignore" );
 
-        // set all the source roots to the project first, then the information
-        // of whether the project is modular will be available.
         classpathMap = getSourceCpeWithExclusions(new LinkedList<>(classpathMap.values()))
             .stream()
             .collect(Collectors.toMap(IClasspathEntry::getPath, Function.identity(), (e1, e2) -> e1, LinkedHashMap::new));
-        // TODO: find a way to get if the project is modular without setting the classpath.
-        IClasspathEntry[] newSourceEntries = classpathMap.values().toArray(new IClasspathEntry[0]);
-        if (!Arrays.equals(javaProject.getRawClasspath(), newSourceEntries)) {
-            javaProject.setRawClasspath(newSourceEntries, monitor);
-        }
+
+        // Detect modularity using the existing classpath state. The current classpath
+        // already contains the source roots from the previous import/update, so
+        // getOwnModuleDescription() will correctly find module-info.java without
+        // needing to set a source-only classpath first.
         boolean isModular = javaProject.getOwnModuleDescription() != null;
 
         setProjectJdk(classpathMap, buildTargets, javaProject, isModular);
@@ -266,11 +256,6 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
             }
         }
 
-        IClasspathEntry[] newEntriesWithDeps = classpathMap.values().toArray(new IClasspathEntry[0]);
-        if (!Arrays.equals(javaProject.getRawClasspath(), newEntriesWithDeps)) {
-            javaProject.setRawClasspath(newEntriesWithDeps, monitor);
-        }
-
         // process jpms arguments.
         JavacOptionsResult javacOptions = connection.buildTargetJavacOptions(new JavacOptionsParams(
                 buildTargets.stream().map(BuildTarget::getId).collect(Collectors.toList()))).join();
@@ -280,13 +265,26 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
         }
 
         JpmsArguments jpmsArgs = JpmsUtils.categorizeJpmsArguments(compilerArgs);
-        if (jpmsArgs.isEmpty()) {
-            return;
+        if (!jpmsArgs.isEmpty()) {
+            JpmsUtils.appendJpmsAttributesToEntries(javaProject, classpathMap, jpmsArgs);
         }
-        JpmsUtils.appendJpmsAttributesToEntries(javaProject, classpathMap, jpmsArgs);
-        IClasspathEntry[] newEntriesWithJpms = classpathMap.values().toArray(new IClasspathEntry[0]);
-        if (!Arrays.equals(javaProject.getRawClasspath(), newEntriesWithJpms)) {
-            javaProject.setRawClasspath(newEntriesWithJpms, monitor);
+
+        // Add project dependency entries into the same classpathMap so that
+        // everything is written in a single setRawClasspath() call.
+        Set<BuildTargetIdentifier> projectDependencies = new LinkedHashSet<>();
+        for (BuildTarget buildTarget : buildTargets) {
+            projectDependencies.addAll(buildTarget.getDependencies());
+        }
+        for (IClasspathEntry entry : getProjectDependencyEntries(project, projectDependencies)) {
+            classpathMap.putIfAbsent(entry.getPath(), entry);
+        }
+
+        // Set classpath only once with the fully assembled entries (source + JDK +
+        // deps + JPMS + project deps). This avoids intermediate states that would
+        // always trigger .classpath writes and auto-build even when nothing changed.
+        IClasspathEntry[] finalClasspath = classpathMap.values().toArray(new IClasspathEntry[0]);
+        if (!Arrays.equals(javaProject.getRawClasspath(), finalClasspath)) {
+            javaProject.setRawClasspath(finalClasspath, javaProject.getOutputLocation(), monitor);
         }
     }
 
@@ -444,10 +442,8 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
         classpathMap = getSourceCpeWithExclusions(new LinkedList<>(classpathMap.values()))
             .stream()
             .collect(Collectors.toMap(IClasspathEntry::getPath, Function.identity(), (e1, e2) -> e1, LinkedHashMap::new));
-        IClasspathEntry[] newSourceEntries = classpathMap.values().toArray(new IClasspathEntry[0]);
-        if (!Arrays.equals(javaProject.getRawClasspath(), newSourceEntries)) {
-            javaProject.setRawClasspath(newSourceEntries, monitor);
-        }
+
+        // Detect modularity using the existing classpath state (same rationale as updateClasspath).
         boolean isModular = javaProject.getOwnModuleDescription() != null;
 
         setProjectJdk(classpathMap, buildTargets, javaProject, isModular);
@@ -465,11 +461,6 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
             }
         }
 
-        IClasspathEntry[] newEntriesWithDeps = classpathMap.values().toArray(new IClasspathEntry[0]);
-        if (!Arrays.equals(javaProject.getRawClasspath(), newEntriesWithDeps)) {
-            javaProject.setRawClasspath(newEntriesWithDeps, monitor);
-        }
-
         // Process JPMS arguments from pre-fetched javac options
         List<String> compilerArgs = new LinkedList<>();
         for (BuildTarget buildTarget : buildTargets) {
@@ -481,13 +472,14 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
         }
 
         JpmsArguments jpmsArgs = JpmsUtils.categorizeJpmsArguments(compilerArgs);
-        if (jpmsArgs.isEmpty()) {
-            return;
+        if (!jpmsArgs.isEmpty()) {
+            JpmsUtils.appendJpmsAttributesToEntries(javaProject, classpathMap, jpmsArgs);
         }
-        JpmsUtils.appendJpmsAttributesToEntries(javaProject, classpathMap, jpmsArgs);
-        IClasspathEntry[] newEntriesWithJpms = classpathMap.values().toArray(new IClasspathEntry[0]);
-        if (!Arrays.equals(javaProject.getRawClasspath(), newEntriesWithJpms)) {
-            javaProject.setRawClasspath(newEntriesWithJpms, monitor);
+
+        // Set classpath only once with the fully assembled entries.
+        IClasspathEntry[] finalClasspath = classpathMap.values().toArray(new IClasspathEntry[0]);
+        if (!Arrays.equals(javaProject.getRawClasspath(), finalClasspath)) {
+            javaProject.setRawClasspath(finalClasspath, monitor);
         }
     }
 


### PR DESCRIPTION
## Problem

Running a test or launching a main class in a Gradle project with the Gradle Build Server enabled causes the Java Language Server to enter an infinite rebuild loop (microsoft/vscode-java-test#1839, redhat-developer/vscode-java#4307).

## Root Cause

A feedback loop across Eclipse Platform auto-build, the BSP importer, and the Gradle Build Server:

```
auto-build → BuildServerBuilder.build() → BSP compile
  → reloadWorkspace() → didChange
  → onBuildTargetDidChange() → update() → updateClasspath()
  → setRawClasspath() writes .classpath
  → Workspace.endOperation() → BuildManager.endTopLevel()
  → AutoBuildJob → auto-build → ♻️
```

Three compounding issues made the loop infinite:

**1. Multi-step `setRawClasspath()` writes that always differ (17→6→17→19)**

`updateClasspath()` called `setRawClasspath()` 3 times with intermediate states, plus `updateProjectDependencies()` added a 4th. The first call stripped all non-source entries (17→6), then subsequent calls added them back. This always produced "changed" classpaths even when nothing actually changed.

**2. `update()` iterated ALL projects** when called for one project's `didChange`, causing N×4 writes per round.

**3. No operation batching** — each `setRawClasspath()` was a separate workspace operation triggering its own `endTopLevel()`.

## Fix

- **Single `setRawClasspath()` call**: Assemble complete classpath (source + JDK + deps + JPMS + project deps) in memory, then write once. When nothing changed, `Arrays.equals()` skips the write → no `.classpath` modification → no auto-build trigger.

- **Modularity detection without intermediate write**: Use existing classpath for `getOwnModuleDescription()` — source roots are already present.

- **Single-project update**: `update()` only processes the passed project.

- **`IWorkspace.run()` batching** + **re-entrancy guard** in `onBuildTargetDidChange`.

## Evidence: Before/After Diagnostic Logs

**Before (each `didChange` round, per project — 12 `.classpath` writes per round):**
```
list:        source-only CHANGED old=17 new=6     ← strips deps
             with-deps   CHANGED old=6  new=17    ← adds back
             proj-deps   SKIPPED
app:         source-only CHANGED old=24 new=6
             with-deps   CHANGED old=6  new=22
             proj-deps   CHANGED old=22 new=24    ← adds project refs
utilities:   source-only CHANGED old=19 new=6
             with-deps   CHANGED old=6  new=18
             proj-deps   CHANGED old=18 new=19
...
→ 12 writes → auto-build → BSP compile → didChange → identical pattern repeats infinitely
```

**After (zero `.classpath` writes — loop broken):**
```
Batching classpath updates for 5 project(s) in a single workspace operation.
  list:        setRawClasspath SKIPPED (no change)
  buildSrc:    setRawClasspath SKIPPED (no change)
  app:         setRawClasspath SKIPPED (no change)
  utilities:   setRawClasspath SKIPPED (no change)
  sample-file: setRawClasspath SKIPPED (no change)
→ 0 writes → loop terminates
```

## Risk Assessment

| Risk | Level | Mitigation |
|------|-------|------------|
| Modularity detection on existing classpath | Low | Only examines source roots for `module-info.java`, which are present in both full and source-only classpath |
| Single-project update | Low | All callers pass specific projects; project deps use path-based `newProjectEntry()` |
| Combined `setRawClasspath()` | Low | Uses `putIfAbsent()` for project deps, same final content |
| Re-entrancy guard | Low | Worst case: one `didChange` skipped, corrected by next cycle |

## Known Remaining Issue (follow-up optimization)

After the fix, `BuildServerBuilder.build()` is still triggered ~5 times before converging, even though all classpath writes are SKIPPED. This is caused by other resource tree modifications in `updateClasspath()` (`refreshLocal()`, `setOption()`, `createLink()`) that are **idempotent** — they converge naturally within 5-6 rounds. A follow-up PR can add guard checks to skip these when values haven't changed.

Fixes microsoft/vscode-java-test#1839
Fixes redhat-developer/vscode-java#4307
