### PR TITLE
fix: handle JSON-RPC connection death and stabilize nested-projects CI

### DIFF
--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -90,6 +90,11 @@ extends:
                     sudo /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
               - task: Gradle@3
                 displayName: Test VSCode
+                # The VS Code integration tests spin up real Gradle builds and
+                # are timing-sensitive on shared agents. GitHub Actions wraps
+                # this step in a 3-attempt retry; mirror that here so a single
+                # flaky run doesn't fail the pipeline (1 initial + 2 retries).
+                retryCountOnTaskFailure: 2
                 env:
                   DISPLAY: ":99.0"
                 inputs:

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -50,6 +50,7 @@ function errorDetails(err: unknown): string {
 
 export class TaskServerClient implements vscode.Disposable {
     private rpcClient: GradleJsonRpcClient | null = null;
+    private rpcClientClosedHandler: vscode.Disposable | undefined;
     private readonly cancelledProjectDependencies: Set<string> = new Set();
     private readonly _onDidConnect: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private readonly _onDidConnectFail: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
@@ -96,6 +97,17 @@ export class TaskServerClient implements vscode.Disposable {
         try {
             const connection = await this.server.awaitTaskConnection();
             this.rpcClient = new GradleJsonRpcClient(connection);
+            // The raw-socket transport can die between gradle-server process
+            // exits (peer reset, crash). Proactively tear down the stale client
+            // so subsequent task loads don't write to a destroyed socket and
+            // silently drop a project's tasks.
+            this.rpcClientClosedHandler?.dispose();
+            this.rpcClientClosedHandler = this.rpcClient.onClosed((err) => {
+                if (err) {
+                    logger.error(`Gradle client connection closed unexpectedly: ${errorDetails(err)}`);
+                }
+                this.close();
+            });
             logger.info("Gradle client connected to server");
             this._onDidConnect.fire(null);
         } catch (err) {
@@ -431,6 +443,8 @@ export class TaskServerClient implements vscode.Disposable {
 
     public close(): void {
         this.statusBarItem.hide();
+        this.rpcClientClosedHandler?.dispose();
+        this.rpcClientClosedHandler = undefined;
         this.rpcClient?.dispose();
         this.rpcClient = null;
     }

--- a/extension/src/test/integration/nested-projects/extension.test.ts
+++ b/extension/src/test/integration/nested-projects/extension.test.ts
@@ -47,9 +47,17 @@ describe(getSuiteName("Extension"), () => {
             });
 
             beforeEach(async () => {
+                // Nested projects load sequentially, so a non-empty task list
+                // does not mean every project finished configuring. Retry until
+                // the tasks this suite asserts on are actually present (or the
+                // budget is exhausted) instead of breaking on the first project
+                // that loads — otherwise a slow/contended agent surfaces a
+                // partial load as a hard assertion failure.
+                const expectedTaskNames = ["helloGroovyDefault", "helloKotlinDefault", "helloGroovyCustom"];
                 for (let i = 0; i < 5; i++) {
                     tasks = await vscode.tasks.fetchTasks({ type: "gradle" });
-                    if (tasks.length > 0) {
+                    const loadedAll = expectedTaskNames.every((name) => tasks!.some((task) => task.name === name));
+                    if (loadedAll) {
                         break;
                     }
                     await sleep(5 * 1000);

--- a/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
+++ b/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
@@ -57,6 +57,7 @@ const RUN_BUILD_REPLY_NOTIF = new NotificationType<GradleStreamPayload>("gradle/
 function wirePair(): {
     client: MessageConnection;
     server: MessageConnection;
+    killTransport: () => void;
     dispose: () => void;
 } {
     const clientToServer = new PassThrough();
@@ -76,6 +77,13 @@ function wirePair(): {
     return {
         client,
         server,
+        // Simulate the gradle-server socket dying without first disposing the
+        // client connection — destroying the stream the client reads from makes
+        // its reader see EOF, which is what fires the connection's onClose.
+        killTransport: () => {
+            serverToClient.destroy();
+            clientToServer.destroy();
+        },
         dispose: () => {
             try {
                 client.dispose();
@@ -328,6 +336,33 @@ describe(suiteName("GradleJsonRpcClient transport"), () => {
                 client.executeCommand(new ExecuteCommandRequest()),
                 (err: Error & { code?: number }) => {
                     assert.strictEqual(err.code, JsonRpcErrors.INTERNAL);
+                    return true;
+                }
+            );
+        });
+
+        it("fires onClosed and rejects further requests when the connection dies", async () => {
+            const closedErrors: Array<Error | undefined> = [];
+            const closed = new Promise<void>((resolve) =>
+                client.onClosed((err) => {
+                    closedErrors.push(err);
+                    resolve();
+                })
+            );
+
+            // Kill the transport (gradle-server socket death) while the client
+            // connection is still listening, so its reader sees EOF.
+            wired.killTransport();
+            await closed;
+
+            assert.strictEqual(closedErrors.length, 1, "onClosed must fire exactly once");
+
+            // After death, a request must surface as a handled GradleRpcError
+            // rather than an unhandled "write after destroyed" rejection.
+            await assert.rejects(
+                client.getProjectDependencies(new GetProjectDependenciesRequest()),
+                (err: Error & { code?: number }) => {
+                    assert.strictEqual(err.code, JsonRpcErrors.UNKNOWN);
                     return true;
                 }
             );

--- a/extension/src/transport/jsonrpc/GradleJsonRpcClient.ts
+++ b/extension/src/transport/jsonrpc/GradleJsonRpcClient.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { Disposable, MessageConnection, NotificationType, RequestType } from "vscode-jsonrpc";
+import { Disposable, Emitter, Event, MessageConnection, NotificationType, RequestType } from "vscode-jsonrpc";
 import {
     CancelBuildReply,
     CancelBuildRequest,
@@ -62,6 +62,19 @@ export class GradleJsonRpcClient implements Disposable {
     private readonly getBuildSinks = new Map<number, StreamSink<GetBuildReply>>();
     private readonly runBuildSinks = new Map<number, StreamSink<RunBuildReply>>();
     private readonly disposables: Disposable[] = [];
+    private readonly _onClosed = new Emitter<Error | undefined>();
+    private closed = false;
+    private lastError: Error | undefined;
+
+    /**
+     * Fires once when the underlying connection dies — either because the
+     * `gradle-server` socket closed (process exit / peer reset) or because a
+     * transport-level read/write error tore it down. Owners should dispose the
+     * client and stop issuing requests in response; further calls reject with a
+     * handled {@link GradleRpcError} instead of leaking an unhandled
+     * "Cannot call write after a stream was destroyed" rejection.
+     */
+    public readonly onClosed: Event<Error | undefined> = this._onClosed.event;
 
     public constructor(private readonly connection: MessageConnection) {
         this.disposables.push(
@@ -78,6 +91,22 @@ export class GradleJsonRpcClient implements Disposable {
                 if (sink) {
                     sink(RunBuildReply.deserializeBinary(decodeProto(params.payload)));
                 }
+            })
+        );
+
+        // The raw-socket transport does not heal connection loss the way gRPC
+        // did internally, so we must observe it explicitly. `onError` surfaces
+        // transport read/write failures (the socket-destroyed write throw is
+        // re-fired here); `onClose` fires when the reader/writer sees EOF and
+        // vscode-jsonrpc transitions the connection to Closed.
+        this.disposables.push(
+            this.connection.onError(([error]) => {
+                this.lastError = error;
+            })
+        );
+        this.disposables.push(
+            this.connection.onClose(() => {
+                this.markClosed(this.lastError);
             })
         );
 
@@ -123,6 +152,7 @@ export class GradleJsonRpcClient implements Disposable {
     }
 
     public dispose(): void {
+        this.closed = true;
         for (const d of this.disposables) {
             try {
                 d.dispose();
@@ -143,6 +173,26 @@ export class GradleJsonRpcClient implements Disposable {
         } catch {
             // best-effort
         }
+        this._onClosed.dispose();
+    }
+
+    private markClosed(err: Error | undefined): void {
+        if (this.closed) {
+            return;
+        }
+        this.closed = true;
+        this._onClosed.fire(err);
+    }
+
+    /**
+     * Fail fast when the connection is already dead so callers get a handled
+     * {@link GradleRpcError} rather than triggering a write on a destroyed
+     * socket (which vscode-jsonrpc would surface as an unhandled rejection).
+     */
+    private ensureOpen(): void {
+        if (this.closed) {
+            throw toGradleRpcError(new Error("Gradle JSON-RPC connection is closed."));
+        }
     }
 
     private async runUnaryRequest<TRequest extends { serializeBinary(): Uint8Array }, TReply>(
@@ -150,6 +200,7 @@ export class GradleJsonRpcClient implements Disposable {
         request: TRequest,
         deserialize: (bytes: Uint8Array) => TReply
     ): Promise<TReply | null> {
+        this.ensureOpen();
         try {
             const response = await this.connection.sendRequest(type, {
                 request: encodeProto(request.serializeBinary()),
@@ -168,6 +219,7 @@ export class GradleJsonRpcClient implements Disposable {
         sinkMap: Map<number, StreamSink<TReply>>,
         deserialize: (bytes: Uint8Array) => TReply
     ): Promise<TReply | null> {
+        this.ensureOpen();
         const streamId = nextStreamId();
         sinkMap.set(streamId, onReply);
         try {

--- a/extension/src/transport/jsonrpc/loopbackServer.ts
+++ b/extension/src/transport/jsonrpc/loopbackServer.ts
@@ -92,6 +92,20 @@ export async function createLoopbackListener(options: LoopbackListenerOptions = 
 
             const reader = new SocketMessageReader(socket);
             const writer = new SocketMessageWriter(socket);
+
+            // gRPC managed connection state internally; with a raw socket we
+            // must attach our own handlers so a peer reset / process exit can
+            // never surface as an uncaught 'error' event, and so socket
+            // lifecycle is visible in the transport log. Connection teardown is
+            // driven by the MessageConnection's own onClose (GradleJsonRpcClient
+            // observes it); these handlers only guard and trace.
+            socket.on("error", (socketErr) => {
+                options.logger?.error(`gradle-server loopback socket error: ${socketErr.message}`);
+            });
+            socket.on("close", (hadError) => {
+                options.logger?.info(`gradle-server loopback socket closed${hadError ? " after error" : ""}`);
+            });
+
             const conn = createMessageConnection(reader, writer, options.logger);
             resolve(conn);
         });


### PR DESCRIPTION
#1860 

## Problem

The ADO pipeline `microsoft.vscode-gradle.CI` (step **Test VSCode**) failed with:

```
Error: Cannot call write after a stream was destroyed
  ... vscode-jsonrpc SocketMessageWriter ...
1) Run nested project tests ... With nestedProjects:true setting
   should load groovy default build file tasks:
   AssertionError: assert.ok(groovyDefaultTask)  // falsy
```

GitHub Actions was **green on the same commit**, because `main.yml` retries `testVsCode` up to 3 times while the ADO pipeline ran it once.

## Root cause

The gRPC → JSON-RPC migration left the raw loopback socket and the `vscode-jsonrpc` `MessageConnection` without error/close handling:

- `connection.sendRequest` (vscode-jsonrpc v6) only catches the **synchronous** write throw. When the gradle-server socket dies, the **async** `socket.write` rejection on a destroyed stream becomes an **unhandled** `Cannot call write after a stream was destroyed`.
- `TaskServerClient.getBuild` catches the failure and returns `undefined` → the affected nested project contributes no tasks.
- The nested-projects test `beforeEach` broke as soon as `tasks.length > 0` (any task), not when the **expected** tasks were present. Since nested projects load sequentially, a partial load surfaced as a hard assertion failure on slow/contended agents.

## Changes

- **GradleJsonRpcClient**: observe `connection.onError`/`onClose`, expose an `onClosed` event, and guard sends so post-death calls reject with a handled `GradleRpcError` instead of leaking an unhandled write rejection.
- **loopbackServer**: attach `socket.on('error'/'close')` so a peer reset can't become an uncaught `'error'` event; trace socket lifecycle.
- **TaskServerClient**: tear down the stale `rpcClient` on connection death so later task loads don't write to a dead socket and silently drop a project's tasks.
- **nested-projects test**: retry until the expected tasks are present rather than on the first project that loads.
- **ADO pipeline**: `retryCountOnTaskFailure: 2` on `Test VSCode` to mirror GitHub Actions' existing 3-attempt retry for the timing-sensitive integration tests.

## Validation

- `tsc -p .` clean · `npm run compile` (webpack prod) clean · eslint clean · YAML valid
- Transport unit tests: 12/12 passing, including a new test asserting connection death fires `onClosed` once and rejects further requests with a handled error.