### PR TITLE
Load Gradle dependencies lazily

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -258,6 +258,19 @@
         }
       },
       {
+        "command": "gradle.cancelDependencyLoading",
+        "title": "Cancel Loading Dependencies",
+        "icon": {
+          "light": "resources/light/stop.svg",
+          "dark": "resources/dark/stop.svg"
+        }
+      },
+      {
+        "command": "gradle.reloadDependencies",
+        "title": "Reload Dependencies",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "gradle.explorerFlat",
         "title": "Show Flat Tasks",
         "icon": {
@@ -437,6 +450,14 @@
         },
         {
           "command": "gradle.cancelTreeItemTask",
+          "when": "false"
+        },
+        {
+          "command": "gradle.cancelDependencyLoading",
+          "when": "false"
+        },
+        {
+          "command": "gradle.reloadDependencies",
           "when": "false"
         },
         {
@@ -637,6 +658,11 @@
           "command": "gradle.cancellingTreeItemTask",
           "when": "view =~ /^gradleTasksView$|^recentTasksView$/ && viewItem =~ /^cancellingTask.*$/",
           "group": "inline@6"
+        },
+        {
+          "command": "gradle.cancelDependencyLoading",
+          "when": "view =~ /^gradleTasksView$|^gradleDefaultProjectsView$/ && viewItem == dependenciesLoading",
+          "group": "inline@0"
         },
         {
           "command": "gradle.pinTask",

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -95,7 +95,7 @@ export class Extension {
             this.taskServerClient,
             this.gradleBuildContentProvider
         );
-        this.gradleDependencyProvider = new GradleDependencyProvider(this.gradleBuildContentProvider);
+        this.gradleDependencyProvider = new GradleDependencyProvider(this.taskServerClient);
         this.taskProvider = vscode.tasks.registerTaskProvider("gradle", this.gradleTaskProvider);
         this.icons = new Icons(context);
 
@@ -133,7 +133,8 @@ export class Extension {
             this.gradleTaskProvider,
             this.rootProjectsStore,
             this.taskServerClient,
-            this.icons
+            this.icons,
+            this.gradleDependencyProvider
         );
         this.defaultProjectsTreeView = vscode.window.createTreeView(GRADLE_DEFAULT_PROJECTS_VIEW, {
             treeDataProvider: this.defaultProjectsTreeDataProvider,
@@ -157,13 +158,20 @@ export class Extension {
             this.gradleBuildContentProvider,
             this.gradleTasksTreeDataProvider,
             this.recentTasksTreeDataProvider,
+            this.defaultProjectsTreeDataProvider,
             this.gradleDaemonsTreeDataProvider,
             this.taskServerClient,
+            this.gradleDependencyProvider,
             this.rootProjectsStore,
             this.taskTerminalsStore,
             this.recentTasksStore,
             this.gradleTasksTreeView
         );
+
+        this.gradleDependencyProvider.onDidChangeDependencyTreeItem((treeItem) => {
+            this.gradleTasksTreeDataProvider.refresh(treeItem);
+            this.defaultProjectsTreeDataProvider.refresh(treeItem);
+        });
 
         this.buildServerController = new BuildServerController(context);
 

--- a/extension/src/client/CancellationKeys.ts
+++ b/extension/src/client/CancellationKeys.ts
@@ -2,6 +2,10 @@ export function getBuildCancellationKey(rootProjectFolder: string): string {
     return "getBuild" + rootProjectFolder;
 }
 
+export function getProjectDependenciesCancellationKey(rootProjectFolder: string, projectPath: string): string {
+    return ["getProjectDependencies", rootProjectFolder, projectPath].join("\u0000");
+}
+
 export function getRunBuildCancellationKey(rootProjectFolder: string, args: ReadonlyArray<string>): string {
     return "runBuild" + rootProjectFolder + args.join("");
 }

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -4,8 +4,11 @@ import { connectivityState as ConnectivityState } from "@grpc/grpc-js";
 
 import {
     Output,
+    DependencyItem,
     GetBuildRequest,
     GetBuildReply,
+    GetProjectDependenciesRequest,
+    GetProjectDependenciesReply,
     Cancelled,
     GradleBuild,
     Environment,
@@ -27,9 +30,10 @@ import { ProgressHandler } from "../progress";
 import { removeCancellingTask, restartQueuedTask } from "../tasks/taskUtil";
 import { COMMAND_REFRESH_DAEMON_STATUS, COMMAND_SHOW_LOGS, COMMAND_CANCEL_BUILD } from "../commands";
 import { RootProject } from "../rootProject/RootProject";
-import { getBuildCancellationKey } from "./CancellationKeys";
+import { getBuildCancellationKey, getProjectDependenciesCancellationKey } from "./CancellationKeys";
 import { EventWaiter } from "../util/EventWaiter";
 import { getGradleConfig, getJavaDebugCleanOutput } from "../util/config";
+import { normalizeGradleProjectPath } from "../util/gradlePath";
 import { setDefault, unsetDefault } from "../views/defaultProject/DefaultProjectUtils";
 import { SpecifySourcePackageNameStep } from "../createProject/SpecifySourcePackageNameStep";
 import { retryOnSpuriousCancel } from "./retryOnSpuriousCancel";
@@ -46,6 +50,7 @@ function logBuildEnvironment(environment: Environment): void {
 export class TaskServerClient implements vscode.Disposable {
     private readonly connectDeadline = 30; // seconds
     private grpcClient: GrpcClient | null = null;
+    private readonly cancelledProjectDependencies: Set<string> = new Set();
     private readonly _onDidConnect: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private readonly _onDidConnectFail: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     public readonly onDidConnect: vscode.Event<null> = this._onDidConnect.event;
@@ -267,6 +272,62 @@ export class TaskServerClient implements vscode.Disposable {
                 })
                 .on("end", () => resolve(build));
         });
+    }
+
+    public async getProjectDependencies(
+        rootProject: RootProject,
+        projectPath: string,
+        gradleConfig: GradleConfig,
+        showOutputColors = false
+    ): Promise<DependencyItem | undefined> {
+        await this.connectWaiter.wait();
+        this.statusBarItem.hide();
+        const normalizedProjectPath = normalizeGradleProjectPath(projectPath);
+        const cancellationKey = getProjectDependenciesCancellationKey(
+            rootProject.getProjectUri().fsPath,
+            normalizedProjectPath
+        );
+        const request = new GetProjectDependenciesRequest();
+        request.setProjectDir(rootProject.getProjectUri().fsPath);
+        request.setProjectPath(normalizedProjectPath);
+        request.setCancellationKey(cancellationKey);
+        request.setGradleConfig(gradleConfig);
+        request.setShowOutputColors(showOutputColors);
+
+        return new Promise((resolve) => {
+            this.grpcClient!.getProjectDependencies(
+                request,
+                (err: grpc.ServiceError | null, reply: GetProjectDependenciesReply | undefined) => {
+                    if (err) {
+                        if (this.cancelledProjectDependencies.delete(cancellationKey)) {
+                            logger.info(`Getting dependencies for ${normalizedProjectPath} was cancelled.`);
+                            resolve(undefined);
+                            return;
+                        }
+                        if (err.code === grpc.status.NOT_FOUND) {
+                            logger.info(`No Gradle project found for dependency path ${normalizedProjectPath}.`);
+                            resolve(undefined);
+                            return;
+                        }
+                        logger.error(
+                            `Error getting dependencies for ${normalizedProjectPath}: ${err.details || err.message}`
+                        );
+                        this.statusBarItem.command = COMMAND_SHOW_LOGS;
+                        this.statusBarItem.text = "$(warning) Gradle: Dependency Error";
+                        this.statusBarItem.show();
+                        resolve(undefined);
+                        return;
+                    }
+                    this.cancelledProjectDependencies.delete(cancellationKey);
+                    resolve(reply?.getDependencyItem());
+                }
+            );
+        });
+    }
+
+    public async cancelProjectDependencies(cancellationKey: string): Promise<void> {
+        this.cancelledProjectDependencies.add(cancellationKey);
+        await this.cancelBuild(cancellationKey);
     }
 
     public async runBuild(

--- a/extension/src/commands/CancelDependencyLoadingCommand.ts
+++ b/extension/src/commands/CancelDependencyLoadingCommand.ts
@@ -1,0 +1,15 @@
+import { GradleDependencyProvider } from "../dependencies/GradleDependencyProvider";
+import { ProjectDependencyTreeItem } from "../views/gradleTasks/ProjectDependencyTreeItem";
+import { Command } from "./Command";
+
+export const COMMAND_CANCEL_DEPENDENCY_LOADING = "gradle.cancelDependencyLoading";
+
+export class CancelDependencyLoadingCommand extends Command {
+    constructor(private readonly gradleDependencyProvider: GradleDependencyProvider) {
+        super();
+    }
+
+    async run(treeItem: ProjectDependencyTreeItem): Promise<void> {
+        await this.gradleDependencyProvider.cancelDependencies(treeItem);
+    }
+}

--- a/extension/src/commands/Commands.ts
+++ b/extension/src/commands/Commands.ts
@@ -17,6 +17,8 @@ import {
     RenderTaskCommand,
     COMMAND_CANCEL_BUILD,
     CancelBuildCommand,
+    COMMAND_CANCEL_DEPENDENCY_LOADING,
+    CancelDependencyLoadingCommand,
     COMMAND_CANCEL_TREE_ITEM_TASK,
     CancelTreeItemTaskCommand,
     COMMAND_REFRESH,
@@ -65,13 +67,17 @@ import {
     COMMAND_UNPIN_TASK,
     COMMAND_RUN_TASK_DOUBLE_CLICK,
     RunTaskDoubleClickCommand,
+    COMMAND_RELOAD_DEPENDENCIES,
+    ReloadDependenciesCommand,
 } from ".";
 import { TaskServerClient } from "../client";
 import { GradleBuildContentProvider } from "../client/GradleBuildContentProvider";
+import { GradleDependencyProvider } from "../dependencies/GradleDependencyProvider";
 import { PinnedTasksStore, RecentTasksStore, RootProjectsStore, TaskTerminalsStore } from "../stores";
 import { GradleTaskProvider } from "../tasks";
 import { isJavaExtEnabled } from "../util/javaExtension";
 import { GradleDaemonsTreeDataProvider, GradleTasksTreeDataProvider, RecentTasksTreeDataProvider } from "../views";
+import { DefaultProjectsTreeDataProvider } from "../views/defaultProject/DefaultProjectsTreeDataProvider";
 import { Command } from "./Command";
 import { COMMAND_CREATE_PROJECT, COMMAND_CREATE_PROJECT_ADVANCED, CreateProjectCommand } from "./CreateProjectCommand";
 import { HideStoppedDaemonsCommand, HIDE_STOPPED_DAEMONS } from "./HideStoppedDaemonsCommand";
@@ -87,8 +93,10 @@ export class Commands {
         private gradleBuildContentProvider: GradleBuildContentProvider,
         private gradleTasksTreeDataProvider: GradleTasksTreeDataProvider,
         private recentTasksTreeDataProvider: RecentTasksTreeDataProvider,
+        private defaultProjectsTreeDataProvider: DefaultProjectsTreeDataProvider,
         private gradleDaemonsTreeDataProvider: GradleDaemonsTreeDataProvider,
         private client: TaskServerClient,
+        private gradleDependencyProvider: GradleDependencyProvider,
         private rootProjectsStore: RootProjectsStore,
         private taskTerminalsStore: TaskTerminalsStore,
         private recentTasksStore: RecentTasksStore,
@@ -133,6 +141,11 @@ export class Commands {
             new RenderTaskCommand(this.gradleTasksTreeDataProvider, this.recentTasksTreeDataProvider)
         );
         this.registerCommand(COMMAND_CANCEL_BUILD, new CancelBuildCommand(this.client));
+        this.registerCommand(
+            COMMAND_CANCEL_DEPENDENCY_LOADING,
+            new CancelDependencyLoadingCommand(this.gradleDependencyProvider)
+        );
+        this.registerCommand(COMMAND_RELOAD_DEPENDENCIES, new ReloadDependenciesCommand(this.gradleDependencyProvider));
         this.registerCommand(COMMAND_CANCEL_TREE_ITEM_TASK, new CancelTreeItemTaskCommand());
         this.registerCommandWithoutInstrument(
             COMMAND_REFRESH,
@@ -140,7 +153,9 @@ export class Commands {
                 this.gradleTaskProvider,
                 this.gradleBuildContentProvider,
                 this.gradleTasksTreeDataProvider,
-                this.recentTasksTreeDataProvider
+                this.recentTasksTreeDataProvider,
+                this.defaultProjectsTreeDataProvider,
+                this.gradleDependencyProvider
             )
         );
         this.registerCommand(COMMAND_LOAD_TASKS, new LoadTasksCommand(this.gradleTaskProvider));

--- a/extension/src/commands/RefreshCommand.ts
+++ b/extension/src/commands/RefreshCommand.ts
@@ -1,6 +1,8 @@
 import { GradleBuildContentProvider } from "../client/GradleBuildContentProvider";
+import { GradleDependencyProvider } from "../dependencies/GradleDependencyProvider";
 import { GradleTaskProvider } from "../tasks";
 import { GradleTasksTreeDataProvider, RecentTasksTreeDataProvider } from "../views";
+import { DefaultProjectsTreeDataProvider } from "../views/defaultProject/DefaultProjectsTreeDataProvider";
 import { Command } from "./Command";
 export const COMMAND_REFRESH = "gradle.refresh";
 
@@ -9,15 +11,19 @@ export class RefreshCommand extends Command {
         private gradleTaskProvider: GradleTaskProvider,
         private gradleBuildContentProvider: GradleBuildContentProvider,
         private gradleTasksTreeDataProvider: GradleTasksTreeDataProvider,
-        private recentTasksTreeDataProvider: RecentTasksTreeDataProvider
+        private recentTasksTreeDataProvider: RecentTasksTreeDataProvider,
+        private defaultProjectsTreeDataProvider: DefaultProjectsTreeDataProvider,
+        private gradleDependencyProvider: GradleDependencyProvider
     ) {
         super();
     }
     async run(): Promise<void> {
         this.gradleTaskProvider.clearTasksCache();
+        this.gradleDependencyProvider.clearCache();
         this.gradleBuildContentProvider.refresh();
         void this.gradleTaskProvider.loadTasks();
         this.gradleTasksTreeDataProvider.refresh();
+        this.defaultProjectsTreeDataProvider.refresh();
         this.recentTasksTreeDataProvider.refresh();
     }
 }

--- a/extension/src/commands/ReloadDependenciesCommand.ts
+++ b/extension/src/commands/ReloadDependenciesCommand.ts
@@ -1,0 +1,15 @@
+import { GradleDependencyProvider } from "../dependencies/GradleDependencyProvider";
+import { ProjectDependencyTreeItem } from "../views/gradleTasks/ProjectDependencyTreeItem";
+import { Command } from "./Command";
+
+export const COMMAND_RELOAD_DEPENDENCIES = "gradle.reloadDependencies";
+
+export class ReloadDependenciesCommand extends Command {
+    constructor(private readonly gradleDependencyProvider: GradleDependencyProvider) {
+        super();
+    }
+
+    async run(treeItem: ProjectDependencyTreeItem): Promise<void> {
+        this.gradleDependencyProvider.reloadDependencies(treeItem);
+    }
+}

--- a/extension/src/commands/index.ts
+++ b/extension/src/commands/index.ts
@@ -1,4 +1,5 @@
 export * from "./CancelBuildCommand";
+export * from "./CancelDependencyLoadingCommand";
 export * from "./CancelTreeItemTaskCommand";
 export * from "./CancellingTreeItemTaskCommand";
 export * from "./UnpinAllTasksCommand";
@@ -16,6 +17,7 @@ export * from "./PinTaskCommand";
 export * from "./PinTaskWithArgsCommand";
 export * from "./RefreshCommand";
 export * from "./RefreshDaemonStatusCommand";
+export * from "./ReloadDependenciesCommand";
 export * from "./UnpinTaskCommand";
 export * from "./RemoveRecentTaskCommand";
 export * from "./RenderTaskCommand";

--- a/extension/src/dependencies/GradleDependencyProvider.ts
+++ b/extension/src/dependencies/GradleDependencyProvider.ts
@@ -2,47 +2,203 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
-import { GradleBuildContentProvider } from "../client/GradleBuildContentProvider";
-import { findGradleProjectFromBuild } from "../client/utils";
+import { TaskServerClient } from "../client";
+import { getProjectDependenciesCancellationKey } from "../client/CancellationKeys";
 import { RootProject } from "../rootProject";
+import { getGradleConfig } from "../util/config";
+import { normalizeGradleProjectPath } from "../util/gradlePath";
 import { getDependencyConfigurationTreeItems } from "../views/gradleTasks/DependencyUtils";
 import { HintItem } from "../views/gradleTasks/HintItem";
 import { ProjectDependencyTreeItem } from "../views/gradleTasks/ProjectDependencyTreeItem";
 
+const COMMAND_CANCEL_DEPENDENCY_LOADING = "gradle.cancelDependencyLoading";
+const COMMAND_RELOAD_DEPENDENCIES = "gradle.reloadDependencies";
+
 export class GradleDependencyProvider {
     // <projectPath, configItem[]>
     private cachedDependencies: Map<string, vscode.TreeItem[]> = new Map();
+    private cancelledDependencies: Set<string> = new Set();
+    private loadingDependencies: Map<string, Promise<void>> = new Map();
+    private loadVersions: Map<string, number> = new Map();
+    private dependencyCacheKeys: WeakMap<ProjectDependencyTreeItem, string> = new WeakMap();
+    private loadingDependencyCancellationKeys: Map<string, string> = new Map();
+    private readonly _onDidChangeDependencyTreeItem = new vscode.EventEmitter<vscode.TreeItem>();
+    private nextLoadVersion = 0;
 
-    constructor(private readonly contentProvider: GradleBuildContentProvider) {}
+    constructor(private readonly client: TaskServerClient) {}
+
+    public onDidChangeDependencyTreeItem(refreshTreeItem: (treeItem: vscode.TreeItem) => void): vscode.Disposable {
+        return this._onDidChangeDependencyTreeItem.event(refreshTreeItem);
+    }
 
     public async getDependencies(
         element: ProjectDependencyTreeItem,
         rootProject: RootProject
     ): Promise<vscode.TreeItem[]> {
-        const projectPath = element.getProjectPath();
-        if (this.cachedDependencies.has(projectPath)) {
-            return this.cachedDependencies.get(projectPath)!;
+        const gradleProjectPath = normalizeGradleProjectPath(element.getGradleProjectPath());
+        const cacheKey = `${rootProject.getProjectUri().fsPath}:${gradleProjectPath}`;
+        this.dependencyCacheKeys.set(element, cacheKey);
+        if (this.cachedDependencies.has(cacheKey)) {
+            return this.cachedDependencies.get(cacheKey)!;
         }
-        const gradleBuild = await this.contentProvider.getGradleBuild(rootProject);
-        if (gradleBuild) {
-            const project = findGradleProjectFromBuild(projectPath, gradleBuild);
-            if (project) {
-                const dependencyItem = project.getDependencyitem();
-                if (dependencyItem) {
-                    const configItems = getDependencyConfigurationTreeItems(dependencyItem, element);
-                    if (configItems) {
-                        this.cachedDependencies.set(projectPath, configItems);
-                        return configItems;
-                    }
+
+        if (this.cancelledDependencies.has(cacheKey)) {
+            return [this.getCancelledDependencyTreeItem(element)];
+        }
+
+        const cancellationKey = getProjectDependenciesCancellationKey(
+            rootProject.getProjectUri().fsPath,
+            gradleProjectPath
+        );
+
+        if (!this.loadingDependencies.has(cacheKey)) {
+            const loadVersion = this.createLoadVersion(cacheKey);
+            const dependencyLoad = this.loadDependencies(
+                element,
+                rootProject,
+                gradleProjectPath,
+                cacheKey,
+                loadVersion
+            ).finally(() => {
+                if (this.loadingDependencies.get(cacheKey) === dependencyLoad) {
+                    this.loadingDependencies.delete(cacheKey);
                 }
-            }
+            });
+            this.loadingDependencies.set(cacheKey, dependencyLoad);
         }
-        const noDependencies = GradleDependencyProvider.getNoDependencies();
-        this.cachedDependencies.set(projectPath, noDependencies);
-        return noDependencies;
+
+        this.setLoading(element, cacheKey, cancellationKey);
+        return [this.getLoadingDependencyTreeItem(element)];
+    }
+
+    public async cancelDependencies(element: ProjectDependencyTreeItem): Promise<void> {
+        const cacheKey = this.dependencyCacheKeys.get(element);
+        if (!cacheKey) {
+            return;
+        }
+        const cancellationKey = this.loadingDependencyCancellationKeys.get(cacheKey);
+        if (cancellationKey) {
+            this.cancelledDependencies.add(cacheKey);
+            await this.client.cancelProjectDependencies(cancellationKey);
+        }
+    }
+
+    public reloadDependencies(element: ProjectDependencyTreeItem): void {
+        const cacheKey = this.dependencyCacheKeys.get(element);
+        if (cacheKey) {
+            this.invalidateLoad(cacheKey);
+            this.loadingDependencies.delete(cacheKey);
+            this.cachedDependencies.delete(cacheKey);
+            this.cancelledDependencies.delete(cacheKey);
+        }
+        this._onDidChangeDependencyTreeItem.fire(element);
+    }
+
+    public clearCache(): void {
+        this.cachedDependencies.clear();
+        this.cancelledDependencies.clear();
+        this.loadingDependencies.clear();
+        this.loadVersions.clear();
+        this.loadingDependencyCancellationKeys.clear();
     }
 
     public static getNoDependencies(): vscode.TreeItem[] {
         return [new HintItem("No dependencies")];
+    }
+
+    private createLoadVersion(cacheKey: string): number {
+        const loadVersion = ++this.nextLoadVersion;
+        this.loadVersions.set(cacheKey, loadVersion);
+        return loadVersion;
+    }
+
+    private invalidateLoad(cacheKey: string): void {
+        this.loadVersions.set(cacheKey, ++this.nextLoadVersion);
+    }
+
+    private isCurrentLoad(cacheKey: string, loadVersion: number): boolean {
+        return this.loadVersions.get(cacheKey) === loadVersion;
+    }
+
+    private async loadDependencies(
+        element: ProjectDependencyTreeItem,
+        rootProject: RootProject,
+        gradleProjectPath: string,
+        cacheKey: string,
+        loadVersion: number
+    ): Promise<void> {
+        try {
+            const dependencyItem = await this.client.getProjectDependencies(
+                rootProject,
+                gradleProjectPath,
+                getGradleConfig()
+            );
+            if (!this.isCurrentLoad(cacheKey, loadVersion) || this.cancelledDependencies.has(cacheKey)) {
+                return;
+            }
+            if (dependencyItem) {
+                const configItems = getDependencyConfigurationTreeItems(dependencyItem, element);
+                if (configItems) {
+                    this.cachedDependencies.set(cacheKey, configItems);
+                    return;
+                }
+            }
+
+            this.cachedDependencies.set(cacheKey, GradleDependencyProvider.getNoDependencies());
+        } catch {
+            if (!this.isCurrentLoad(cacheKey, loadVersion) || this.cancelledDependencies.has(cacheKey)) {
+                return;
+            }
+            this.cachedDependencies.set(cacheKey, [new HintItem("Failed to load dependencies")]);
+        } finally {
+            if (this.isCurrentLoad(cacheKey, loadVersion)) {
+                this.setLoading(element, cacheKey, undefined);
+            }
+        }
+    }
+
+    private getLoadingDependencyTreeItem(parent: ProjectDependencyTreeItem): vscode.TreeItem {
+        const item = new vscode.TreeItem("Loading dependencies", vscode.TreeItemCollapsibleState.None);
+        item.iconPath = new vscode.ThemeIcon("loading~spin");
+        item.tooltip = "Cancel loading dependencies";
+        item.command = {
+            command: COMMAND_CANCEL_DEPENDENCY_LOADING,
+            title: "Cancel Loading Dependencies",
+            arguments: [parent],
+        };
+        return item;
+    }
+
+    private getCancelledDependencyTreeItem(parent: ProjectDependencyTreeItem): vscode.TreeItem {
+        const item = new vscode.TreeItem("Loading cancelled", vscode.TreeItemCollapsibleState.None);
+        item.iconPath = new vscode.ThemeIcon("refresh");
+        item.tooltip = "Reload dependencies";
+        item.command = {
+            command: COMMAND_RELOAD_DEPENDENCIES,
+            title: "Reload Dependencies",
+            arguments: [parent],
+        };
+        return item;
+    }
+
+    private setLoading(
+        element: ProjectDependencyTreeItem,
+        cacheKey: string,
+        cancellationKey: string | undefined
+    ): void {
+        if (cancellationKey) {
+            if (this.loadingDependencyCancellationKeys.get(cacheKey) === cancellationKey) {
+                return;
+            }
+            this.loadingDependencyCancellationKeys.set(cacheKey, cancellationKey);
+            element.setLoading(true);
+        } else {
+            if (!this.loadingDependencyCancellationKeys.has(cacheKey)) {
+                return;
+            }
+            this.loadingDependencyCancellationKeys.delete(cacheKey);
+            element.setLoading(false);
+        }
+        this._onDidChangeDependencyTreeItem.fire(element);
     }
 }

--- a/extension/src/test/testUtil.ts
+++ b/extension/src/test/testUtil.ts
@@ -112,6 +112,8 @@ export function buildMockContext(): any {
 export function buildMockClient(): any {
     return {
         getBuild: sinon.stub(),
+        getProjectDependencies: sinon.stub(),
+        cancelProjectDependencies: sinon.stub(),
         getDaemonsStatus: sinon.stub(),
         stopDaemon: sinon.stub(),
         stopDaemons: sinon.stub(),

--- a/extension/src/test/unit/gradleTasks.test.ts
+++ b/extension/src/test/unit/gradleTasks.test.ts
@@ -16,6 +16,7 @@ import {
     stubWorkspaceFolders,
 } from "../testUtil";
 import { GradleBuild, GradleProject } from "../../proto/gradle_pb";
+import { RootProject } from "../../rootProject";
 import {
     GradleTasksTreeDataProvider,
     GradleTaskTreeItem,
@@ -24,6 +25,7 @@ import {
     NoGradleTasksTreeItem,
     RootProjectTreeItem,
 } from "../../views";
+import { ProjectDependencyTreeItem } from "../../views/gradleTasks/ProjectDependencyTreeItem";
 import { GradleTaskProvider } from "../../tasks";
 import { IconPath, Icons } from "../../icons";
 import {
@@ -92,6 +94,34 @@ const mockGradleProjectWithoutTasks = new GradleProject();
 mockGradleProjectWithoutTasks.setIsRoot(true);
 const mockGradleBuildWithoutTasks = new GradleBuild();
 mockGradleBuildWithoutTasks.setProject(mockGradleProjectWithoutTasks);
+
+function createDeferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (reason?: unknown) => void } {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((promiseResolve, promiseReject) => {
+        resolve = promiseResolve;
+        reject = promiseReject;
+    });
+    return { promise, resolve, reject };
+}
+
+function waitForDependencyRefresh(provider: GradleDependencyProvider): Promise<void> {
+    let refreshCount = 0;
+    return new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            subscription.dispose();
+            reject(new Error("Timed out waiting for dependency refresh"));
+        }, 1000);
+        const subscription = provider.onDidChangeDependencyTreeItem(() => {
+            refreshCount++;
+            if (refreshCount === 2) {
+                clearTimeout(timeout);
+                subscription.dispose();
+                resolve();
+            }
+        });
+    });
+}
 
 describe(getSuiteName("Gradle tasks"), () => {
     let gradleTasksTreeDataProvider: GradleTasksTreeDataProvider;
@@ -222,6 +252,87 @@ describe(getSuiteName("Gradle tasks"), () => {
                     assert.strictEqual(iconPath.dark, path.join("resources", "dark", ICON_GRADLE_TASK));
                     assert.strictEqual(iconPath.light, path.join("resources", "light", ICON_GRADLE_TASK));
                     assert.strictEqual(taskItem.parentTreeItem, groupItem);
+                });
+
+                it("should normalize leading-colon root task paths for dependency requests", async () => {
+                    const taskDefinition = buildMockTaskDefinition(mockWorkspaceFolder1, "::assemble", "Description");
+                    const task = buildMockGradleTask(taskDefinition);
+                    const project = new GradleProject();
+                    project.setIsRoot(true);
+                    project.setTasksList([task]);
+                    const build = new GradleBuild();
+                    build.setProject(project);
+                    client.getBuild.resolves(build);
+
+                    const projects = await gradleTasksTreeDataProvider.getChildren();
+                    const projectItem = projects[0] as ProjectTreeItem;
+                    const projectChildren = await gradleTasksTreeDataProvider.getChildrenForProjectTreeItem(
+                        projectItem
+                    );
+                    const dependencyItem = projectChildren.find(
+                        (child) => child instanceof ProjectDependencyTreeItem
+                    ) as ProjectDependencyTreeItem;
+
+                    assert.ok(dependencyItem instanceof ProjectDependencyTreeItem);
+                    assert.strictEqual(dependencyItem.getGradleProjectPath(), ":");
+                });
+
+                it("should show no dependencies when lazy dependency loading returns no dependency item", async () => {
+                    const dependencyRefresh = waitForDependencyRefresh(gradleDependencyProvider);
+                    client.getProjectDependencies.resolves(undefined);
+                    const rootProject = (await rootProjectsStore.getProjectRoots())[0];
+                    const projectItem = gradleProjects[0] as ProjectTreeItem;
+                    const dependencyItem = new ProjectDependencyTreeItem(
+                        "Dependencies",
+                        vscode.TreeItemCollapsibleState.Collapsed,
+                        projectItem,
+                        mockWorkspaceFolder1.uri.fsPath,
+                        "folder1",
+                        ":"
+                    );
+
+                    const loadingItems = await gradleDependencyProvider.getDependencies(dependencyItem, rootProject);
+                    assert.strictEqual(loadingItems[0].label, "Loading dependencies");
+
+                    await dependencyRefresh;
+                    const dependencyItems = await gradleDependencyProvider.getDependencies(dependencyItem, rootProject);
+                    assert.strictEqual(dependencyItems[0].description, "No dependencies");
+                });
+
+                it("should allow dependencies to reload after cancellation", async () => {
+                    const firstDependencyLoad = createDeferred<undefined>();
+                    client.getProjectDependencies.onFirstCall().returns(firstDependencyLoad.promise);
+                    client.getProjectDependencies.onSecondCall().resolves(undefined);
+                    const firstDependencyRefresh = waitForDependencyRefresh(gradleDependencyProvider);
+                    const rootProject = (await rootProjectsStore.getProjectRoots())[0] as RootProject;
+                    const projectItem = gradleProjects[0] as ProjectTreeItem;
+                    const dependencyItem = new ProjectDependencyTreeItem(
+                        "Dependencies",
+                        vscode.TreeItemCollapsibleState.Collapsed,
+                        projectItem,
+                        mockWorkspaceFolder1.uri.fsPath,
+                        "folder1",
+                        ":"
+                    );
+
+                    await gradleDependencyProvider.getDependencies(dependencyItem, rootProject);
+                    await gradleDependencyProvider.cancelDependencies(dependencyItem);
+                    firstDependencyLoad.resolve(undefined);
+                    await firstDependencyRefresh;
+
+                    const cancelledItems = await gradleDependencyProvider.getDependencies(dependencyItem, rootProject);
+                    assert.strictEqual(cancelledItems[0].label, "Loading cancelled");
+                    assert.strictEqual(client.cancelProjectDependencies.callCount, 1);
+
+                    const secondDependencyRefresh = waitForDependencyRefresh(gradleDependencyProvider);
+                    gradleDependencyProvider.reloadDependencies(dependencyItem);
+                    const reloadingItems = await gradleDependencyProvider.getDependencies(dependencyItem, rootProject);
+                    assert.strictEqual(reloadingItems[0].label, "Loading dependencies");
+
+                    await secondDependencyRefresh;
+                    const dependencyItems = await gradleDependencyProvider.getDependencies(dependencyItem, rootProject);
+                    assert.strictEqual(dependencyItems[0].description, "No dependencies");
+                    assert.strictEqual(client.getProjectDependencies.callCount, 2);
                 });
             });
 

--- a/extension/src/util/gradlePath.ts
+++ b/extension/src/util/gradlePath.ts
@@ -1,0 +1,9 @@
+export function normalizeGradleProjectPath(projectPath: string | undefined): string {
+    const segments = (projectPath || "").split(":").filter(Boolean);
+    return segments.length === 0 ? ":" : `:${segments.join(":")}`;
+}
+
+export function getGradleProjectPathFromTaskPath(taskPath: string): string {
+    const segments = taskPath.split(":").filter(Boolean).slice(0, -1);
+    return normalizeGradleProjectPath(segments.join(":"));
+}

--- a/extension/src/views/constants.ts
+++ b/extension/src/views/constants.ts
@@ -20,6 +20,8 @@ export const TREE_ITEM_STATE_TASK_DEBUG_IDLE = "debugTask";
 export const TREE_ITEM_STATE_TASK_PINNED_PREFIX = "pinned";
 export const TREE_ITEM_STATE_NO_TASKS = "notasks";
 export const TREE_ITEM_STATE_FOLDER = "folder";
+export const TREE_ITEM_STATE_DEPENDENCIES = "dependencies";
+export const TREE_ITEM_STATE_DEPENDENCIES_LOADING = "dependenciesLoading";
 
 export const TASK_STATE_RUNNING_REGEX = new RegExp(`^${TREE_ITEM_STATE_TASK_RUNNING}`);
 

--- a/extension/src/views/defaultProject/DefaultProjectsTreeDataProvider.ts
+++ b/extension/src/views/defaultProject/DefaultProjectsTreeDataProvider.ts
@@ -5,6 +5,8 @@ import * as vscode from "vscode";
 import * as path from "path";
 import { GradleTasksTreeDataProvider, GroupTreeItem, ProjectTreeItem } from "..";
 import { TaskServerClient } from "../../client";
+import { findRootProject } from "../../client/utils";
+import { GradleDependencyProvider } from "../../dependencies/GradleDependencyProvider";
 import { RootProjectsStore } from "../../stores";
 import { GradleTaskProvider } from "../../tasks";
 import { DefaultProjectProvider } from "./DefaultProjectProvider";
@@ -14,14 +16,22 @@ import { ProjectTaskTreeItem } from "../gradleTasks/ProjectTaskTreeItem";
 
 export class DefaultProjectsTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
     private defaultProjectProvider: DefaultProjectProvider;
+    private readonly _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | null> =
+        new vscode.EventEmitter<vscode.TreeItem | null>();
+    public readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | null> = this._onDidChangeTreeData.event;
 
     constructor(
         private readonly gradleTaskProvider: GradleTaskProvider,
         private readonly rootProjectStore: RootProjectsStore,
         private readonly client: TaskServerClient,
-        private readonly icons: Icons
+        private readonly icons: Icons,
+        private readonly gradleDependencyProvider: GradleDependencyProvider
     ) {
         this.defaultProjectProvider = new DefaultProjectProvider();
+    }
+
+    public refresh(treeItem: vscode.TreeItem | null = null): void {
+        this._onDidChangeTreeData.fire(treeItem);
     }
 
     public getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
@@ -44,7 +54,11 @@ export class DefaultProjectsTreeDataProvider implements vscode.TreeDataProvider<
         } else if (element instanceof ProjectTreeItem) {
             return this.getChildrenForProjectTreeItem(element);
         } else if (element instanceof ProjectDependencyTreeItem) {
-            return this.defaultProjectProvider.getDefaultDependencyItems(element);
+            const rootProject = await findRootProject(this.rootProjectStore, element.projectPath);
+            if (!rootProject) {
+                return GradleDependencyProvider.getNoDependencies();
+            }
+            return this.gradleDependencyProvider.getDependencies(element, rootProject);
         } else if (element instanceof ProjectTaskTreeItem) {
             return element.getChildren() || [];
         } else if (element instanceof GroupTreeItem) {
@@ -66,7 +80,8 @@ export class DefaultProjectsTreeDataProvider implements vscode.TreeDataProvider<
             vscode.TreeItemCollapsibleState.Collapsed,
             element,
             path.dirname(resourceUri.fsPath),
-            typeof element.label === "string" ? element.label : resourceUri.fsPath
+            typeof element.label === "string" ? element.label : resourceUri.fsPath,
+            element.gradleProjectPath
         );
         return [projectDependencyTreeItem, ...results];
     }

--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -12,6 +12,7 @@ import {
 import { GradleTaskDefinition, GradleTaskProvider } from "../../tasks";
 import { isWorkspaceFolder } from "../../util";
 import { cloneTask, isGradleTask } from "../../tasks/taskUtil";
+import { getGradleProjectPathFromTaskPath } from "../../util/gradlePath";
 import { PinnedTasksStore, RootProjectsStore } from "../../stores";
 import { Icons } from "../../icons";
 import { DependencyConfigurationTreeItem } from "./DependencyConfigurationTreeItem";
@@ -233,7 +234,8 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
             vscode.TreeItemCollapsibleState.Collapsed,
             element,
             path.dirname(resourceUri.fsPath),
-            typeof element.label === "string" ? element.label : resourceUri.fsPath
+            typeof element.label === "string" ? element.label : resourceUri.fsPath,
+            element.gradleProjectPath
         );
         return [...results, projectDependencyTreeItem, ...element.subprojects];
     }
@@ -262,7 +264,8 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
                     gradleProjectTreeItemMap.set(definition.projectFolder, gradleProjectTreeItem);
                 }
 
-                const projectPath = definition.script.split(":").slice(0, -1);
+                const projectPath = definition.script.split(":").filter(Boolean).slice(0, -1);
+                const gradleProjectPath = getGradleProjectPathFromTaskPath(definition.script);
                 const projectMapKey = definition.projectFolder + "_" + projectPath.join(":");
                 let projectTreeItem = projectTreeItemMap.get(projectMapKey);
                 if (!projectTreeItem) {
@@ -274,7 +277,8 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
                     projectTreeItem = new ProjectTreeItem(
                         definition.project,
                         parentProject,
-                        vscode.Uri.file(definition.buildFile)
+                        vscode.Uri.file(definition.buildFile),
+                        gradleProjectPath
                     );
                     if (parentProject instanceof ProjectTreeItem) {
                         parentProject.addSubproject(projectTreeItem);

--- a/extension/src/views/gradleTasks/ProjectDependencyTreeItem.ts
+++ b/extension/src/views/gradleTasks/ProjectDependencyTreeItem.ts
@@ -2,19 +2,29 @@
 // Licensed under the MIT license.
 
 import * as vscode from "vscode";
+import { TREE_ITEM_STATE_DEPENDENCIES, TREE_ITEM_STATE_DEPENDENCIES_LOADING } from "../constants";
 
 export class ProjectDependencyTreeItem extends vscode.TreeItem {
     private children: vscode.TreeItem[] | undefined;
+    private readonly defaultIconPath: vscode.ThemeIcon;
     constructor(
         name: string,
         collapsibleState: vscode.TreeItemCollapsibleState,
         public readonly parentTreeItem: vscode.TreeItem,
         readonly projectPath: string,
         readonly projectName: string,
+        readonly gradleProjectPath: string,
         iconPath: vscode.ThemeIcon = new vscode.ThemeIcon("folder-library")
     ) {
         super(name, collapsibleState);
+        this.defaultIconPath = iconPath;
         this.iconPath = iconPath;
+        this.contextValue = TREE_ITEM_STATE_DEPENDENCIES;
+    }
+
+    public setLoading(loading: boolean): void {
+        this.contextValue = loading ? TREE_ITEM_STATE_DEPENDENCIES_LOADING : TREE_ITEM_STATE_DEPENDENCIES;
+        this.iconPath = loading ? new vscode.ThemeIcon("loading~spin") : this.defaultIconPath;
     }
 
     public setChildren(children: vscode.TreeItem[]): void {
@@ -31,5 +41,9 @@ export class ProjectDependencyTreeItem extends vscode.TreeItem {
 
     public getProjectName(): string {
         return this.projectName;
+    }
+
+    public getGradleProjectPath(): string {
+        return this.gradleProjectPath;
     }
 }

--- a/extension/src/views/gradleTasks/ProjectTreeItem.ts
+++ b/extension/src/views/gradleTasks/ProjectTreeItem.ts
@@ -3,4 +3,14 @@ import { TreeItemWithTasksOrGroups } from ".";
 
 export class ProjectTreeItem extends TreeItemWithTasksOrGroups {
     public readonly iconPath = vscode.ThemeIcon.File;
+
+    constructor(
+        name: string,
+        parentTreeItem?: vscode.TreeItem,
+        resourceUri?: vscode.Uri,
+        public readonly gradleProjectPath = ":",
+        collapsibleState = vscode.TreeItemCollapsibleState.Expanded
+    ) {
+        super(name, parentTreeItem, resourceUri, collapsibleState);
+    }
 }

--- a/gradle-plugin-api/src/main/java/com/microsoft/gradle/api/GradleDependencyModel.java
+++ b/gradle-plugin-api/src/main/java/com/microsoft/gradle/api/GradleDependencyModel.java
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.gradle.api;
+
+import org.gradle.tooling.model.Model;
+
+public interface GradleDependencyModel extends Model {
+	GradleDependencyNode getDependencyNode();
+}

--- a/gradle-plugin-api/src/main/java/com/microsoft/gradle/api/GradleDependencyModelAction.java
+++ b/gradle-plugin-api/src/main/java/com/microsoft/gradle/api/GradleDependencyModelAction.java
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.gradle.api;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+public class GradleDependencyModelAction implements BuildAction<GradleDependencyNode> {
+	private final String projectPath;
+
+	public GradleDependencyModelAction(String projectPath) {
+		this.projectPath = normalizeProjectPath(projectPath);
+	}
+
+	private static String normalizeProjectPath(String projectPath) {
+		if (projectPath == null) {
+			return ":";
+		}
+		StringBuilder normalizedPath = new StringBuilder();
+		for (String segment : projectPath.split(":")) {
+			if (!segment.isEmpty()) {
+				normalizedPath.append(":").append(segment);
+			}
+		}
+		return normalizedPath.length() == 0 ? ":" : normalizedPath.toString();
+	}
+
+	@Override
+	public GradleDependencyNode execute(BuildController controller) {
+		GradleBuild build = controller.getBuildModel();
+		return getDependencyNode(controller, build);
+	}
+
+	private GradleDependencyNode getDependencyNode(BuildController controller, GradleBuild build) {
+		for (BasicGradleProject project : build.getProjects()) {
+			if (this.projectPath.equals(project.getPath())) {
+				GradleDependencyModel dependencyModel = controller.getModel(project, GradleDependencyModel.class);
+				return dependencyModel.getDependencyNode();
+			}
+		}
+		for (GradleBuild includedBuild : build.getIncludedBuilds()) {
+			GradleDependencyNode dependencyNode = getDependencyNode(controller, includedBuild);
+			if (dependencyNode != null) {
+				return dependencyNode;
+			}
+		}
+		return null;
+	}
+}

--- a/gradle-plugin/src/main/java/com/microsoft/gradle/DefaultGradleDependencyModel.java
+++ b/gradle-plugin/src/main/java/com/microsoft/gradle/DefaultGradleDependencyModel.java
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.microsoft.gradle;
+
+import com.microsoft.gradle.api.GradleDependencyModel;
+import com.microsoft.gradle.api.GradleDependencyNode;
+import java.io.Serializable;
+
+public class DefaultGradleDependencyModel implements GradleDependencyModel, Serializable {
+	private GradleDependencyNode node;
+
+	public DefaultGradleDependencyModel(GradleDependencyNode node) {
+		this.node = node;
+	}
+
+	@Override
+	public GradleDependencyNode getDependencyNode() {
+		return this.node;
+	}
+}

--- a/gradle-plugin/src/main/java/com/microsoft/gradle/GradleProjectModelBuilder.java
+++ b/gradle-plugin/src/main/java/com/microsoft/gradle/GradleProjectModelBuilder.java
@@ -4,6 +4,7 @@
 package com.microsoft.gradle;
 
 import com.microsoft.gradle.api.GradleClosure;
+import com.microsoft.gradle.api.GradleDependencyModel;
 import com.microsoft.gradle.api.GradleDependencyNode;
 import com.microsoft.gradle.api.GradleDependencyType;
 import com.microsoft.gradle.api.GradleField;
@@ -56,10 +57,14 @@ public class GradleProjectModelBuilder implements ToolingModelBuilder {
 	}
 
 	public boolean canBuild(String modelName) {
-		return modelName.equals(GradleProjectModel.class.getName());
+		return modelName.equals(GradleProjectModel.class.getName())
+				|| modelName.equals(GradleDependencyModel.class.getName());
 	}
 
 	public Object buildAll(String modelName, Project project) {
+		if (modelName.equals(GradleDependencyModel.class.getName())) {
+			return new DefaultGradleDependencyModel(generateDefaultGradleDependencyNode(project));
+		}
 		cachedTasks.clear();
 		DefaultGradleProject gradleProject = (DefaultGradleProject) this.registry
 				.getBuilder("org.gradle.tooling.model.GradleProject").buildAll(modelName, project);
@@ -100,7 +105,7 @@ public class GradleProjectModelBuilder implements ToolingModelBuilder {
 		classpath.getAsFiles().forEach((file) -> {
 			scriptClasspaths.add(file.getAbsolutePath());
 		});
-		GradleDependencyNode node = generateDefaultGradleDependencyNode(project);
+		GradleDependencyNode node = new DefaultGradleDependencyNode(project.getName(), GradleDependencyType.PROJECT);
 		List<String> plugins = getPlugins(project);
 		List<GradleClosure> closures = getPluginClosures(project);
 		List<GradleProjectModel> subModels = new ArrayList<>();

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/TaskService.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/TaskService.java
@@ -4,6 +4,7 @@ import com.github.badsyntax.gradle.handlers.CancelBuildHandler;
 import com.github.badsyntax.gradle.handlers.CancelBuildsHandler;
 import com.github.badsyntax.gradle.handlers.ExecuteCommandHandler;
 import com.github.badsyntax.gradle.handlers.GetBuildHandler;
+import com.github.badsyntax.gradle.handlers.GetProjectDependenciesHandler;
 import com.github.badsyntax.gradle.handlers.RunBuildHandler;
 import io.grpc.stub.StreamObserver;
 
@@ -13,6 +14,13 @@ public class TaskService extends GradleGrpc.GradleImplBase {
 	public void getBuild(GetBuildRequest req, StreamObserver<GetBuildReply> responseObserver) {
 		GetBuildHandler getBuildHandler = new GetBuildHandler(req, responseObserver);
 		getBuildHandler.run();
+	}
+
+	@Override
+	public void getProjectDependencies(GetProjectDependenciesRequest req,
+			StreamObserver<GetProjectDependenciesReply> responseObserver) {
+		GetProjectDependenciesHandler handler = new GetProjectDependenciesHandler(req, responseObserver);
+		handler.run();
 	}
 
 	@Override

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/DependencyItemUtils.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/DependencyItemUtils.java
@@ -1,0 +1,26 @@
+package com.github.badsyntax.gradle.handlers;
+
+import com.github.badsyntax.gradle.DependencyItem;
+import com.microsoft.gradle.api.GradleDependencyNode;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class DependencyItemUtils {
+	private DependencyItemUtils() {
+	}
+
+	public static DependencyItem getDependencyItem(GradleDependencyNode node) {
+		DependencyItem.Builder item = DependencyItem.newBuilder();
+		item.setName(node.getName());
+		item.setTypeValue(node.getType().ordinal());
+		if (node.getChildren() == null) {
+			return item.build();
+		}
+		List<DependencyItem> children = new ArrayList<>();
+		for (GradleDependencyNode child : node.getChildren()) {
+			children.add(getDependencyItem(child));
+		}
+		item.addAllChildren(children);
+		return item.build();
+	}
+}

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -2,7 +2,6 @@ package com.github.badsyntax.gradle.handlers;
 
 import com.github.badsyntax.gradle.ByteBufferOutputStream;
 import com.github.badsyntax.gradle.Cancelled;
-import com.github.badsyntax.gradle.DependencyItem;
 import com.github.badsyntax.gradle.Environment;
 import com.github.badsyntax.gradle.ErrorMessageBuilder;
 import com.github.badsyntax.gradle.GetBuildReply;
@@ -25,7 +24,6 @@ import com.github.badsyntax.gradle.utils.Utils;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 import com.microsoft.gradle.api.GradleClosure;
-import com.microsoft.gradle.api.GradleDependencyNode;
 import com.microsoft.gradle.api.GradleField;
 import com.microsoft.gradle.api.GradleMethod;
 import com.microsoft.gradle.api.GradleModelAction;
@@ -38,7 +36,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.gradle.internal.service.ServiceCreationException;
 import org.gradle.tooling.BuildActionExecuter;
 import org.gradle.tooling.BuildCancelledException;
@@ -110,10 +107,7 @@ public class GetBuildHandler {
 				arguments.addAll(Arrays.asList("--init-script", initScript.getAbsolutePath()));
 			}
 			String jvmArguments = req.getGradleConfig().getJvmArguments();
-			if (!Strings.isNullOrEmpty(jvmArguments)) {
-				arguments.addAll(Arrays.stream(jvmArguments.split(" ")).filter(e -> e != null && !e.isEmpty())
-						.collect(Collectors.toList()));
-			}
+			arguments.addAll(GradleArguments.parseJvmArguments(jvmArguments));
 			action.withArguments(arguments);
 			CancellationToken cancellationToken = GradleBuildCancellation.buildToken(req.getCancellationKey());
 			Set<OperationType> progressEvents = new HashSet<>();
@@ -187,10 +181,7 @@ public class GetBuildHandler {
 				.setStandardOutput(standardOutputListener).setStandardError(standardErrorListener)
 				.setColorOutput(req.getShowOutputColors());
 		String jvmArguments = req.getGradleConfig().getJvmArguments();
-		if (!Strings.isNullOrEmpty(jvmArguments)) {
-			buildEnvironment.setJvmArguments(Arrays.stream(jvmArguments.split(" "))
-					.filter(e -> e != null && !e.isEmpty()).toArray(String[]::new));
-		}
+		buildEnvironment.setJvmArguments(GradleArguments.parseJvmArguments(jvmArguments).toArray(new String[0]));
 
 		try {
 			BuildEnvironment environment = buildEnvironment.get();
@@ -221,7 +212,7 @@ public class GetBuildHandler {
 		}
 		project.addAllProjects(subProjects);
 		project.setProjectPath(gradleModel.getProjectPath());
-		project.setDependencyItem(getDependencyItem(gradleModel.getDependencyNode()));
+		project.setDependencyItem(DependencyItemUtils.getDependencyItem(gradleModel.getDependencyNode()));
 		project.addAllPlugins(gradleModel.getPlugins());
 		project.addAllPluginClosures(getPluginClosures(gradleModel));
 		project.addAllScriptClasspaths(gradleModel.getScriptClasspaths());
@@ -246,21 +237,6 @@ public class GetBuildHandler {
 			tasks.add(builder.build());
 		});
 		return tasks;
-	}
-
-	private DependencyItem getDependencyItem(GradleDependencyNode node) {
-		DependencyItem.Builder item = DependencyItem.newBuilder();
-		item.setName(node.getName());
-		item.setTypeValue(node.getType().ordinal());
-		if (node.getChildren() == null) {
-			return item.build();
-		}
-		List<DependencyItem> children = new ArrayList<>();
-		for (GradleDependencyNode child : node.getChildren()) {
-			children.add(getDependencyItem(child));
-		}
-		item.addAllChildren(children);
-		return item.build();
 	}
 
 	private List<GrpcGradleClosure> getPluginClosures(GradleProjectModel model) {

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetProjectDependenciesHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetProjectDependenciesHandler.java
@@ -1,0 +1,74 @@
+package com.github.badsyntax.gradle.handlers;
+
+import com.github.badsyntax.gradle.ErrorMessageBuilder;
+import com.github.badsyntax.gradle.GetProjectDependenciesReply;
+import com.github.badsyntax.gradle.GetProjectDependenciesRequest;
+import com.github.badsyntax.gradle.GradleBuildCancellation;
+import com.github.badsyntax.gradle.GradleProjectConnector;
+import com.github.badsyntax.gradle.utils.PluginUtils;
+import com.google.common.base.Strings;
+import com.microsoft.gradle.api.GradleDependencyModelAction;
+import com.microsoft.gradle.api.GradleDependencyNode;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.gradle.tooling.BuildActionExecuter;
+import org.gradle.tooling.BuildCancelledException;
+import org.gradle.tooling.CancellationToken;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+
+public class GetProjectDependenciesHandler {
+	private GetProjectDependenciesRequest req;
+	private StreamObserver<GetProjectDependenciesReply> responseObserver;
+
+	public GetProjectDependenciesHandler(GetProjectDependenciesRequest req,
+			StreamObserver<GetProjectDependenciesReply> responseObserver) {
+		this.req = req;
+		this.responseObserver = responseObserver;
+	}
+
+	public void run() {
+		GradleConnector gradleConnector = GradleProjectConnector.build(req.getProjectDir(), req.getGradleConfig());
+		try (ProjectConnection connection = gradleConnector.connect()) {
+			BuildActionExecuter<GradleDependencyNode> action = connection
+					.action(new GradleDependencyModelAction(req.getProjectPath()));
+			List<String> arguments = new ArrayList<>();
+			String debugPlugin = System.getenv("VSCODE_DEBUG_PLUGIN");
+			if ("true".equals(debugPlugin)) {
+				arguments.add("-Dorg.gradle.debug=true");
+			}
+			File initScript = PluginUtils.getInitScript();
+			if (initScript != null) {
+				arguments.addAll(Arrays.asList("--init-script", initScript.getAbsolutePath()));
+			}
+			String jvmArguments = req.getGradleConfig().getJvmArguments();
+			arguments.addAll(GradleArguments.parseJvmArguments(jvmArguments));
+			action.withArguments(arguments);
+			CancellationToken cancellationToken = GradleBuildCancellation.buildToken(req.getCancellationKey());
+			action.withCancellationToken(cancellationToken).setColorOutput(req.getShowOutputColors());
+			if (!Strings.isNullOrEmpty(req.getGradleConfig().getJavaHome())) {
+				action.setJavaHome(new File(req.getGradleConfig().getJavaHome()));
+			}
+			GradleDependencyNode dependencyNode = action.run();
+			if (dependencyNode == null) {
+				responseObserver.onError(ErrorMessageBuilder.build(
+						new IllegalArgumentException("Cannot find Gradle project: " + req.getProjectPath()),
+						Status.NOT_FOUND));
+				return;
+			}
+			responseObserver.onNext(GetProjectDependenciesReply.newBuilder()
+					.setDependencyItem(DependencyItemUtils.getDependencyItem(dependencyNode)).build());
+			responseObserver.onCompleted();
+		} catch (BuildCancelledException e) {
+			responseObserver.onError(ErrorMessageBuilder.build(e, Status.CANCELLED));
+		} catch (Exception e) {
+			responseObserver.onError(ErrorMessageBuilder.build(e));
+		} finally {
+			GradleBuildCancellation.clearToken(req.getCancellationKey());
+		}
+	}
+}

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GradleArguments.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GradleArguments.java
@@ -1,0 +1,56 @@
+package com.github.badsyntax.gradle.handlers;
+
+import com.google.common.base.Strings;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class GradleArguments {
+
+	private GradleArguments() {
+	}
+
+	public static List<String> parseJvmArguments(String arguments) {
+		List<String> result = new ArrayList<>();
+		if (Strings.isNullOrEmpty(arguments)) {
+			return result;
+		}
+		StringBuilder current = new StringBuilder();
+		char quote = 0;
+		for (int index = 0; index < arguments.length(); index++) {
+			char currentChar = arguments.charAt(index);
+			if (quote == 0 && Character.isWhitespace(currentChar)) {
+				addArgument(result, current);
+				continue;
+			}
+			if (currentChar == '\'' || currentChar == '"') {
+				if (quote == 0) {
+					quote = currentChar;
+					continue;
+				}
+				if (quote == currentChar) {
+					quote = 0;
+					continue;
+				}
+			}
+			if (currentChar == '\\' && index + 1 < arguments.length()) {
+				char nextChar = arguments.charAt(index + 1);
+				if (nextChar == '\'' || nextChar == '"' || Character.isWhitespace(nextChar) || nextChar == '\\') {
+					current.append(nextChar);
+					index++;
+					continue;
+				}
+			}
+			current.append(currentChar);
+		}
+		addArgument(result, current);
+		return result;
+	}
+
+	private static void addArgument(List<String> result, StringBuilder current) {
+		if (current.length() == 0) {
+			return;
+		}
+		result.add(current.toString());
+		current.setLength(0);
+	}
+}

--- a/proto/gradle.proto
+++ b/proto/gradle.proto
@@ -8,6 +8,7 @@ package gradle;
 
 service Gradle {
   rpc GetBuild(GetBuildRequest) returns (stream GetBuildReply) {}
+  rpc GetProjectDependencies(GetProjectDependenciesRequest) returns (GetProjectDependenciesReply) {}
   rpc RunBuild(RunBuildRequest) returns (stream RunBuildReply) {}
   rpc CancelBuild(CancelBuildRequest) returns (CancelBuildReply) {}
   rpc CancelBuilds(CancelBuildsRequest) returns (CancelBuildsReply) {}
@@ -30,6 +31,18 @@ message GetBuildReply {
     Environment environment = 5;
     string compatibility_check_error = 6;
   }
+}
+
+message GetProjectDependenciesRequest {
+  string project_dir = 1;
+  string project_path = 2;
+  string cancellation_key = 3;
+  GradleConfig gradle_config = 4;
+  bool show_output_colors = 5;
+}
+
+message GetProjectDependenciesReply {
+  DependencyItem dependency_item = 1;
 }
 
 message GetBuildResult {


### PR DESCRIPTION
## Summary
- avoid resolving full Gradle dependency trees during initial project/task loading
- add a lazy GetProjectDependencies RPC and dependency-only Tooling API model/action
- load dependency nodes on expansion with per-node stop and reload controls
- clear dependency cache on Gradle refresh and add tests for empty/cancelled reload behavior

Fixes #1822

## Testing
- ./gradlew build
- cd extension && npm run compile:test
- cd extension && npm run lint (passes with existing no-explicit-any warnings)
- cd extension && npm run compile
- cd extension && npm test: no-gradle unit suite passed (56 passing, 1 pending); Gradle integration fixture still failed at task discovery before dependency expansion behavior was exercised