### PR TITLE
perf: create fresh terminal for Gradle task executions

### DIFF
--- a/extension/src/tasks/taskUtil.ts
+++ b/extension/src/tasks/taskUtil.ts
@@ -139,13 +139,16 @@ export function createTaskFromDefinition(
     const taskName = buildTaskName(definition);
     const cancellationKey = getRunTaskCommandCancellationKey(rootProject.getProjectUri().fsPath, definition.script);
 
-    const terminal = new GradleRunnerTerminal(rootProject, args, cancellationKey, client);
     const task = new vscode.Task(
         definition,
         rootProject.getWorkspaceFolder(),
         taskName,
         "gradle",
-        new vscode.CustomExecution(async (): Promise<vscode.Pseudoterminal> => terminal),
+        new vscode.CustomExecution(async (): Promise<vscode.Pseudoterminal> => {
+            const terminal = new GradleRunnerTerminal(rootProject, args, cancellationKey, client);
+            terminal.setTask(task);
+            return terminal;
+        }),
         ["$gradle"]
     );
 
@@ -164,7 +167,6 @@ export function createTaskFromDefinition(
         panel: panelKind,
         reveal: vscode.TaskRevealKind.Always,
     };
-    terminal.setTask(task);
     return task;
 }
 


### PR DESCRIPTION
Avoid reusing the same Pseudoterminal instance across repeated Gradle tree task runs so terminal close/reuse lifecycle events cannot cancel a subsequent execution of the same task.

may potential resolve #1815