### PR TITLE
feat: do not print 'Could not execute build' message after build failure

### DIFF
--- a/extension/src/terminal/GradleRunnerTerminal.ts
+++ b/extension/src/terminal/GradleRunnerTerminal.ts
@@ -141,7 +141,9 @@ export class GradleRunnerTerminal implements vscode.Pseudoterminal {
                 );
             }
         } else {
-            this.write(err.details || err.message);
+            if (!err.details?.startsWith("Could not execute build using connection to Gradle distribution")) {
+                this.write(err.details || err.message);
+            }
         }
     }
 


### PR DESCRIPTION
Please see #1834 for details.

Resolves #1834
Maybe also solution for #1621 (?)
