### PR TITLE
fix: self-heal JSON-RPC transport with keepalive + bounded auto-restart

### DIFF
--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -423,6 +423,12 @@ export class TaskServerClient implements vscode.Disposable {
         logger.error("Error connecting to gradle server:", e.message);
         this.close();
         this._onDidConnectFail.fire(null);
+        // An auto-restart is already scheduled; it will respawn the server and
+        // the client will reconnect on the next onDidStart. Don't compete with
+        // it by prompting the user to restart manually.
+        if (this.server.isAutoRestartPending()) {
+            return;
+        }
         if (this.server.isReady()) {
             await this.showRestartMessage();
         } else {

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -12,12 +12,21 @@ import { extensionInstalled } from "../util/config";
 import { BspProxy } from "../bs/BspProxy";
 import { getRandomPipeName } from "../util/generateRandomPipeName";
 import { createLoopbackListener, LoopbackListener } from "../transport/jsonrpc";
+import { shouldAutoRestart } from "./autoRestartPolicy";
 const SERVER_LOGLEVEL_REGEX = /^\[([A-Z]+)\](.*)$/;
 const DOWNLOAD_PROGRESS_CHAR = ".";
 const STDERR_TAIL_LINES = 40;
 const STDERR_TAIL_PREVIEW_LINES = 3;
 const VIEW_LOG_ACTION = "View Log";
 const RELOAD_HINT = "Run 'Developer: Reload Window' if Gradle stops working.";
+// Bounded auto-restart for unexpected gradle-server exits (e.g. a loopback
+// transport reset that kills the JVM). Relaunch transparently instead of
+// immediately asking the user to reload, and only fall back to the warning
+// once the retry budget is exhausted. The budget is per session (not reset on
+// recovery) to keep this conservative; a future refinement could reset it on a
+// successful reconnect.
+const MAX_AUTO_RESTARTS = 3;
+const AUTO_RESTART_DELAY_MS = 1_000;
 
 export interface ServerOptions {
     host: string;
@@ -38,6 +47,9 @@ export class GradleServer {
     private processStartedAt = 0;
     private stderrTail: string[] = [];
     private pendingStderrLine = "";
+    private disposing = false;
+    private autoRestartCount = 0;
+    private autoRestartTimer: NodeJS.Timeout | undefined;
 
     constructor(
         private readonly opts: ServerOptions,
@@ -70,6 +82,12 @@ export class GradleServer {
         return this.languageServerPipePath;
     }
     public async start(): Promise<void> {
+        // Cancel any pending auto-restart so an explicit start()/restart()
+        // never races with a scheduled relaunch into a double-spawn.
+        if (this.autoRestartTimer) {
+            clearTimeout(this.autoRestartTimer);
+            this.autoRestartTimer = undefined;
+        }
         let startBuildServer = false;
         if (extensionInstalled("redhat.java")) {
             const isPrepared = this.bspProxy.prepareToStart();
@@ -157,6 +175,9 @@ export class GradleServer {
                     return;
                 }
                 if ((code !== null && code !== 0) || signal !== null) {
+                    if (this.tryAutoRestart(code, signal)) {
+                        return;
+                    }
                     await this.handleUnexpectedExit(code, signal);
                 }
             });
@@ -247,6 +268,42 @@ export class GradleServer {
         }
     }
 
+    /**
+     * Transparently relaunch the gradle-server after an unexpected exit, up to
+     * {@link MAX_AUTO_RESTARTS} times, so a transient transport failure
+     * self-heals instead of forcing the user to reload the window. Returns
+     * `true` if a restart was scheduled (caller must not show the
+     * unexpected-exit warning); `false` if the retry budget is exhausted or the
+     * server is being disposed.
+     */
+    private tryAutoRestart(code: number | null, signal: NodeJS.Signals | null): boolean {
+        if (!shouldAutoRestart(this.disposing, this.autoRestartCount, MAX_AUTO_RESTARTS)) {
+            return false;
+        }
+        this.autoRestartCount += 1;
+        sendInfo("", {
+            kind: "serverProcessAutoRestart",
+            data3: code !== null ? code.toString() : "",
+            dataMsg: signal ?? "",
+            attempt: this.autoRestartCount.toString(),
+        });
+        this.logger.warn(
+            `Gradle server exited unexpectedly; auto-restarting (attempt ${this.autoRestartCount}/${MAX_AUTO_RESTARTS}) in ${AUTO_RESTART_DELAY_MS}ms`
+        );
+        this.autoRestartTimer = setTimeout(() => {
+            this.autoRestartTimer = undefined;
+            void this.start();
+        }, AUTO_RESTART_DELAY_MS);
+        return true;
+    }
+
+    /** True while an auto-restart is scheduled but not yet completed. Lets the
+     * client suppress its manual "reconnect" prompts so they don't compete with
+     * the transparent relaunch. */
+    public isAutoRestartPending(): boolean {
+        return this.autoRestartTimer !== undefined;
+    }
+
     private async handleUnexpectedExit(code: number | null, signal: NodeJS.Signals | null): Promise<void> {
         sendInfo("", {
             kind: "serverProcessExit",
@@ -273,6 +330,11 @@ export class GradleServer {
     }
 
     public async asyncDispose(): Promise<void> {
+        this.disposing = true;
+        if (this.autoRestartTimer) {
+            clearTimeout(this.autoRestartTimer);
+            this.autoRestartTimer = undefined;
+        }
         this.bspProxy.closeConnection();
         this.process?.removeAllListeners();
         await this.killProcess();

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -301,9 +301,14 @@ export class GradleServer {
         this.autoRestartTimer = setTimeout(() => {
             this.autoRestartTimer = undefined;
             this.start().catch((error) => {
+                // The relaunch itself failed (e.g. the loopback listener could
+                // not bind). Fall back to the normal unexpected-exit handling so
+                // the user still gets the recovery prompt instead of being left
+                // with a silently dead server.
                 this.logger.error(
                     `Gradle server auto-restart failed: ${error instanceof Error ? error.message : String(error)}`
                 );
+                void this.handleUnexpectedExit(code, signal);
             });
         }, AUTO_RESTART_DELAY_MS);
         return true;

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -175,15 +175,20 @@ export class GradleServer {
                     return;
                 }
                 if ((code !== null && code !== 0) || signal !== null) {
-                    // Record every unexpected exit so counts stay comparable to
-                    // the baseline, even when the exit is transparently
-                    // recovered below (correlate with serverProcessAutoRestart).
+                    // Decide on recovery first, then record a single
+                    // serverProcessExit event for every unexpected exit (kept
+                    // comparable to the historical baseline). autoRestartAttempt
+                    // carries the recovery outcome on the same event: "1".."N"
+                    // while self-healing, "" once we give up (budget exhausted
+                    // or disposing) and the user is prompted to reload.
+                    const willAutoRestart = this.tryAutoRestart(code, signal);
                     sendInfo("", {
                         kind: "serverProcessExit",
                         data3: code !== null ? code.toString() : "",
                         dataMsg: signal ?? "",
+                        autoRestartAttempt: willAutoRestart ? this.autoRestartCount.toString() : "",
                     });
-                    if (this.tryAutoRestart(code, signal)) {
+                    if (willAutoRestart) {
                         return;
                     }
                     await this.handleUnexpectedExit(code, signal);
@@ -282,19 +287,14 @@ export class GradleServer {
      * self-heals instead of forcing the user to reload the window. Returns
      * `true` if a restart was scheduled (caller must not show the
      * unexpected-exit warning); `false` if the retry budget is exhausted or the
-     * server is being disposed.
+     * server is being disposed. The exit itself (and the resulting attempt
+     * number) is reported by the caller on the serverProcessExit event.
      */
     private tryAutoRestart(code: number | null, signal: NodeJS.Signals | null): boolean {
         if (!shouldAutoRestart(this.disposing, this.autoRestartCount, MAX_AUTO_RESTARTS)) {
             return false;
         }
         this.autoRestartCount += 1;
-        sendInfo("", {
-            kind: "serverProcessAutoRestart",
-            data3: code !== null ? code.toString() : "",
-            dataMsg: signal ?? "",
-            attempt: this.autoRestartCount.toString(),
-        });
         this.logger.warn(
             `Gradle server exited unexpectedly; auto-restarting (attempt ${this.autoRestartCount}/${MAX_AUTO_RESTARTS}) in ${AUTO_RESTART_DELAY_MS}ms`
         );

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -175,6 +175,14 @@ export class GradleServer {
                     return;
                 }
                 if ((code !== null && code !== 0) || signal !== null) {
+                    // Record every unexpected exit so counts stay comparable to
+                    // the baseline, even when the exit is transparently
+                    // recovered below (correlate with serverProcessAutoRestart).
+                    sendInfo("", {
+                        kind: "serverProcessExit",
+                        data3: code !== null ? code.toString() : "",
+                        dataMsg: signal ?? "",
+                    });
                     if (this.tryAutoRestart(code, signal)) {
                         return;
                     }
@@ -292,7 +300,11 @@ export class GradleServer {
         );
         this.autoRestartTimer = setTimeout(() => {
             this.autoRestartTimer = undefined;
-            void this.start();
+            this.start().catch((error) => {
+                this.logger.error(
+                    `Gradle server auto-restart failed: ${error instanceof Error ? error.message : String(error)}`
+                );
+            });
         }, AUTO_RESTART_DELAY_MS);
         return true;
     }
@@ -305,11 +317,6 @@ export class GradleServer {
     }
 
     private async handleUnexpectedExit(code: number | null, signal: NodeJS.Signals | null): Promise<void> {
-        sendInfo("", {
-            kind: "serverProcessExit",
-            data3: code !== null ? code.toString() : "",
-            dataMsg: signal ?? "",
-        });
         const reason = signal
             ? `was terminated by signal ${signal}`
             : `exited unexpectedly with code ${code ?? "null"}`;

--- a/extension/src/server/autoRestartPolicy.ts
+++ b/extension/src/server/autoRestartPolicy.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Decide whether the gradle-server may be auto-restarted after an unexpected
+ * exit. Kept as a pure function so the bounded-retry policy is unit-testable
+ * independently of process spawning: we stop restarting while the server is
+ * being disposed (extension shutdown) or once the per-session attempt budget is
+ * exhausted, at which point the caller surfaces the manual recovery prompt.
+ */
+export function shouldAutoRestart(disposing: boolean, attempts: number, maxAttempts: number): boolean {
+    return !disposing && attempts < maxAttempts;
+}

--- a/extension/src/test/unit/autoRestartPolicy.test.ts
+++ b/extension/src/test/unit/autoRestartPolicy.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import { shouldAutoRestart } from "../../server/autoRestartPolicy";
+
+function suiteName(name: string): string {
+    const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
+    return `${prefix}${name}`;
+}
+
+describe(suiteName("shouldAutoRestart"), () => {
+    const MAX = 3;
+
+    it("allows restarts while under the per-session attempt budget", () => {
+        assert.strictEqual(shouldAutoRestart(false, 0, MAX), true);
+        assert.strictEqual(shouldAutoRestart(false, 1, MAX), true);
+        assert.strictEqual(shouldAutoRestart(false, 2, MAX), true);
+    });
+
+    it("stops once the attempt budget is exhausted", () => {
+        assert.strictEqual(shouldAutoRestart(false, 3, MAX), false);
+        assert.strictEqual(shouldAutoRestart(false, 4, MAX), false);
+    });
+
+    it("never restarts while the server is being disposed", () => {
+        assert.strictEqual(shouldAutoRestart(true, 0, MAX), false);
+        assert.strictEqual(shouldAutoRestart(true, 2, MAX), false);
+    });
+});

--- a/extension/src/test/unit/transport/loopbackServer.test.ts
+++ b/extension/src/test/unit/transport/loopbackServer.test.ts
@@ -3,6 +3,7 @@
 
 import * as assert from "assert";
 import * as net from "net";
+import * as sinon from "sinon";
 import type { Logger as JsonRpcLogger } from "vscode-jsonrpc";
 import { createLoopbackListener, LoopbackListener } from "../../../transport/jsonrpc";
 
@@ -41,6 +42,41 @@ describe(suiteName("createLoopbackListener"), () => {
         const connection = await listener.connection;
         assert.ok(connection, "expected a MessageConnection to resolve from the listener");
         connection.dispose();
+    });
+
+    it("disables Nagle and enables TCP keepalive on the accepted gradle-server socket", async () => {
+        // Spy on the prototype so we observe the configuration applied to the
+        // inbound (accepted) socket. The test client never sets these itself,
+        // so any matching call must originate from the listener. Use spies
+        // (call-through) rather than stubs so the real socket still works.
+        const noDelaySpy = sinon.spy(net.Socket.prototype, "setNoDelay");
+        const keepAliveSpy = sinon.spy(net.Socket.prototype, "setKeepAlive");
+        try {
+            listener = await createLoopbackListener({ connectTimeoutMs: 2_000 });
+
+            clientSock = net.connect(listener.port, "127.0.0.1");
+            await new Promise<void>((resolve, reject) => {
+                clientSock!.once("connect", () => resolve());
+                clientSock!.once("error", reject);
+            });
+
+            const connection = await listener.connection;
+
+            assert.ok(noDelaySpy.calledWith(true), "expected setNoDelay(true) on the accepted gradle-server socket");
+            assert.ok(
+                keepAliveSpy
+                    .getCalls()
+                    .some((call) => call.args[0] === true && typeof call.args[1] === "number" && call.args[1] > 0),
+                `expected setKeepAlive(true, <ms>) on the accepted gradle-server socket, got: ${JSON.stringify(
+                    keepAliveSpy.getCalls().map((call) => call.args)
+                )}`
+            );
+
+            connection.dispose();
+        } finally {
+            noDelaySpy.restore();
+            keepAliveSpy.restore();
+        }
     });
 
     it("rejects the connection promise when dispose() is called before any JVM connects", async () => {

--- a/extension/src/transport/jsonrpc/loopbackServer.ts
+++ b/extension/src/transport/jsonrpc/loopbackServer.ts
@@ -24,6 +24,11 @@ import type { Logger as JsonRpcLogger } from "vscode-jsonrpc";
 
 const LOOPBACK = "127.0.0.1";
 const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+// Probe idle loopback connections so a peer that vanishes without a FIN
+// (e.g. a security product severing the socket) surfaces as a close/error
+// instead of a silently half-open connection. Raw sockets have keepalive off
+// by default.
+const KEEPALIVE_DELAY_MS = 15_000;
 
 export interface LoopbackListener {
     /** Ephemeral port the JVM should be told to connect back to. */
@@ -82,6 +87,12 @@ export async function createLoopbackListener(options: LoopbackListenerOptions = 
                 return;
             }
             acceptedSocket = socket;
+            // Raw TCP sockets default to Nagle-on / keepalive-off. Disable
+            // Nagle so the small JSON-RPC frames aren't delayed, and enable
+            // keepalive so a half-open connection (peer gone without a FIN) is
+            // detected instead of hanging until the OS-default timeout.
+            socket.setNoDelay(true);
+            socket.setKeepAlive(true, KEEPALIVE_DELAY_MS);
             if (timeoutHandle) {
                 clearTimeout(timeoutHandle);
                 timeoutHandle = undefined;

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/transport/jsonrpc/TaskSocketServer.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/transport/jsonrpc/TaskSocketServer.java
@@ -49,6 +49,12 @@ public final class TaskSocketServer {
 	public static Future<Void> connectAndStart(int port, ExecutorService workerExecutor) throws IOException {
 		Socket socket = new Socket();
 		socket.connect(new InetSocketAddress(LOOPBACK, port), CONNECT_TIMEOUT_MS);
+		// Mirror the Node listener: disable Nagle for the small JSON-RPC frames
+		// and enable TCP keepalive so a half-open connection (peer gone without
+		// a FIN, e.g. a security product severing loopback) is detected instead
+		// of blocking forever on a read.
+		socket.setTcpNoDelay(true);
+		socket.setKeepAlive(true);
 
 		GradleServiceImpl service = new GradleServiceImpl(workerExecutor);
 		Launcher<GradleClient> launcher = new Launcher.Builder<GradleClient>().setLocalService(service)


### PR DESCRIPTION
## Summary

The JSON-RPC-over-TCP-loopback transport between the extension and the `gradle-server` JVM (shipped in #1860) currently dies hard on a transport reset: the JVM calls `System.exit(1)` and the extension can only prompt the user to **Reload Window**.

Telemetry for the released build shows Windows hosts still hit a **~17% transport-failure rate** (gRPC era was ~20%), the bulk of it **transient/environmental** loopback resets (`ECONNRESET`) rather than a protocol defect, consistent with host security/EDR software interfering with loopback TCP. The transport is otherwise a net improvement over gRPC.

This PR makes those transient failures **self-heal** instead of forcing a manual reload.

## Changes

- **`loopbackServer.ts` / `TaskSocketServer.java`** — on the paired socket, enable TCP **keepalive** and disable **Nagle** on both the Node and Java ends. Keepalive surfaces a half-open connection (peer gone without a FIN) as a close/error instead of a silent hang; `noDelay` avoids delaying the small JSON-RPC frames. (Java-side keepalive is best-effort: it uses the OS default idle interval and plays no role in the dominant `ECONNRESET` case, which the OS delivers immediately.)
- **`GradleServer.ts`** — on an unexpected exit, transparently relaunch the server **up to 3 times per session** (fixed 1s delay) before falling back to the existing *Reload Window* warning. A pending restart is cancelled on explicit `start()`/`dispose()` so an explicit restart never races into a double-spawn. If the relaunch's own `start()` fails, it falls back to the recovery prompt so the user is never left with a silently dead server.
- **`TaskServerClient.ts`** — suppress the manual reconnect prompt while an auto-restart is pending so it doesn't compete with the transparent relaunch.
- The restart gate is extracted into a pure `shouldAutoRestart()` helper for unit testing.

## Telemetry

Recovery is recorded on the **single existing `serverProcessExit` event** (one event per unexpected exit, matching the existing `serverProcess*` convention, cf. `serverProcessExitRestart`), via a new `autoRestartAttempt` field:

- `autoRestartAttempt` = `"1"`..`"3"` -> the exit is being transparently auto-restarted (this attempt number).
- `autoRestartAttempt` = `""` -> terminal: the budget is exhausted or the server is disposing, and the user is prompted to reload.

This avoids double-counting a transient failure and keeps the exit reason (`data3`=code, `dataMsg`=signal) correlated with the recovery outcome on one row.

## Expected impact (and how to measure it)

- **Transient failers self-heal**: the dominant `ECONNRESET`-then-JVM-exit scenario now recovers without user action.
- **Persistent/environmental failures are unchanged** — the floor does not rise; keepalive only additionally helps the small silent half-open subset.
- This does **not** fix the root cause (loopback interference); eliminating it would require a different channel (named pipe / stdio), deferred.
- WARNING: **Measure recovery rate, not raw exit counts.** `serverProcessExit` counts may stay flat or even rise (a single session can now emit several exits). Recovery rate = `countif(autoRestartAttempt != "") / count()` over `serverProcessExit`.

## Verification

- **Fault injection (definitive)**: killed the `gradle-server` JVM mid-session on a real build, log showed a real `read ECONNRESET`, then `auto-restarting (attempt 1/3) in 1000ms`, JVM reconnected on a fresh loopback port, `CONFIGURE SUCCESSFUL`. No *Reload Window* prompt, no user action.
- **Non-regression autotest**: clean session stays healthy; auto-restart correctly does **not** fire on a graceful (code 0) exit.
- **Unit tests** (run in the VS Code test host): keepalive/noDelay applied to the accepted socket; `shouldAutoRestart` cap + disposing-guard boundaries.
- `prettier` + `eslint` clean; `:gradle-server:test` passes.

Related: #1860