### PR TITLE
fix: resolve EventWaiter race condition causing CI test failures

### DIFF
--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -7,6 +7,7 @@ import { DidChangeConfigurationNotification, LanguageClientOptions } from "vscod
 import { LanguageClient, StreamInfo } from "vscode-languageclient/node";
 import { GradleBuildContentProvider } from "../client/GradleBuildContentProvider";
 import { GradleBuild, GradleProject } from "../proto/gradle_pb";
+import { logger } from "../logger";
 import { RootProjectsStore } from "../stores";
 import {
     getConfigJavaImportGradleHome,
@@ -135,7 +136,13 @@ async function syncProject(project: GradleProject): Promise<void> {
 export async function syncGradleBuild(gradleBuild: GradleBuild): Promise<void> {
     const rootProject = gradleBuild.getProject();
     if (rootProject && rootProject.getIsRoot()) {
-        await syncProject(rootProject);
+        try {
+            await syncProject(rootProject);
+        } catch (e) {
+            // Log but don't propagate - sync failures should not block task discovery
+            const message = e instanceof Error ? e.message : String(e);
+            logger.error("Failed to sync Gradle project with language server:", message);
+        }
     }
 }
 

--- a/extension/src/util/EventWaiter.ts
+++ b/extension/src/util/EventWaiter.ts
@@ -1,37 +1,46 @@
 import * as vscode from "vscode";
 
-type callback = () => void;
-
+/**
+ * Waits for a VS Code event to fire, supporting reset for repeated waits.
+ *
+ * Design: a single background listener captures the event and resolves all
+ * pending wait() callers.  reset() replaces only that background listener,
+ * so it never invalidates an in-flight wait() Promise.
+ */
 export class EventWaiter<T = null> {
     private eventRun = false;
-    private activeDisposable: vscode.Disposable | undefined;
+    private backgroundDisposable: vscode.Disposable | undefined;
+    private pendingResolvers: Set<() => void> = new Set();
 
     constructor(private readonly event: vscode.Event<T>) {
-        this.waitForEvent();
+        this.listen();
     }
 
-    public waitForEvent = (callback?: callback): void => {
-        this.activeDisposable?.dispose();
+    private listen(): void {
+        this.backgroundDisposable?.dispose();
         const disposable = this.event(() => {
             disposable.dispose();
-            this.activeDisposable = undefined;
+            this.backgroundDisposable = undefined;
             this.eventRun = true;
-            if (callback) {
-                callback();
+            for (const resolve of this.pendingResolvers) {
+                resolve();
             }
+            this.pendingResolvers.clear();
         });
-        this.activeDisposable = disposable;
-    };
+        this.backgroundDisposable = disposable;
+    }
 
     public wait = (): Promise<void> => {
         if (this.eventRun) {
             return Promise.resolve();
         }
-        return new Promise(this.waitForEvent);
+        return new Promise<void>((resolve) => {
+            this.pendingResolvers.add(resolve);
+        });
     };
 
     public reset(): void {
         this.eventRun = false;
-        this.waitForEvent();
+        this.listen();
     }
 }


### PR DESCRIPTION
## Problem

PR #1796 introduced \ActiveDisposable\ tracking in \EventWaiter.waitForEvent()\ to prevent listener leaks. This caused a **critical race condition** that broke all CI test jobs (ubuntu, macos, windows).

### Race Condition

1. \getBuild()\ → \connectWaiter.wait()\ → registers listener **L_wait** with \
esolve\ callback
2. Server starts → \handleServerStart()\ → \connectWaiter.reset()\ → \waitForEvent()\ → **disposes L_wait** via \ActiveDisposable\
3. Connection succeeds → event fires → only the new listener (no callback) fires
4. \
esolve()\ is **never called** → \getBuild()\ hangs forever → task discovery fails

This happens when \fetchTasks()\ is called before the server finishes connecting — common in multi-root workspaces where startup takes longer.

### Root Cause

\waitForEvent()\ served dual duty for both \
eset()\ (background listener) and \wait()\ (Promise resolver), but a single \ActiveDisposable\ couldn't safely track both — \
eset()\ would destroy an in-flight \wait()\.

## Fix

### 1. Redesign \EventWaiter\ to separate concerns (\EventWaiter.ts\)

- A single **background listener** (managed by \listen()\) captures the event and sets \EventRun\. \
eset()\ only replaces this listener.
- \wait()\ registers resolve callbacks in a \pendingResolvers\ set — **not** as event listeners.
- The background listener resolves all pending waiters when the event fires.
- This eliminates the race: \
eset()\ never touches pending \wait()\ Promises.

### 2. Error-isolate \syncProject\ in \syncGradleBuild\ (\languageServer.ts\)

- Wrap \Await syncProject()\ in try/catch so language server sync failures don't propagate and block task discovery.
- Use \logger.error\ (project convention) instead of \console.error\.

## Verification

All test suites pass locally (previously multi-root tests failed with \Assert.ok(groovyDefaultTask)\):

\\\
33 passing (unit)
10+10+10 passing (gradle fixtures)
10 passing (network)
7 passing (multi-root) ← previously 2 passing, 1 failing
5 passing (multi-project)
9 passing (nested-projects)
2 passing (no-gradle)
BUILD SUCCESSFUL
\\\

## PR #1796 fixes preserved

All 6 bug fixes from #1796 remain intact — only the \EventWaiter\ implementation was redesigned.

Fixes CI failures introduced by #1796.