### PR TITLE
Bump version to 3.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the "vscode-gradle" extension will be documented in this 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.17.3
+## What's Changed
+* perf - Batch BSP calls during import to reduce round-trips from ~4400 to 6 in https://github.com/microsoft/vscode-gradle/pull/1791
+* perf - Skip reloadWorkspace() when compile tasks are all UP-TO-DATE in https://github.com/microsoft/build-server-for-gradle/pull/222
+* fix - Suppress auto-build during BSP didChange to prevent infinite rebuild loop in https://github.com/microsoft/vscode-gradle/pull/1794
+* fix - Improve server connection stability and fix resource leaks in https://github.com/microsoft/vscode-gradle/pull/1796
+* fix - Fix log message taskId NPE error in https://github.com/microsoft/vscode-gradle/pull/1769
+* fix - Fix Gradle project test treeview refresh after running in https://github.com/microsoft/vscode-gradle/pull/1766
+* fix - Fix debug agent attaching to compilation tasks instead of target task in https://github.com/microsoft/vscode-gradle/pull/1757
+
 ## 3.17.2
 ## What's Changed
 * fix - IllegalResolutionException when resolving configurations in https://github.com/microsoft/vscode-gradle/pull/1740

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-gradle",
-  "version": "3.17.2",
+  "version": "3.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-gradle",
-      "version": "3.17.2",
+      "version": "3.17.3",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "await-lock": "^2.2.2",
@@ -49,7 +49,7 @@
         "webpack-cli": "^5.0.1"
       },
       "engines": {
-        "node": "^18.20.4",
+        "node": ">=20.0.0",
         "npm": "^10.7.0",
         "vscode": "^1.76.0"
       }

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-gradle",
   "displayName": "Gradle for Java",
   "description": "Manage Gradle Projects, run Gradle tasks and provide better Gradle file authoring experience in VS Code",
-  "version": "3.17.2",
+  "version": "3.17.3",
   "private": true,
   "publisher": "vscjava",
   "aiKey": "b4aae7d0-c65b-4819-92bf-1d2f537ae7ce",


### PR DESCRIPTION
Bump version to 3.17.3 and update CHANGELOG.

## Changes included in this release

### Performance
- Batch BSP calls during import to reduce round-trips from ~4400 to 6 (#1791)
- Skip reloadWorkspace() when compile tasks are all UP-TO-DATE (build-server-for-gradle#222)

### Fixed
- Suppress auto-build during BSP didChange to prevent infinite rebuild loop (#1794)
- Improve server connection stability and fix resource leaks (#1796)
- Fix log message taskId NPE error (#1769)
- Fix Gradle project test treeview refresh after running (#1766)
- Fix debug agent attaching to compilation tasks instead of target task (#1757)