### PR TITLE
fix: surface unexpected Gradle server exits with actionable notification

### DIFF
--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -34,6 +34,7 @@ export class GradleServer {
     private bspProxy: BspProxy;
     private processStartedAt = 0;
     private stderrTail: string[] = [];
+    private pendingStderrLine = "";
 
     constructor(
         private readonly opts: ServerOptions,
@@ -97,6 +98,7 @@ export class GradleServer {
 
         this.processStartedAt = Date.now();
         this.stderrTail = [];
+        this.pendingStderrLine = "";
         this.process = cp.spawn(`"${cmd}"`, args, {
             cwd,
             env,
@@ -108,6 +110,7 @@ export class GradleServer {
         this.process
             .on("error", (err: Error) => this.logger.error(err.message))
             .on("exit", async (code, signal) => {
+                this.flushPendingStderrLine();
                 const durationMs = Date.now() - this.processStartedAt;
                 this.logger.warn(
                     `Gradle server stopped (exitCode=${code ?? "null"}, signal=${
@@ -129,7 +132,7 @@ export class GradleServer {
                     await this.start();
                     return;
                 }
-                if (code !== 0 || signal !== null) {
+                if ((code !== null && code !== 0) || signal !== null) {
                     await this.handleUnexpectedExit(code, signal);
                 }
             });
@@ -162,8 +165,13 @@ export class GradleServer {
     }
 
     private captureStderrTail = (data: Buffer | string): void => {
-        const text = typeof data === "string" ? data : data.toString();
-        for (const rawLine of text.split(/\r?\n/)) {
+        const text = this.pendingStderrLine + (typeof data === "string" ? data : data.toString());
+        const lines = text.split(/\r?\n/);
+        // The last element is either an incomplete line (no trailing newline)
+        // or an empty string (chunk ended on a newline). Either way it cannot
+        // be pushed yet; keep it for the next chunk.
+        this.pendingStderrLine = lines.pop() ?? "";
+        for (const rawLine of lines) {
             const line = rawLine.trim();
             if (!line) {
                 continue;
@@ -174,6 +182,18 @@ export class GradleServer {
             }
         }
     };
+
+    private flushPendingStderrLine(): void {
+        const line = this.pendingStderrLine.trim();
+        this.pendingStderrLine = "";
+        if (!line) {
+            return;
+        }
+        this.stderrTail.push(line);
+        if (this.stderrTail.length > STDERR_TAIL_LINES) {
+            this.stderrTail.shift();
+        }
+    }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private logOutput = (data: any): void => {

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -16,6 +16,7 @@ const DOWNLOAD_PROGRESS_CHAR = ".";
 const STDERR_TAIL_LINES = 40;
 const STDERR_TAIL_PREVIEW_LINES = 3;
 const VIEW_LOG_ACTION = "View Log";
+const RELOAD_HINT = "Run 'Developer: Reload Window' if Gradle stops working.";
 
 export interface ServerOptions {
     host: string;
@@ -233,18 +234,13 @@ export class GradleServer {
             ? `was terminated by signal ${signal}`
             : `exited unexpectedly with code ${code ?? "null"}`;
         const tailPreview = this.stderrTail.slice(-STDERR_TAIL_PREVIEW_LINES).join(" | ");
-        const message = tailPreview
-            ? `Gradle server ${reason}. Last output: ${tailPreview}`
-            : `Gradle server ${reason}. See the "Gradle for Java" output channel for details.`;
-        const selection = await vscode.window.showWarningMessage(message, VIEW_LOG_ACTION, OPT_RESTART);
-        sendInfo("", {
-            kind: "serverProcessExitRestart",
-            data3: selection === OPT_RESTART ? "true" : "false",
-        });
+        const detail = tailPreview
+            ? `Last output: ${tailPreview}`
+            : `See the "Gradle for Java" output channel for details.`;
+        const message = `Gradle server ${reason}. ${detail} ${RELOAD_HINT}`;
+        const selection = await vscode.window.showWarningMessage(message, VIEW_LOG_ACTION);
         if (selection === VIEW_LOG_ACTION) {
             this.logger.getChannel()?.show(true);
-        } else if (selection === OPT_RESTART) {
-            await commands.executeCommand("workbench.action.restartExtensionHost");
         }
     }
 

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -13,6 +13,9 @@ import { BspProxy } from "../bs/BspProxy";
 import { getRandomPipeName } from "../util/generateRandomPipeName";
 const SERVER_LOGLEVEL_REGEX = /^\[([A-Z]+)\](.*)$/;
 const DOWNLOAD_PROGRESS_CHAR = ".";
+const STDERR_TAIL_LINES = 40;
+const STDERR_TAIL_PREVIEW_LINES = 3;
+const VIEW_LOG_ACTION = "View Log";
 
 export interface ServerOptions {
     host: string;
@@ -29,6 +32,8 @@ export class GradleServer {
     private process?: cp.ChildProcessWithoutNullStreams;
     private languageServerPipePath: string;
     private bspProxy: BspProxy;
+    private processStartedAt = 0;
+    private stderrTail: string[] = [];
 
     constructor(
         private readonly opts: ServerOptions,
@@ -90,6 +95,8 @@ export class GradleServer {
         }
         this.logger.debug(`Gradle Server cmd: ${cmd} ${args.join(" ")}`);
 
+        this.processStartedAt = Date.now();
+        this.stderrTail = [];
         this.process = cp.spawn(`"${cmd}"`, args, {
             cwd,
             env,
@@ -97,10 +104,22 @@ export class GradleServer {
         });
         this.process.stdout.on("data", this.logOutput);
         this.process.stderr.on("data", this.logOutput);
+        this.process.stderr.on("data", this.captureStderrTail);
         this.process
             .on("error", (err: Error) => this.logger.error(err.message))
-            .on("exit", async (code) => {
-                this.logger.warn("Gradle server stopped");
+            .on("exit", async (code, signal) => {
+                const durationMs = Date.now() - this.processStartedAt;
+                this.logger.warn(
+                    `Gradle server stopped (exitCode=${code ?? "null"}, signal=${
+                        signal ?? "none"
+                    }, durationMs=${durationMs})`
+                );
+                if (this.stderrTail.length > 0) {
+                    this.logger.warn("Gradle server stderr tail:");
+                    for (const line of this.stderrTail) {
+                        this.logger.warn(`  ${line}`);
+                    }
+                }
                 this._onDidStop.fire(null);
                 this.ready = false;
                 this.process?.removeAllListeners();
@@ -108,8 +127,10 @@ export class GradleServer {
                 if (this.restarting) {
                     this.restarting = false;
                     await this.start();
-                } else if (code !== 0) {
-                    await this.handleServerStartError(code);
+                    return;
+                }
+                if (code !== 0 || signal !== null) {
+                    await this.handleUnexpectedExit(code, signal);
                 }
             });
 
@@ -140,6 +161,20 @@ export class GradleServer {
         this.killProcess();
     }
 
+    private captureStderrTail = (data: Buffer | string): void => {
+        const text = typeof data === "string" ? data : data.toString();
+        for (const rawLine of text.split(/\r?\n/)) {
+            const line = rawLine.trim();
+            if (!line) {
+                continue;
+            }
+            this.stderrTail.push(line);
+            if (this.stderrTail.length > STDERR_TAIL_LINES) {
+                this.stderrTail.shift();
+            }
+        }
+    };
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     private logOutput = (data: any): void => {
         const str = data.toString().trim();
@@ -168,12 +203,29 @@ export class GradleServer {
         }
     }
 
-    private async handleServerStartError(code: number | null): Promise<void> {
+    private async handleUnexpectedExit(code: number | null, signal: NodeJS.Signals | null): Promise<void> {
         sendInfo("", {
             kind: "serverProcessExit",
-            data3: code ? code.toString() : "",
+            data3: code !== null ? code.toString() : "",
+            dataMsg: signal ?? "",
         });
-        await this.showRestartMessage();
+        const reason = signal
+            ? `was terminated by signal ${signal}`
+            : `exited unexpectedly with code ${code ?? "null"}`;
+        const tailPreview = this.stderrTail.slice(-STDERR_TAIL_PREVIEW_LINES).join(" | ");
+        const message = tailPreview
+            ? `Gradle server ${reason}. Last output: ${tailPreview}`
+            : `Gradle server ${reason}. See the "Gradle for Java" output channel for details.`;
+        const selection = await vscode.window.showWarningMessage(message, VIEW_LOG_ACTION, OPT_RESTART);
+        sendInfo("", {
+            kind: "serverProcessExitRestart",
+            data3: selection === OPT_RESTART ? "true" : "false",
+        });
+        if (selection === VIEW_LOG_ACTION) {
+            this.logger.getChannel()?.show(true);
+        } else if (selection === OPT_RESTART) {
+            await commands.executeCommand("workbench.action.restartExtensionHost");
+        }
     }
 
     private fireOnStart(): void {


### PR DESCRIPTION
## Why

Issue #1815 surfaces as ``Call cancelled`` / ``Encountered end-of-stream mid-frame`` when the gradle-server child process disappears unexpectedly (JVM crash, OOM, taskkill, EDR/AV, OS process reaper). The current code only logs ``Gradle server stopped`` and shows a generic ``No connection to gradle server. Try restarting`` toast, which makes user reports almost impossible to triage — we cannot tell the exit code, the signal, or what the server was complaining about on stderr just before it died.

PR #1820 fixed the terminal-reuse race that caused most reports, but a few users on the original thread still report the same symptom on the new build. Before doing more invasive work (alternate IPC transport, retries, etc.) we need real exit data from real reproductions.

## What

Small, focused change in ``extension/src/server/GradleServer.ts``:

* Capture the last 40 complete lines of the server stderr in a ring buffer. Incomplete trailing lines are carried across ``data`` events via a ``pendingStderrLine`` buffer and flushed on process exit, so a line split across two pipe chunks (very common for long stack traces) shows up intact.
* On ``exit``, log the exit code, signal, process lifetime, and the stderr tail through the existing ``Gradle for Java`` output channel logger.
* When the exit is unexpected (i.e. not a user-initiated restart path, **and** ``(code !== null && code !== 0) || signal !== null``), replace the generic toast with a warning that includes the reason, the last 3 stderr lines, and a hint to run ``Developer: Reload Window`` if Gradle stops working. The toast has a single ``View Log`` action; **no auto-restart**.

### Why no Restart button

The only restart primitive available is ``workbench.action.restartExtensionHost``, which reloads **all** extensions in the Extension Host (not just Gradle). Taking that action on the user''s behalf — when they did not ask for it, and the failure may be recurring — is too invasive. The toast instead points users at ``Developer: Reload Window`` so they can opt in if they actually need to recover. The legacy ``GradleServer.showRestartMessage`` (fired only from ``TaskServerClient.handleConnectError``) is unchanged, since users hit that flow only after explicitly opting into a restart prompt elsewhere.

Clean disposal (``asyncDispose`` removes listeners before kill) is unaffected, so VS Code shutdown does not trigger the new toast.

## How users see it

Before:

> No connection to gradle server. Try restarting the server.   [ Restart ]

After (externally killed):

> Gradle server was terminated by signal SIGTERM. Last output: ``...`` Run ''Developer: Reload Window'' if Gradle stops working.   [ View Log ]

After (JVM crash):

> Gradle server exited unexpectedly with code 137. Last output: ``Caused by: java.lang.OutOfMemoryError: Java heap space`` Run ''Developer: Reload Window'' if Gradle stops working.   [ View Log ]

## Telemetry

* ``serverProcessExit`` — preserved; now also carries the signal name in ``dataMsg`` so external-kill scenarios are distinguishable from crashes in the metrics pipeline. It now also fires for signal-only exits (previously gated on ``code !== 0`` which silently dropped ``code === null && signal !== null``), so dashboards may see a small uplift in this event for users on Linux/macOS where SIGKILL/SIGTERM are common.
* ``serverProcessExitRestart`` — unchanged shape; no longer fires from the new unexpected-exit path (no Restart button there), but still fires from the legacy ``showRestartMessage`` path.

## Test plan

* ``npm run lint`` (in ``extension/``) — passes; the remaining prettier warnings on ``*.md`` exist on develop and are unrelated to this change.
* ``npm run compile`` — passes.
* Manual: kill the gradle-server PID externally → the new toast surfaces with the exit code / signal / stderr tail; ``View Log`` opens the channel and preserves focus; no involuntary extension-host reload.
* Manual: long multi-chunk stderr line (OOM stack) — verified that ``pendingStderrLine`` reassembles the line before pushing to the ring buffer.
* No behaviour change to ``asyncDispose()`` or to legacy ``showRestartMessage`` callers.

## Out of scope (follow-ups if telemetry warrants)

* Deduping with the legacy ``server.showRestartMessage`` path so users do not see two notifications when an unexpected exit is followed by a stale RPC failing.
* Lightweight in-process restart (re-spawn gradle-server without reloading the whole Extension Host). The unused ``GradleServer.restart()`` public method points at this design but has no callers today.
* Restart backoff / circuit breaker if the server keeps dying immediately on startup.
* Changing the IPC transport (gRPC → JSON-RPC / UDS / Named Pipes). The investigation in #1825 concluded that is high-risk for unclear benefit while the root cause is unconfirmed.

Refs #1815, #1820, #1825
