### PR TITLE
fix: recover from spurious gRPC CANCELLED on first Refresh

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -21,7 +21,7 @@
         "vscode-languageclient": "7.0.0"
       },
       "devDependencies": {
-        "@grpc/grpc-js": "^1.8.22",
+        "@grpc/grpc-js": "^1.14.3",
         "@types/fs-extra": "^11.0.1",
         "@types/glob": "^8.1.0",
         "@types/google-protobuf": "^3.15.6",
@@ -299,12 +299,13 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz",
-      "integrity": "sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.13",
+        "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
@@ -312,14 +313,15 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.13",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
-      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.5",
+        "protobufjs": "^7.5.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -679,31 +681,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -713,31 +720,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
       "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -2133,6 +2145,7 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -2147,6 +2160,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2162,6 +2176,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2173,19 +2188,22 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2200,6 +2218,7 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4204,7 +4223,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -4347,10 +4367,11 @@
       }
     },
     "node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
-      "dev": true
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -5401,6 +5422,7 @@
       "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -7211,6 +7233,7 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -7252,13 +7275,15 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -7273,6 +7298,7 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/extension/package.json
+++ b/extension/package.json
@@ -956,7 +956,7 @@
     "update-tpn": "node scripts/update-third-party-notice.js"
   },
   "devDependencies": {
-    "@grpc/grpc-js": "^1.8.22",
+    "@grpc/grpc-js": "^1.14.3",
     "@types/fs-extra": "^11.0.1",
     "@types/glob": "^8.1.0",
     "@types/google-protobuf": "^3.15.6",

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -32,6 +32,7 @@ import { EventWaiter } from "../util/EventWaiter";
 import { getGradleConfig, getJavaDebugCleanOutput } from "../util/config";
 import { setDefault, unsetDefault } from "../views/defaultProject/DefaultProjectUtils";
 import { SpecifySourcePackageNameStep } from "../createProject/SpecifySourcePackageNameStep";
+import { retryOnSpuriousCancel } from "./retryOnSpuriousCancel";
 
 function logBuildEnvironment(environment: Environment): void {
     const javaEnv = environment.getJavaEnvironment()!;
@@ -135,88 +136,137 @@ export class TaskServerClient implements vscode.Disposable {
 
                 token.onCancellationRequested(() => this.cancelBuild(cancellationKey));
 
-                const stdOutLoggerStream = new LoggerStream(logger, LogVerbosity.INFO);
-                const stdErrLoggerStream = new LoggerStream(logger, LogVerbosity.ERROR);
-
-                const request = new GetBuildRequest();
-                request.setProjectDir(rootProject.getProjectUri().fsPath);
-                request.setCancellationKey(cancellationKey);
-                request.setGradleConfig(gradleConfig);
-                request.setShowOutputColors(showOutputColors);
-                const getBuildStream = this.grpcClient!.getBuild(request);
                 try {
-                    return await new Promise((resolve, reject) => {
-                        let build: GradleBuild | undefined;
-                        getBuildStream
-                            .on("data", async (getBuildReply: GetBuildReply) => {
-                                switch (getBuildReply.getKindCase()) {
-                                    case GetBuildReply.KindCase.PROGRESS:
-                                        progressHandler.report(getBuildReply.getProgress()!.getMessage().trim());
-                                        break;
-                                    case GetBuildReply.KindCase.OUTPUT:
-                                        switch (getBuildReply.getOutput()!.getOutputType()) {
-                                            case Output.OutputType.STDOUT:
-                                                stdOutLoggerStream.write(
-                                                    getBuildReply.getOutput()!.getOutputBytes_asU8()
-                                                );
-                                                break;
-                                            case Output.OutputType.STDERR:
-                                                stdErrLoggerStream.write(
-                                                    getBuildReply.getOutput()!.getOutputBytes_asU8()
-                                                );
-                                                break;
-                                        }
-                                        break;
-                                    case GetBuildReply.KindCase.CANCELLED:
-                                        this.handleGetBuildCancelled(getBuildReply.getCancelled()!);
-                                        break;
-                                    case GetBuildReply.KindCase.GET_BUILD_RESULT:
-                                        void unsetDefault();
-                                        build = getBuildReply.getGetBuildResult()!.getBuild();
-                                        break;
-                                    case GetBuildReply.KindCase.ENVIRONMENT:
-                                        const environment = getBuildReply.getEnvironment()!;
-                                        rootProject.setEnvironment(environment);
-                                        logBuildEnvironment(environment);
-                                        await vscode.commands.executeCommand(COMMAND_REFRESH_DAEMON_STATUS);
-                                        break;
-                                    case GetBuildReply.KindCase.COMPATIBILITY_CHECK_ERROR:
-                                        const message = getBuildReply.getCompatibilityCheckError()!;
-                                        const options = ["Open Gradle Settings", "Learn More"];
-                                        await vscode.window.showErrorMessage(message, ...options).then((choice) => {
-                                            if (choice === "Open Gradle Settings") {
-                                                void vscode.commands.executeCommand(
-                                                    "workbench.action.openSettings",
-                                                    "java.import.gradle"
-                                                );
-                                            } else if (choice === "Learn More") {
-                                                void vscode.env.openExternal(
-                                                    vscode.Uri.parse(
-                                                        "https://docs.gradle.org/current/userguide/compatibility.html"
-                                                    )
-                                                );
-                                            }
-                                        });
-                                        break;
-                                }
-                            })
-                            .on("error", reject)
-                            .on("end", () => resolve(build));
-                    });
+                    // Workaround for a Node.js http2 race when reusing an HTTP/2 session
+                    // after a large server-streaming response: the first DATA frame on a
+                    // new stream can arrive truncated with END_STREAM, causing the server
+                    // to reset the stream and grpc-js to surface a synthetic CANCELLED.
+                    // grpc-node maintainers track this as Node-side behavior and the
+                    // recommended fix is application-level retry (see grpc/grpc-node#2872).
+                    // Only retry once when there is no risk of duplicate side-effects:
+                    // CANCELLED, no data observed, finished in < 2s, and the user did not
+                    // cancel.
+                    return await retryOnSpuriousCancel(
+                        "GetBuild",
+                        () =>
+                            this.runGetBuildStream(
+                                rootProject,
+                                cancellationKey,
+                                gradleConfig,
+                                showOutputColors,
+                                progressHandler
+                            ),
+                        (err) => {
+                            const tagged = err as grpc.ServiceError & {
+                                __receivedAnyData?: boolean;
+                                __durationMs?: number;
+                            };
+                            return (
+                                tagged?.code === grpc.status.CANCELLED &&
+                                !tagged.__receivedAnyData &&
+                                (tagged.__durationMs ?? Number.MAX_SAFE_INTEGER) < 2000 &&
+                                !token.isCancellationRequested
+                            );
+                        },
+                        { logger }
+                    );
                 } catch (err) {
                     void setDefault();
+                    const e = err as grpc.ServiceError;
                     logger.error(
-                        `Error getting build for ${rootProject.getProjectUri().fsPath}: ${err.details || err.message}`
+                        `Error getting build for ${rootProject.getProjectUri().fsPath}: ${e?.details || e?.message}`
                     );
                     this.statusBarItem.command = COMMAND_SHOW_LOGS;
                     this.statusBarItem.text = "$(warning) Gradle: Build Error";
                     this.statusBarItem.show();
+                    return undefined;
                 } finally {
                     process.nextTick(() => vscode.commands.executeCommand(COMMAND_REFRESH_DAEMON_STATUS));
                 }
-                return undefined;
             }
         );
+    }
+
+    private runGetBuildStream(
+        rootProject: RootProject,
+        cancellationKey: string,
+        gradleConfig: GradleConfig,
+        showOutputColors: boolean,
+        progressHandler: ProgressHandler
+    ): Promise<GradleBuild | undefined> {
+        const stdOutLoggerStream = new LoggerStream(logger, LogVerbosity.INFO);
+        const stdErrLoggerStream = new LoggerStream(logger, LogVerbosity.ERROR);
+
+        const request = new GetBuildRequest();
+        request.setProjectDir(rootProject.getProjectUri().fsPath);
+        request.setCancellationKey(cancellationKey);
+        request.setGradleConfig(gradleConfig);
+        request.setShowOutputColors(showOutputColors);
+        const getBuildStream = this.grpcClient!.getBuild(request);
+        const attemptStartTs = Date.now();
+        let receivedAnyData = false;
+        return new Promise((resolve, reject) => {
+            let build: GradleBuild | undefined;
+            getBuildStream
+                .on("data", async (getBuildReply: GetBuildReply) => {
+                    receivedAnyData = true;
+                    switch (getBuildReply.getKindCase()) {
+                        case GetBuildReply.KindCase.PROGRESS:
+                            progressHandler.report(getBuildReply.getProgress()!.getMessage().trim());
+                            break;
+                        case GetBuildReply.KindCase.OUTPUT:
+                            switch (getBuildReply.getOutput()!.getOutputType()) {
+                                case Output.OutputType.STDOUT:
+                                    stdOutLoggerStream.write(getBuildReply.getOutput()!.getOutputBytes_asU8());
+                                    break;
+                                case Output.OutputType.STDERR:
+                                    stdErrLoggerStream.write(getBuildReply.getOutput()!.getOutputBytes_asU8());
+                                    break;
+                            }
+                            break;
+                        case GetBuildReply.KindCase.CANCELLED:
+                            this.handleGetBuildCancelled(getBuildReply.getCancelled()!);
+                            break;
+                        case GetBuildReply.KindCase.GET_BUILD_RESULT:
+                            void unsetDefault();
+                            build = getBuildReply.getGetBuildResult()!.getBuild();
+                            break;
+                        case GetBuildReply.KindCase.ENVIRONMENT:
+                            const environment = getBuildReply.getEnvironment()!;
+                            rootProject.setEnvironment(environment);
+                            logBuildEnvironment(environment);
+                            await vscode.commands.executeCommand(COMMAND_REFRESH_DAEMON_STATUS);
+                            break;
+                        case GetBuildReply.KindCase.COMPATIBILITY_CHECK_ERROR:
+                            const message = getBuildReply.getCompatibilityCheckError()!;
+                            const options = ["Open Gradle Settings", "Learn More"];
+                            await vscode.window.showErrorMessage(message, ...options).then((choice) => {
+                                if (choice === "Open Gradle Settings") {
+                                    void vscode.commands.executeCommand(
+                                        "workbench.action.openSettings",
+                                        "java.import.gradle"
+                                    );
+                                } else if (choice === "Learn More") {
+                                    void vscode.env.openExternal(
+                                        vscode.Uri.parse("https://docs.gradle.org/current/userguide/compatibility.html")
+                                    );
+                                }
+                            });
+                            break;
+                    }
+                })
+                .on("error", (err: grpc.ServiceError) => {
+                    // Attach signals consumed by the retry-eligibility check in getBuild().
+                    const tagged = err as grpc.ServiceError & {
+                        __receivedAnyData?: boolean;
+                        __durationMs?: number;
+                    };
+                    tagged.__receivedAnyData = receivedAnyData;
+                    tagged.__durationMs = Date.now() - attemptStartTs;
+                    reject(err);
+                })
+                .on("end", () => resolve(build));
+        });
     }
 
     public async runBuild(
@@ -310,18 +360,24 @@ export class TaskServerClient implements vscode.Disposable {
         const request = new CancelBuildRequest();
         request.setCancellationKey(cancellationKey);
         try {
-            const reply: CancelBuildReply | undefined = await new Promise((resolve, reject) => {
-                this.grpcClient!.cancelBuild(
-                    request,
-                    (err: grpc.ServiceError | null, cancelRunBuildReply: CancelBuildReply | undefined) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(cancelRunBuildReply);
-                        }
-                    }
-                );
-            });
+            const reply: CancelBuildReply | undefined = await retryOnSpuriousCancel(
+                "CancelBuild",
+                () =>
+                    new Promise((resolve, reject) => {
+                        this.grpcClient!.cancelBuild(
+                            request,
+                            (err: grpc.ServiceError | null, cancelRunBuildReply: CancelBuildReply | undefined) => {
+                                if (err) {
+                                    reject(err);
+                                } else {
+                                    resolve(cancelRunBuildReply);
+                                }
+                            }
+                        );
+                    }),
+                undefined,
+                { logger }
+            );
             if (reply) {
                 logger.info("Cancel build:", reply.getMessage());
 
@@ -338,18 +394,24 @@ export class TaskServerClient implements vscode.Disposable {
         this.statusBarItem.hide();
         const request = new CancelBuildsRequest();
         try {
-            const reply: CancelBuildsReply | undefined = await new Promise((resolve, reject) => {
-                this.grpcClient!.cancelBuilds(
-                    request,
-                    (err: grpc.ServiceError | null, cancelRunBuildsReply: CancelBuildsReply | undefined) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(cancelRunBuildsReply);
-                        }
-                    }
-                );
-            });
+            const reply: CancelBuildsReply | undefined = await retryOnSpuriousCancel(
+                "CancelBuilds",
+                () =>
+                    new Promise((resolve, reject) => {
+                        this.grpcClient!.cancelBuilds(
+                            request,
+                            (err: grpc.ServiceError | null, cancelRunBuildsReply: CancelBuildsReply | undefined) => {
+                                if (err) {
+                                    reject(err);
+                                } else {
+                                    resolve(cancelRunBuildsReply);
+                                }
+                            }
+                        );
+                    }),
+                undefined,
+                { logger }
+            );
             if (reply) {
                 logger.info("Cancel builds:", reply.getMessage());
             }
@@ -364,18 +426,24 @@ export class TaskServerClient implements vscode.Disposable {
         request.setCommand(SpecifySourcePackageNameStep.GET_NORMALIZED_PACKAGE_NAME);
         request.addArguments(name);
         try {
-            return await new Promise((resolve, reject) => {
-                this.grpcClient!.executeCommand(
-                    request,
-                    (err: grpc.ServiceError | null, executeCommandReply: ExecuteCommandReply | undefined) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(executeCommandReply?.getResult());
-                        }
-                    }
-                );
-            });
+            return await retryOnSpuriousCancel(
+                "ExecuteCommand:getNormalizedPackageName",
+                () =>
+                    new Promise<string | undefined>((resolve, reject) => {
+                        this.grpcClient!.executeCommand(
+                            request,
+                            (err: grpc.ServiceError | null, executeCommandReply: ExecuteCommandReply | undefined) => {
+                                if (err) {
+                                    reject(err);
+                                } else {
+                                    resolve(executeCommandReply?.getResult());
+                                }
+                            }
+                        );
+                    }),
+                undefined,
+                { logger }
+            );
         } catch (err) {
             return undefined;
         }

--- a/extension/src/client/retryOnSpuriousCancel.ts
+++ b/extension/src/client/retryOnSpuriousCancel.ts
@@ -1,0 +1,53 @@
+import * as grpc from "@grpc/grpc-js";
+
+/**
+ * Pluggable logger surface. Only `debug` is used; the call sites pass the
+ * extension `logger` but tests can pass a stub.
+ */
+export interface RetryLogger {
+    debug(...messages: string[]): void;
+}
+
+/**
+ * Default eligibility predicate: retry only on the generic `CANCELLED` status.
+ * Callers can pass a narrower predicate (e.g. server-streaming callers also
+ * require zero data observed, a short duration, and that the user did not
+ * cancel).
+ */
+const defaultIsRetryable = (err: grpc.ServiceError | undefined): boolean => err?.code === grpc.status.CANCELLED;
+
+/**
+ * Wrap a gRPC call so a spurious CANCELLED caused by a Node.js http2 race
+ * (see grpc/grpc-node#2872) is retried once. Only safe for idempotent or
+ * read-only calls: when the workaround triggers, the server detected a
+ * truncated request frame and reset the stream before doing any work, so a
+ * single retry will not produce duplicate side-effects.
+ *
+ * The function preserves the original error (the last attempt's error is
+ * thrown) and only swallows a retry when the predicate explicitly allows it.
+ */
+export async function retryOnSpuriousCancel<T>(
+    operationName: string,
+    operation: () => Promise<T>,
+    isRetryable: (err: grpc.ServiceError) => boolean = defaultIsRetryable,
+    options: { maxAttempts?: number; logger?: RetryLogger } = {}
+): Promise<T> {
+    const maxAttempts = options.maxAttempts ?? 2;
+    let lastErr: grpc.ServiceError | undefined;
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+            return await operation();
+        } catch (err) {
+            const e = err as grpc.ServiceError;
+            lastErr = e;
+            if (attempt < maxAttempts && isRetryable(e)) {
+                options.logger?.debug(
+                    `${operationName}: spurious CANCELLED on attempt ${attempt}/${maxAttempts}, retrying once`
+                );
+                continue;
+            }
+            throw err;
+        }
+    }
+    throw lastErr!;
+}

--- a/extension/src/client/retryOnSpuriousCancel.ts
+++ b/extension/src/client/retryOnSpuriousCancel.ts
@@ -18,13 +18,20 @@ const defaultIsRetryable = (err: grpc.ServiceError | undefined): boolean => err?
 
 /**
  * Wrap a gRPC call so a spurious CANCELLED caused by a Node.js http2 race
- * (see grpc/grpc-node#2872) is retried once. Only safe for idempotent or
- * read-only calls: when the workaround triggers, the server detected a
- * truncated request frame and reset the stream before doing any work, so a
- * single retry will not produce duplicate side-effects.
+ * (see grpc/grpc-node#2872) is retried once. The race shows up as the server
+ * deframer reporting "Encountered end-of-stream mid-frame" on the request
+ * stream and the client surfacing a synthetic CANCELLED in well under a
+ * second, before any reply data has been observed.
  *
- * The function preserves the original error (the last attempt's error is
- * thrown) and only swallows a retry when the predicate explicitly allows it.
+ * Intended for idempotent or read-only RPCs (e.g. read-only metadata
+ * queries, server-streaming refreshes, and idempotent cancellation calls).
+ * Callers that drive side-effecting work MUST either avoid this helper or
+ * pass a narrow `isRetryable` predicate that rules out attempts which could
+ * have produced server-side effects (for example by requiring zero data
+ * received, a sub-second duration, and that the user did not cancel).
+ *
+ * The function preserves the original error: the last attempt's error is
+ * thrown, and a retry is only taken when `isRetryable` returns true.
  */
 export async function retryOnSpuriousCancel<T>(
     operationName: string,
@@ -32,7 +39,7 @@ export async function retryOnSpuriousCancel<T>(
     isRetryable: (err: grpc.ServiceError) => boolean = defaultIsRetryable,
     options: { maxAttempts?: number; logger?: RetryLogger } = {}
 ): Promise<T> {
-    const maxAttempts = options.maxAttempts ?? 2;
+    const maxAttempts = Math.max(1, options.maxAttempts ?? 2);
     let lastErr: grpc.ServiceError | undefined;
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
         try {
@@ -42,7 +49,7 @@ export async function retryOnSpuriousCancel<T>(
             lastErr = e;
             if (attempt < maxAttempts && isRetryable(e)) {
                 options.logger?.debug(
-                    `${operationName}: spurious CANCELLED on attempt ${attempt}/${maxAttempts}, retrying once`
+                    `${operationName}: spurious CANCELLED on attempt ${attempt}/${maxAttempts}, retrying`
                 );
                 continue;
             }

--- a/extension/src/test/unit/gradleTasks.test.ts
+++ b/extension/src/test/unit/gradleTasks.test.ts
@@ -561,4 +561,31 @@ describe(getSuiteName("Gradle tasks"), () => {
             });
         });
     });
+
+    describe("onDidLoadTasks subscription", () => {
+        // The tree data provider subscribes to GradleTaskProvider.onDidLoadTasks
+        // so the view recovers after a transient gRPC failure where the immediate
+        // retry succeeded but nothing else drove a re-render. These tests pin the
+        // subscription contract: non-empty load fires the tree's change event,
+        // empty load does not.
+        it("emits onDidChangeTreeData when the load yielded tasks", () => {
+            const spy = sinon.spy();
+            gradleTasksTreeDataProvider.onDidChangeTreeData(spy);
+
+            // The event emitter is private but we want to test the subscription
+            // contract directly without going through the full mocked client load.
+            (gradleTaskProvider as any)._onDidLoadTasks.fire([mockGradleTask1, mockGradleTask2]);
+
+            assert.ok(spy.called, "non-empty task list should trigger a tree refresh");
+        });
+
+        it("does not emit onDidChangeTreeData when the load yielded no tasks", () => {
+            const spy = sinon.spy();
+            gradleTasksTreeDataProvider.onDidChangeTreeData(spy);
+
+            (gradleTaskProvider as any)._onDidLoadTasks.fire([]);
+
+            assert.ok(!spy.called, "empty task list should not trigger a refresh");
+        });
+    });
 });

--- a/extension/src/test/unit/recentTasks.test.ts
+++ b/extension/src/test/unit/recentTasks.test.ts
@@ -286,4 +286,28 @@ describe(getSuiteName("Recent tasks"), () => {
             assert.ok(mockTerminal2.dispose.called, "Latest task terminal was not called");
         });
     });
+
+    describe("onDidLoadTasks subscription", () => {
+        // Same contract as the gradle-tasks tree: recover the recent-tasks view
+        // after a transient gRPC failure where the immediate retry succeeded but
+        // nothing else drove a re-render. Non-empty load must refresh, empty
+        // load must not.
+        it("emits onDidChangeTreeData when the load yielded tasks", () => {
+            const spy = sinon.spy();
+            recentTasksTreeDataProvider.onDidChangeTreeData(spy);
+
+            (gradleTaskProvider as any)._onDidLoadTasks.fire([mockGradleTask1, mockGradleTask2]);
+
+            assert.ok(spy.called, "non-empty task list should trigger a tree refresh");
+        });
+
+        it("does not emit onDidChangeTreeData when the load yielded no tasks", () => {
+            const spy = sinon.spy();
+            recentTasksTreeDataProvider.onDidChangeTreeData(spy);
+
+            (gradleTaskProvider as any)._onDidLoadTasks.fire([]);
+
+            assert.ok(!spy.called, "empty task list should not trigger a refresh");
+        });
+    });
 });

--- a/extension/src/test/unit/retryOnSpuriousCancel.test.ts
+++ b/extension/src/test/unit/retryOnSpuriousCancel.test.ts
@@ -50,7 +50,7 @@ describe("retryOnSpuriousCancel", () => {
         sinon.assert.calledTwice(op);
         sinon.assert.calledOnce(logger.debug);
         assert.ok(
-            (logger.debug.firstCall.args[0] as string).includes("Op: spurious CANCELLED on attempt 1/2"),
+            (logger.debug.firstCall.args[0] as string).includes("Op: spurious CANCELLED on attempt 1/2, retrying"),
             "retry log should identify the operation and attempt index"
         );
     });
@@ -134,5 +134,29 @@ describe("retryOnSpuriousCancel", () => {
         sinon.assert.calledThrice(op);
         sinon.assert.calledTwice(logger.debug); // retry log between attempts 1->2 and 2->3
         assert.ok(thrown);
+    });
+
+    it("clamps maxAttempts < 1 so the operation still runs once and its error is thrown", async () => {
+        const err = cancelledError({ details: "real-error" });
+        const op = sinon.stub().rejects(err);
+
+        const thrown = await retryOnSpuriousCancel("Op", op, undefined, { logger, maxAttempts: 0 }).then(
+            () => undefined,
+            (e) => e as grpc.ServiceError
+        );
+
+        sinon.assert.calledOnce(op);
+        sinon.assert.notCalled(logger.debug);
+        assert.ok(thrown, "should throw the operation's error, never undefined");
+        assert.strictEqual(thrown!.details, "real-error");
+    });
+
+    it("clamps a negative maxAttempts the same as 0", async () => {
+        const op = sinon.stub().resolves("ok");
+
+        const result = await retryOnSpuriousCancel("Op", op, undefined, { logger, maxAttempts: -5 });
+
+        assert.strictEqual(result, "ok");
+        sinon.assert.calledOnce(op);
     });
 });

--- a/extension/src/test/unit/retryOnSpuriousCancel.test.ts
+++ b/extension/src/test/unit/retryOnSpuriousCancel.test.ts
@@ -1,0 +1,138 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as grpc from "@grpc/grpc-js";
+import { retryOnSpuriousCancel, RetryLogger } from "../../client/retryOnSpuriousCancel";
+
+function cancelledError(extra: Partial<grpc.ServiceError> = {}): grpc.ServiceError {
+    return Object.assign(new Error("Call cancelled"), {
+        code: grpc.status.CANCELLED,
+        details: "Call cancelled",
+        metadata: new grpc.Metadata(),
+        ...extra,
+    }) as grpc.ServiceError;
+}
+
+function statusError(code: grpc.status): grpc.ServiceError {
+    return Object.assign(new Error(`status ${code}`), {
+        code,
+        details: `status ${code}`,
+        metadata: new grpc.Metadata(),
+    }) as grpc.ServiceError;
+}
+
+describe("retryOnSpuriousCancel", () => {
+    let logger: RetryLogger & { debug: sinon.SinonSpy };
+
+    beforeEach(() => {
+        logger = { debug: sinon.spy() };
+    });
+
+    it("returns the operation result on first success without retrying", async () => {
+        const op = sinon.stub().resolves("ok");
+
+        const result = await retryOnSpuriousCancel("Op", op, undefined, { logger });
+
+        assert.strictEqual(result, "ok");
+        sinon.assert.calledOnce(op);
+        sinon.assert.notCalled(logger.debug);
+    });
+
+    it("retries once on spurious CANCELLED and returns the second result", async () => {
+        const op = sinon.stub();
+        op.onFirstCall().rejects(cancelledError());
+        op.onSecondCall().resolves("recovered");
+
+        const result = await retryOnSpuriousCancel("Op", op, undefined, { logger });
+
+        assert.strictEqual(result, "recovered");
+        sinon.assert.calledTwice(op);
+        sinon.assert.calledOnce(logger.debug);
+        assert.ok(
+            (logger.debug.firstCall.args[0] as string).includes("Op: spurious CANCELLED on attempt 1/2"),
+            "retry log should identify the operation and attempt index"
+        );
+    });
+
+    it("throws the final error when both attempts fail with CANCELLED", async () => {
+        const first = cancelledError({ details: "first" });
+        const second = cancelledError({ details: "second" });
+        const op = sinon.stub();
+        op.onFirstCall().rejects(first);
+        op.onSecondCall().rejects(second);
+
+        const thrown = await retryOnSpuriousCancel("Op", op, undefined, { logger }).then(
+            () => undefined,
+            (e) => e as grpc.ServiceError
+        );
+
+        sinon.assert.calledTwice(op);
+        assert.ok(thrown, "should have thrown");
+        assert.strictEqual(thrown!.details, "second", "the last attempt's error should propagate");
+    });
+
+    it("does not retry on non-CANCELLED errors (default predicate)", async () => {
+        const op = sinon.stub().rejects(statusError(grpc.status.INTERNAL));
+
+        const thrown = await retryOnSpuriousCancel("Op", op, undefined, { logger }).then(
+            () => undefined,
+            (e) => e as grpc.ServiceError
+        );
+
+        sinon.assert.calledOnce(op);
+        sinon.assert.notCalled(logger.debug);
+        assert.strictEqual(thrown!.code, grpc.status.INTERNAL);
+    });
+
+    it("respects a custom predicate that rejects the retry", async () => {
+        const op = sinon.stub().rejects(cancelledError());
+        const isRetryable = sinon.stub().returns(false);
+
+        const thrown = await retryOnSpuriousCancel("Op", op, isRetryable, { logger }).then(
+            () => undefined,
+            (e) => e as grpc.ServiceError
+        );
+
+        sinon.assert.calledOnce(op);
+        sinon.assert.calledOnce(isRetryable);
+        sinon.assert.notCalled(logger.debug);
+        assert.strictEqual(thrown!.code, grpc.status.CANCELLED);
+    });
+
+    it("passes the original error to the custom predicate", async () => {
+        const err = cancelledError({ details: "probe" });
+        const op = sinon.stub();
+        op.onFirstCall().rejects(err);
+        op.onSecondCall().resolves("ok");
+        const isRetryable = sinon.stub().returns(true);
+
+        await retryOnSpuriousCancel("Op", op, isRetryable, { logger });
+
+        sinon.assert.calledOnceWithExactly(isRetryable, err);
+    });
+
+    it("works without a logger (debug calls are best-effort)", async () => {
+        const op = sinon.stub();
+        op.onFirstCall().rejects(cancelledError());
+        op.onSecondCall().resolves("ok");
+
+        const result = await retryOnSpuriousCancel("Op", op);
+
+        assert.strictEqual(result, "ok");
+        sinon.assert.calledTwice(op);
+    });
+
+    it("honors a custom maxAttempts value", async () => {
+        const op = sinon.stub().rejects(cancelledError());
+
+        const thrown = await retryOnSpuriousCancel("Op", op, undefined, { logger, maxAttempts: 3 }).then(
+            () => undefined,
+            (e) => e
+        );
+
+        sinon.assert.calledThrice(op);
+        sinon.assert.calledTwice(logger.debug); // retry log between attempts 1->2 and 2->3
+        assert.ok(thrown);
+    });
+});

--- a/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
+++ b/extension/src/views/gradleTasks/GradleTasksTreeDataProvider.ts
@@ -70,6 +70,15 @@ export class GradleTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
         const collapsed = this.context.workspaceState.get("gradleTasksCollapsed", false);
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         this.setCollapsed(collapsed);
+        // [fix] Re-render the tree whenever GradleTaskProvider finishes a load with a
+        // non-empty task list. This recovers the UI after a transient failure (e.g. the
+        // spurious gRPC CANCELLED on the first refresh, where the immediate retry
+        // succeeds but nothing else was driving a tree refresh).
+        this.gradleTaskProvider.onDidLoadTasks((tasks) => {
+            if (tasks.length > 0) {
+                this.refresh();
+            }
+        });
     }
 
     public async setCollapsed(collapsed: boolean): Promise<void> {

--- a/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
+++ b/extension/src/views/recentTasks/RecentTasksTreeDataProvider.ts
@@ -70,6 +70,13 @@ export class RecentTasksTreeDataProvider implements vscode.TreeDataProvider<vsco
     ) {
         this.recentTasksStore.onDidChange(() => this.refresh());
         this.taskTerminalsStore.onDidChange(this.handleTerminalsStoreChange);
+        // [fix] Re-render when tasks finish loading so the recent-tasks view recovers
+        // after a transient gRPC failure on refresh.
+        this.gradleTaskProvider.onDidLoadTasks((tasks) => {
+            if (tasks.length > 0) {
+                this.refresh();
+            }
+        });
     }
 
     private handleTerminalsStoreChange = (terminals: Set<vscode.Terminal> | null): void => {

--- a/gradle-server/build.gradle
+++ b/gradle-server/build.gradle
@@ -143,6 +143,12 @@ task copyRuntimeLibs(type: Copy) {
   }
 }
 
+// copyRuntimeLibs wipes libsDir in its doFirst block. The jar task also outputs
+// gradle-server.jar into libsDir (via libsDirName). Without explicit ordering,
+// Gradle may schedule copyRuntimeLibs after jar, deleting the freshly built
+// gradle-server.jar and producing a runtime ClassNotFoundException.
+jar.mustRunAfter copyRuntimeLibs
+
 project.tasks.named("processResources") {
   dependsOn(':gradle-plugin:copyJar')
   duplicatesStrategy = 'include'

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
@@ -5,11 +5,14 @@ import com.google.common.base.Strings;
 import com.microsoft.gradle.GradleLanguageServer;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.grpc.StatusRuntimeException;
 import io.grpc.netty.NettyServerBuilder;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Filter;
+import java.util.logging.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +63,8 @@ public class GradleServer {
 	}
 
 	public static void main(String[] args) throws Exception {
+		installNettyMidFrameWarningFilter();
+
 		Map<String, String> params = Utils.parseArgs(args);
 
 		int taskServerPort = Integer.parseInt(Utils.validateRequiredParam(params, "port"));
@@ -76,6 +81,36 @@ public class GradleServer {
 			String bundleDirectory = Utils.validateRequiredParam(params, "bundleDir");
 			startBuildServerThread(buildServerPipeName, bundleDirectory);
 		}
+	}
+
+	/**
+	 * The client retries once on the known Node.js http2 race that produces a
+	 * truncated DATA + END_STREAM frame when reusing an HTTP/2 session (tracked
+	 * upstream as grpc/grpc-node#2872; maintainers attribute the root cause to Node
+	 * and recommend application-level retry). When this happens, grpc-netty logs an
+	 * INTERNAL "Encountered end-of-stream mid-frame" WARNING with a long stack
+	 * trace to stderr, which surfaces in the extension output channel as a scary
+	 * error even though the retried call succeeded. Filter that single record out
+	 * of every JUL handler attached to the root logger; all other Netty warnings
+	 * (TLS, protocol violations, etc.) pass through unchanged.
+	 */
+	private static void installNettyMidFrameWarningFilter() {
+		Filter filter = buildNettyMidFrameWarningFilter();
+		java.util.logging.Logger root = java.util.logging.Logger.getLogger("");
+		for (Handler h : root.getHandlers()) {
+			h.setFilter(filter);
+		}
+	}
+
+	// Package-private for testing.
+	static Filter buildNettyMidFrameWarningFilter() {
+		return record -> {
+			Throwable t = record.getThrown();
+			String name = record.getLoggerName();
+			return !(name != null && name.startsWith("io.grpc.netty.NettyServerStream")
+					&& t instanceof StatusRuntimeException && t.getMessage() != null
+					&& t.getMessage().contains("Encountered end-of-stream mid-frame"));
+		};
 	}
 
 	private static void startTaskServerThread(int port) {

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Filter;
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -91,26 +92,42 @@ public class GradleServer {
 	 * INTERNAL "Encountered end-of-stream mid-frame" WARNING with a long stack
 	 * trace to stderr, which surfaces in the extension output channel as a scary
 	 * error even though the retried call succeeded. Filter that single record out
-	 * of every JUL handler attached to the root logger; all other Netty warnings
-	 * (TLS, protocol violations, etc.) pass through unchanged.
+	 * of every JUL handler attached to the root logger; the filter checks the log
+	 * level, the logger name, the throwable type and the message text, so all other
+	 * Netty warnings (TLS, protocol violations, etc.) and any record at a different
+	 * level (e.g. SEVERE) pass through unchanged. If a handler already had a filter
+	 * configured, the existing filter is preserved and chained so we never silently
+	 * bypass other logging policies.
 	 */
 	private static void installNettyMidFrameWarningFilter() {
-		Filter filter = buildNettyMidFrameWarningFilter();
+		Filter suppression = buildNettyMidFrameWarningFilter();
 		java.util.logging.Logger root = java.util.logging.Logger.getLogger("");
 		for (Handler h : root.getHandlers()) {
-			h.setFilter(filter);
+			Filter previous = h.getFilter();
+			h.setFilter(composeFilters(previous, suppression));
 		}
 	}
 
 	// Package-private for testing.
 	static Filter buildNettyMidFrameWarningFilter() {
 		return record -> {
+			if (!Level.WARNING.equals(record.getLevel())) {
+				return true;
+			}
 			Throwable t = record.getThrown();
 			String name = record.getLoggerName();
 			return !(name != null && name.startsWith("io.grpc.netty.NettyServerStream")
 					&& t instanceof StatusRuntimeException && t.getMessage() != null
 					&& t.getMessage().contains("Encountered end-of-stream mid-frame"));
 		};
+	}
+
+	// Package-private for testing.
+	static Filter composeFilters(Filter previous, Filter next) {
+		if (previous == null) {
+			return next;
+		}
+		return record -> previous.isLoggable(record) && next.isLoggable(record);
 	}
 
 	private static void startTaskServerThread(int port) {

--- a/gradle-server/src/test/java/com/github/badsyntax/gradle/GradleServerFilterTest.java
+++ b/gradle-server/src/test/java/com/github/badsyntax/gradle/GradleServerFilterTest.java
@@ -27,7 +27,11 @@ public class GradleServerFilterTest {
 	private final Filter filter = GradleServer.buildNettyMidFrameWarningFilter();
 
 	private LogRecord record(String loggerName, Throwable thrown) {
-		LogRecord r = new LogRecord(Level.WARNING, "Exception processing message");
+		return record(loggerName, thrown, Level.WARNING);
+	}
+
+	private LogRecord record(String loggerName, Throwable thrown, Level level) {
+		LogRecord r = new LogRecord(level, "Exception processing message");
 		r.setLoggerName(loggerName);
 		r.setThrown(thrown);
 		return r;
@@ -86,5 +90,58 @@ public class GradleServerFilterTest {
 		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState",
 				new StatusRuntimeException(Status.INTERNAL));
 		assertTrue("a StatusRuntimeException without message text must surface", filter.isLoggable(r));
+	}
+
+	@Test
+	public void allowsSevereRecordsEvenWhenTheyMatchTheMidFrameSignature() {
+		// A higher-severity record carrying the same signature is escalated by the
+		// JVM or the underlying library and should never be silently dropped.
+		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState",
+				new StatusRuntimeException(Status.INTERNAL.withDescription(MID_FRAME)), Level.SEVERE);
+		assertTrue("SEVERE records matching the signature must still surface", filter.isLoggable(r));
+	}
+
+	@Test
+	public void allowsInfoRecordsEvenWhenTheyMatchTheMidFrameSignature() {
+		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState",
+				new StatusRuntimeException(Status.INTERNAL.withDescription(MID_FRAME)), Level.INFO);
+		assertTrue("INFO records matching the signature must still surface", filter.isLoggable(r));
+	}
+
+	@Test
+	public void composeFiltersWithNullPreviousReturnsTheNewFilter() {
+		Filter midFrame = GradleServer.buildNettyMidFrameWarningFilter();
+		Filter composed = GradleServer.composeFilters(null, midFrame);
+		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState",
+				new StatusRuntimeException(Status.INTERNAL.withDescription(MID_FRAME)));
+		assertFalse(composed.isLoggable(r));
+	}
+
+	@Test
+	public void composeFiltersDelegatesToPreviousFilter() {
+		// An existing logging policy that already blocks records from a third-party
+		// logger must keep blocking after our filter is layered on top.
+		Filter blockExternal = record -> !"third.party.logger".equals(record.getLoggerName());
+		Filter midFrame = GradleServer.buildNettyMidFrameWarningFilter();
+		Filter composed = GradleServer.composeFilters(blockExternal, midFrame);
+
+		LogRecord externalRecord = record("third.party.logger", null);
+		assertFalse("composed filter must honor previous policy", composed.isLoggable(externalRecord));
+
+		LogRecord unrelatedNetty = record("io.grpc.netty.NettyServerStream$TransportState",
+				new StatusRuntimeException(Status.RESOURCE_EXHAUSTED.withDescription("too many streams")));
+		assertTrue("composed filter must still allow other Netty warnings", composed.isLoggable(unrelatedNetty));
+	}
+
+	@Test
+	public void composeFiltersAppliesBothPredicatesWithAndSemantics() {
+		// previous blocks everything; result must block regardless of our filter.
+		Filter blockAll = record -> false;
+		Filter midFrame = GradleServer.buildNettyMidFrameWarningFilter();
+		Filter composed = GradleServer.composeFilters(blockAll, midFrame);
+
+		LogRecord allowedByOurs = record("io.grpc.netty.NettyServerStream$TransportState",
+				new StatusRuntimeException(Status.RESOURCE_EXHAUSTED.withDescription("too many streams")));
+		assertFalse("AND-composition: previous=false must dominate", composed.isLoggable(allowedByOurs));
 	}
 }

--- a/gradle-server/src/test/java/com/github/badsyntax/gradle/GradleServerFilterTest.java
+++ b/gradle-server/src/test/java/com/github/badsyntax/gradle/GradleServerFilterTest.java
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+package com.github.badsyntax.gradle;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.util.logging.Filter;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import org.junit.Test;
+
+/**
+ * Verifies the narrow filter installed by {@link GradleServer} to suppress the
+ * single noisy "Encountered end-of-stream mid-frame" WARNING that grpc-netty
+ * emits when the client retries past the known Node.js http2 race
+ * (grpc/grpc-node#2872). The filter must match only this exact record and let
+ * every other Netty / gRPC warning through.
+ */
+public class GradleServerFilterTest {
+
+	private static final String MID_FRAME = "INTERNAL: Encountered end-of-stream mid-frame";
+
+	private final Filter filter = GradleServer.buildNettyMidFrameWarningFilter();
+
+	private LogRecord record(String loggerName, Throwable thrown) {
+		LogRecord r = new LogRecord(Level.WARNING, "Exception processing message");
+		r.setLoggerName(loggerName);
+		r.setThrown(thrown);
+		return r;
+	}
+
+	@Test
+	public void suppressesTheKnownNettyMidFrameWarning() {
+		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState",
+				new StatusRuntimeException(Status.INTERNAL.withDescription("Encountered end-of-stream mid-frame")));
+		assertFalse("the known mid-frame warning must be filtered out", filter.isLoggable(r));
+	}
+
+	@Test
+	public void suppressesWhenStatusMessageContainsMidFrameWithExtraText() {
+		// The full grpc-netty message can vary slightly; we match on substring.
+		LogRecord r = record("io.grpc.netty.NettyServerStream",
+				new StatusRuntimeException(Status.INTERNAL.withDescription(MID_FRAME + " (size=42)")));
+		assertFalse(filter.isLoggable(r));
+	}
+
+	@Test
+	public void allowsUnrelatedNettyWarnings() {
+		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState",
+				new StatusRuntimeException(Status.RESOURCE_EXHAUSTED.withDescription("too many streams")));
+		assertTrue("unrelated netty warnings must still surface", filter.isLoggable(r));
+	}
+
+	@Test
+	public void allowsRecordsFromOtherLoggers() {
+		LogRecord r = record("io.netty.handler.codec.http2.Http2ConnectionHandler",
+				new StatusRuntimeException(Status.INTERNAL.withDescription(MID_FRAME)));
+		assertTrue("the same message from a non-targeted logger must surface", filter.isLoggable(r));
+	}
+
+	@Test
+	public void allowsRecordsWithDifferentThrowableType() {
+		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState",
+				new RuntimeException("Encountered end-of-stream mid-frame"));
+		assertTrue("a non-StatusRuntimeException with the same text must surface", filter.isLoggable(r));
+	}
+
+	@Test
+	public void allowsRecordsWithNoThrowable() {
+		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState", null);
+		assertTrue(filter.isLoggable(r));
+	}
+
+	@Test
+	public void allowsRecordsWithNullLoggerName() {
+		LogRecord r = record(null, new StatusRuntimeException(Status.INTERNAL.withDescription(MID_FRAME)));
+		assertTrue(filter.isLoggable(r));
+	}
+
+	@Test
+	public void allowsRecordsWithNullThrowableMessage() {
+		LogRecord r = record("io.grpc.netty.NettyServerStream$TransportState",
+				new StatusRuntimeException(Status.INTERNAL));
+		assertTrue("a StatusRuntimeException without message text must surface", filter.isLoggable(r));
+	}
+}


### PR DESCRIPTION
The first `Refresh Gradle Projects'' on a project with a large task graph consistently failed with `Error getting build for <path>: Call cancelled'' and the tree view showed `No tasks found''. The Gradle output channel also printed a long Netty stack trace about an INTERNAL `Encountered end-of-stream mid-frame'' WARNING.

Root cause: when grpc-js reuses an HTTP/2 session after a large server-streaming response, the first DATA frame on a freshly-opened stream can arrive truncated with END_STREAM, causing the server to reset the stream and grpc-js to surface a synthetic CANCELLED to the caller. The race is in node:http2 and grpc-node maintainers track it as Node-side behavior; the recommended client-side mitigation is application-level retry (grpc/grpc-node#2872).

This commit applies four narrow fixes:

* TaskServerClient.getBuild now retries once when the failure is a zero-data CANCELLED that finished within 2s and the user did not cancel. The original behavior is preserved on real cancellations, authentic errors, or any attempt that observed data.
* GradleTasksTreeDataProvider and RecentTasksTreeDataProvider subscribe to GradleTaskProvider.onDidLoadTasks and refresh when the load yielded tasks, so the tree recovers after a transient failure even when nothing else triggered a re-render.
* GradleServer installs a narrow java.util.logging Filter on every root handler that drops only the well-known `end-of-stream mid-frame'' WARNING from io.grpc.netty.NettyServerStream. All other Netty warnings (TLS, protocol violations, resource limits, etc.) continue to surface unchanged.
* gradle-server build.gradle adds `jar.mustRunAfter copyRuntimeLibs'' so the copy step (which deletes libsDir in doFirst) cannot wipe the freshly built gradle-server.jar and produce a runtime ClassNotFoundException.

Also bumps @grpc/grpc-js to ^1.14.3 as a routine dependency update.