### PR TITLE
refactor: rename GrpcGradle* proto messages to Gradle*Proto

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,6 @@
   "java.configuration.updateBuildConfiguration": "automatic",
   "cSpell.language": "en-GB",
   "cSpell.words": [
-    "Grpc",
     "Proto",
     "Protobuf",
     "linting"

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/handlers/GetBuildHandler.java
@@ -8,13 +8,13 @@ import com.github.badsyntax.gradle.GetBuildRequest;
 import com.github.badsyntax.gradle.GetBuildResult;
 import com.github.badsyntax.gradle.GradleBuild;
 import com.github.badsyntax.gradle.GradleBuildCancellation;
+import com.github.badsyntax.gradle.GradleClosureProto;
 import com.github.badsyntax.gradle.GradleEnvironment;
+import com.github.badsyntax.gradle.GradleFieldProto;
+import com.github.badsyntax.gradle.GradleMethodProto;
 import com.github.badsyntax.gradle.GradleProject;
 import com.github.badsyntax.gradle.GradleProjectConnector;
 import com.github.badsyntax.gradle.GradleTask;
-import com.github.badsyntax.gradle.GrpcGradleClosure;
-import com.github.badsyntax.gradle.GrpcGradleField;
-import com.github.badsyntax.gradle.GrpcGradleMethod;
 import com.github.badsyntax.gradle.JavaEnvironment;
 import com.github.badsyntax.gradle.Output;
 import com.github.badsyntax.gradle.Progress;
@@ -253,12 +253,12 @@ public class GetBuildHandler {
 		return tasks;
 	}
 
-	private List<GrpcGradleClosure> getPluginClosures(GradleProjectModel model) {
-		List<GrpcGradleClosure> closures = new ArrayList<>();
+	private List<GradleClosureProto> getPluginClosures(GradleProjectModel model) {
+		List<GradleClosureProto> closures = new ArrayList<>();
 		for (GradleClosure closure : model.getClosures()) {
-			GrpcGradleClosure.Builder closureBuilder = GrpcGradleClosure.newBuilder();
+			GradleClosureProto.Builder closureBuilder = GradleClosureProto.newBuilder();
 			for (GradleMethod method : closure.getMethods()) {
-				GrpcGradleMethod.Builder methodBuilder = GrpcGradleMethod.newBuilder();
+				GradleMethodProto.Builder methodBuilder = GradleMethodProto.newBuilder();
 				methodBuilder.setName(method.getName());
 				methodBuilder.addAllParameterTypes(method.getParameterTypes());
 				methodBuilder.setDeprecated(method.getDeprecated());
@@ -266,7 +266,7 @@ public class GetBuildHandler {
 			}
 			closureBuilder.setName(closure.getName());
 			for (GradleField field : closure.getFields()) {
-				GrpcGradleField.Builder fieldBuilder = GrpcGradleField.newBuilder();
+				GradleFieldProto.Builder fieldBuilder = GradleFieldProto.newBuilder();
 				fieldBuilder.setName(field.getName());
 				fieldBuilder.setDeprecated(field.getDeprecated());
 				closureBuilder.addFields(fieldBuilder.build());

--- a/proto/gradle.proto
+++ b/proto/gradle.proto
@@ -54,19 +54,19 @@ message DependencyItem {
   repeated DependencyItem children = 3;
 }
 
-message GrpcGradleClosure {
+message GradleClosureProto {
   string name = 1;
-  repeated GrpcGradleMethod methods = 2;
-  repeated GrpcGradleField fields = 3;
+  repeated GradleMethodProto methods = 2;
+  repeated GradleFieldProto fields = 3;
 }
 
-message GrpcGradleMethod {
+message GradleMethodProto {
   string name = 1;
   repeated string parameterTypes = 2;
   bool deprecated = 3;
 }
 
-message GrpcGradleField {
+message GradleFieldProto {
   string name = 1;
   bool deprecated = 2;
 }
@@ -130,7 +130,7 @@ message GradleProject {
   string projectPath = 4;
   DependencyItem dependencyItem = 5;
   repeated string plugins = 6;
-  repeated GrpcGradleClosure pluginClosures = 7;
+  repeated GradleClosureProto pluginClosures = 7;
   repeated string scriptClasspaths = 8;
 }
 


### PR DESCRIPTION
## What

Follow-up cosmetic cleanup after the gRPC → JSON-RPC transport migration (#1863, #1864, #1867). Renames the last gRPC-named identifiers in the codebase.

| File | Change |
|---|---|
| `proto/gradle.proto` | `GrpcGradleClosure` / `GrpcGradleMethod` / `GrpcGradleField` → `GradleClosureProto` / `GradleMethodProto` / `GradleFieldProto` (incl. the `pluginClosures` field reference) |
| `gradle-server/.../handlers/GetBuildHandler.java` | Updated imports + usages to the new names |
| `.vscode/settings.json` | Removed the now-unused `"Grpc"` cSpell word (`"Proto"` already present) |

## Why the `Proto` suffix (not bare `GradleClosure`)

`GetBuildHandler.java` already imports the domain models `com.microsoft.gradle.api.GradleClosure/Method/Field`. The generated proto classes live in `com.github.badsyntax.gradle`, so naming them `GradleClosure` etc. would produce two same-named imports in one file and fail to compile. The `*Proto` suffix is collision-free and reads naturally.

## Compatibility

Renaming a protobuf **message** does not change the wire format — field numbers and tags (`pluginClosures = 7`) are unchanged, and message names are not transmitted in the binary encoding. Both ends regenerate from the same `proto`, and this ships after the full migration, so there is no cross-version concern.

## Verification

- **Extension/TS**: regenerated `extension/src/proto` (protoc + protoc-gen-ts) now emits `GradleClosureProto`; `tsc -p . --noEmit` passes.
- **gradle-server/Java**: proto codegen + `GetBuildHandler` resolve the renamed symbols (the only remaining local clean-build errors are the unrelated, CI-provided `build-server-for-gradle` BSP `server.jar` artifacts, present on `develop` too); `spotlessJavaCheck` clean.
- No runtime log/telemetry code touched.

Depends on #1863 + #1864 + #1867 (all merged to `develop`).
