### PR TITLE
fix: improve server connection stability and fix resource leaks

### DIFF
--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -50,7 +50,7 @@ export class TaskServerClient implements vscode.Disposable {
     public readonly onDidConnect: vscode.Event<null> = this._onDidConnect.event;
     public readonly onDidConnectFail: vscode.Event<null> = this._onDidConnectFail.event;
 
-    private readonly waitForConnect = new EventWaiter(this.onDidConnect).wait;
+    private readonly connectWaiter = new EventWaiter(this.onDidConnect);
 
     public constructor(
         private readonly server: GradleServer,
@@ -66,6 +66,7 @@ export class TaskServerClient implements vscode.Disposable {
     };
 
     public handleServerStart = (): Thenable<void> => {
+        this.connectWaiter.reset();
         return vscode.window.withProgress(
             {
                 location: vscode.ProgressLocation.Window,
@@ -111,6 +112,7 @@ export class TaskServerClient implements vscode.Disposable {
         } catch (err) {
             logger.error("Unable to construct the gRPC client:", err.message);
             this.statusBarItem.hide();
+            this._onDidConnectFail.fire(null);
         }
     }
 
@@ -119,7 +121,7 @@ export class TaskServerClient implements vscode.Disposable {
         gradleConfig: GradleConfig,
         showOutputColors = false
     ): Promise<GradleBuild | undefined> {
-        await this.waitForConnect();
+        await this.connectWaiter.wait();
         this.statusBarItem.hide();
         return vscode.window.withProgress(
             {
@@ -230,7 +232,7 @@ export class TaskServerClient implements vscode.Disposable {
         title?: string,
         location?: vscode.ProgressLocation
     ): Promise<void> {
-        await this.waitForConnect();
+        await this.connectWaiter.wait();
         this.statusBarItem.hide();
         return vscode.window.withProgress(
             {
@@ -303,7 +305,7 @@ export class TaskServerClient implements vscode.Disposable {
     }
 
     public async cancelBuild(cancellationKey: string, task?: vscode.Task): Promise<void> {
-        await this.waitForConnect();
+        await this.connectWaiter.wait();
         this.statusBarItem.hide();
         const request = new CancelBuildRequest();
         request.setCancellationKey(cancellationKey);
@@ -357,7 +359,7 @@ export class TaskServerClient implements vscode.Disposable {
     }
 
     public async getNormalizedPackageName(name: string): Promise<string | undefined> {
-        await this.waitForConnect();
+        await this.connectWaiter.wait();
         const request = new ExecuteCommandRequest();
         request.setCommand(SpecifySourcePackageNameStep.GET_NORMALIZED_PACKAGE_NAME);
         request.addArguments(name);
@@ -430,5 +432,6 @@ export class TaskServerClient implements vscode.Disposable {
     public dispose(): void {
         this.close();
         this._onDidConnect.dispose();
+        this._onDidConnectFail.dispose();
     }
 }

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -49,6 +49,7 @@ export async function startLanguageClientAndWaitForConnection(
                 },
                 (e) => {
                     void vscode.window.showErrorMessage(e);
+                    resolve();
                 }
             );
             const disposable = languageClient.start();
@@ -133,7 +134,7 @@ async function syncProject(project: GradleProject): Promise<void> {
 export async function syncGradleBuild(gradleBuild: GradleBuild): Promise<void> {
     const rootProject = gradleBuild.getProject();
     if (rootProject && rootProject.getIsRoot()) {
-        syncProject(rootProject);
+        await syncProject(rootProject);
     }
 }
 

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -48,7 +48,8 @@ export async function startLanguageClientAndWaitForConnection(
                     resolve();
                 },
                 (e) => {
-                    void vscode.window.showErrorMessage(e);
+                    const errorMessage = e instanceof Error ? e.message : String(e);
+                    void vscode.window.showErrorMessage(errorMessage);
                     resolve();
                 }
             );

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -158,9 +158,11 @@ export class GradleServer {
 
     private async killProcess(): Promise<void> {
         if (this.process) {
-            return new Promise((resolve, _reject) => {
+            return new Promise((resolve) => {
                 if (this.process?.pid) {
-                    kill(this.process.pid, () => resolve);
+                    kill(this.process.pid, () => resolve());
+                } else {
+                    resolve();
                 }
             });
         }

--- a/extension/src/util/EventWaiter.ts
+++ b/extension/src/util/EventWaiter.ts
@@ -4,19 +4,23 @@ type callback = () => void;
 
 export class EventWaiter<T = null> {
     private eventRun = false;
+    private activeDisposable: vscode.Disposable | undefined;
 
     constructor(private readonly event: vscode.Event<T>) {
         this.waitForEvent();
     }
 
     public waitForEvent = (callback?: callback): void => {
+        this.activeDisposable?.dispose();
         const disposable = this.event(() => {
             disposable.dispose();
+            this.activeDisposable = undefined;
             this.eventRun = true;
             if (callback) {
                 callback();
             }
         });
+        this.activeDisposable = disposable;
     };
 
     public wait = (): Promise<void> => {


### PR DESCRIPTION
## Problem

Several stability issues in the extension can cause operations to hang indefinitely, leading to poor user experience especially when the Gradle server connection is unstable.

## Root Causes & Fixes

### 1. \killProcess()\ Promise never resolves (GradleServer.ts)
**Bug**: \kill(this.process.pid, () => resolve)\ passes a function that *returns* \esolve\ but never *calls* it. Should be \() => resolve()\.
**Impact**: \syncDispose()\ hangs on \wait killProcess()\, causing extension deactivation to stall for ~5s (VS Code's deactivation timeout).
**Fix**: Changed to \() => resolve()\ and added \lse { resolve() }\ for when \pid\ is undefined.

### 2. Operations hang forever after gRPC connection failure (TaskServerClient.ts)
**Bug**: \EventWaiter\ only listens for \onDidConnect\. After a connection failure, \ventRun\ stays \alse\, so all subsequent \getBuild()\/\unBuild()\/\cancelBuild()\ calls block on \connectWaiter.wait()\ forever.
**Impact**: After a single connection failure, the extension becomes completely non-functional — every Gradle operation shows an infinite progress spinner.
**Fix**: Call \connectWaiter.reset()\ in \handleServerStart()\ so the waiter is ready for the next connection attempt.

### 3. \connectToServer()\ catch block doesn't fire fail event (TaskServerClient.ts)
**Bug**: If \GrpcClient\ constructor throws, the catch block logs the error but fires neither \onDidConnect\ nor \onDidConnectFail\, leaving the progress dialog stuck.
**Fix**: Added \	his._onDidConnectFail.fire(null)\ in the catch block.

### 4. Language Server progress never dismisses on error (languageServer.ts)
**Bug**: The \onReady()\ rejection handler shows an error message but doesn't call \esolve()\, leaving a permanent 'Initializing Gradle Language Server' progress indicator.
**Fix**: Added \esolve()\ in the error handler.

### 5. Missing \wait\ in \syncGradleBuild()\ (languageServer.ts)
**Bug**: \syncProject(rootProject)\ was called without \wait\, so errors were unobserved.
**Fix**: Added \wait\.

### 6. \_onDidConnectFail\ not disposed (TaskServerClient.ts)
**Bug**: \dispose()\ only disposed \_onDidConnect\ but not \_onDidConnectFail\, causing an event listener leak.
**Fix**: Added \	his._onDidConnectFail.dispose()\.

## Testing
- TypeScript compilation passes (\	sc --noEmit\)
- All changes are minimal and surgical — no behavioral changes beyond fixing the bugs