### PR TITLE
fix: support multi-root workspaces with a single Gradle build in buil…

### DIFF
--- a/extension/build.gradle
+++ b/extension/build.gradle
@@ -195,7 +195,9 @@ task buildJdtlsPlugin(type: CrossPlatformExec) {
   if (mavenRepoLocal) {
     mavenArguments << "-Dmaven.repo.local=${mavenRepoLocal}"
   }
-  mavenArguments += ['clean', 'package']
+  // 'verify' instead of 'package' so the tycho-surefire tests of
+  // com.microsoft.gradle.bs.importer.test are executed as well
+  mavenArguments += ['clean', 'verify']
   if (System.getProperty('os.name').toLowerCase(Locale.ROOT).contains('windows')) {
     commandLine(['mvnw'] + mavenArguments)
   } else {

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target
@@ -20,6 +20,7 @@
             <unit id="org.eclipse.equinox.p2.core.feature.source.feature.group" version="0.0.0"/>
             <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
             <unit id="org.mockito.mockito-core" version="0.0.0"/>
+            <unit id="org.junit" version="0.0.0"/>
             <unit id="org.apache.commons.commons-io" version="0.0.0"/>
             <unit id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0"/>
             <repository location="https://download.eclipse.org/eclipse/updates/4.35/"/>

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer.test/META-INF/MANIFEST.MF
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer.test/META-INF/MANIFEST.MF
@@ -1,0 +1,8 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Gradle Build Server Importer Tests
+Bundle-SymbolicName: com.microsoft.gradle.bs.importer.test
+Bundle-Version: 0.5.4
+Fragment-Host: com.microsoft.gradle.bs.importer
+Bundle-RequiredExecutionEnvironment: JavaSE-21
+Require-Bundle: org.junit

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer.test/build.properties
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer.test/build.properties
@@ -1,0 +1,4 @@
+source.. = src/
+output.. = bin/
+bin.includes = META-INF/,\
+               .

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer.test/pom.xml
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer.test/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.microsoft.gradle.jdtls.ext</groupId>
+        <artifactId>gradle-jdtls-ext-parent</artifactId>
+        <version>0.5.4</version>
+    </parent>
+    <artifactId>com.microsoft.gradle.bs.importer.test</artifactId>
+    <packaging>eclipse-test-plugin</packaging>
+    <name>${base.name} :: Gradle Build Server Importer Tests</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-surefire-plugin</artifactId>
+                <version>${tycho-version}</version>
+                <configuration>
+                    <useUIHarness>false</useUIHarness>
+                    <!-- Start org.eclipse.jdt.ls.core in syntax server mode so its
+                         activator does not require the m2e bundles, which are not
+                         part of the target platform. -->
+                    <argLine>-Dsyntaxserver=true</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer.test/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporterTest.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer.test/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporterTest.java
@@ -1,0 +1,159 @@
+package com.microsoft.gradle.bs.importer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
+import org.eclipse.jdt.ls.core.internal.preferences.PreferenceManager;
+import org.eclipse.jdt.ls.core.internal.preferences.Preferences;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests for {@link GradleBuildServerProjectImporter} in multi-root workspaces.
+ *
+ * jdt.ls creates a fresh importer instance for every workspace root, but
+ * {@code initialize()} triggers {@code reset()} whenever the root folder
+ * changes. These tests exercise that defensive guard by reusing a single
+ * instance across roots: state derived from a previous root must not leak
+ * into the next one.
+ */
+public class GradleBuildServerProjectImporterTest {
+
+    private java.nio.file.Path gradleRoot;
+    private java.nio.file.Path plainRoot;
+    private PreferenceManager previousPreferenceManager;
+
+    @Before
+    public void setUp() throws Exception {
+        gradleRoot = Files.createTempDirectory("importer-test-gradle").toRealPath();
+        Files.createFile(gradleRoot.resolve("build.gradle"));
+        plainRoot = Files.createTempDirectory("importer-test-plain").toRealPath();
+
+        Preferences preferences = Preferences.createFrom(
+                Map.<String, Object>of("java.gradle.buildServer.enabled", "on"));
+        preferences.setRootPaths(List.of(
+                new Path(plainRoot.toString()),
+                new Path(gradleRoot.toString())));
+        PreferenceManager preferenceManager = new PreferenceManager();
+        preferenceManager.update(preferences);
+        // PreferenceManager is global static state on JavaLanguageServerPlugin;
+        // remember the previous one so tearDown() can restore it and the tests
+        // stay independent of each other and of execution order.
+        previousPreferenceManager = JavaLanguageServerPlugin.getPreferencesManager();
+        JavaLanguageServerPlugin.setPreferencesManager(preferenceManager);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        JavaLanguageServerPlugin.setPreferencesManager(previousPreferenceManager);
+        for (IProject project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
+            project.delete(true, true, new NullProgressMonitor());
+        }
+        deleteRecursively(plainRoot);
+        deleteRecursively(gradleRoot);
+    }
+
+    @Test
+    public void appliesToGradleRootAfterPlainRoot() throws Exception {
+        GradleBuildServerProjectImporter importer = new GradleBuildServerProjectImporter();
+
+        importer.initialize(plainRoot.toFile());
+        assertFalse("importer must not apply to a root without a Gradle build",
+                importer.applies(new NullProgressMonitor()));
+
+        importer.initialize(gradleRoot.toFile());
+        assertTrue("importer must apply to the Gradle root even when a plain root was visited first",
+                importer.applies(new NullProgressMonitor()));
+    }
+
+    @Test
+    public void doesNotApplyToPlainRootAfterGradleRoot() throws Exception {
+        GradleBuildServerProjectImporter importer = new GradleBuildServerProjectImporter();
+
+        importer.initialize(gradleRoot.toFile());
+        assertTrue("importer must apply to the Gradle root",
+                importer.applies(new NullProgressMonitor()));
+
+        importer.initialize(plainRoot.toFile());
+        assertFalse("importer must not reuse the Gradle root scan result for a plain root",
+                importer.applies(new NullProgressMonitor()));
+    }
+
+    @Test
+    public void doesNotApplyWhenMultipleRootsContainGradleBuilds() throws Exception {
+        Files.createFile(plainRoot.resolve("build.gradle"));
+        GradleBuildServerProjectImporter importer = new GradleBuildServerProjectImporter();
+
+        importer.initialize(gradleRoot.toFile());
+        assertFalse("importer must not apply when more than one root contains a Gradle build",
+                importer.applies(new NullProgressMonitor()));
+    }
+
+    @Test
+    public void resetClearsStaleUnresolvedState() throws Exception {
+        IProject project = createBuildServerProject("already-imported");
+
+        TestableImporter importer = new TestableImporter();
+        importer.initialize(gradleRoot.toFile());
+        // a directory outside the root folder makes the importer fail to
+        // determine the build server root and mark itself unresolved
+        importer.setDirectories(List.of(plainRoot));
+        importer.importToWorkspace(new NullProgressMonitor());
+
+        // switching to another root must reset the failure state
+        importer.initialize(plainRoot.toFile());
+
+        assertFalse(importer.isResolved(plainRoot.toFile()));
+        assertTrue("a stale failure from a previous root must not delete imported projects",
+                project.exists());
+    }
+
+    private IProject createBuildServerProject(String name) throws Exception {
+        IWorkspace workspace = ResourcesPlugin.getWorkspace();
+        IProjectDescription description = workspace.newProjectDescription(name);
+        description.setNatureIds(new String[] { GradleBuildServerProjectNature.NATURE_ID });
+        IProject project = workspace.getRoot().getProject(name);
+        project.create(description, new NullProgressMonitor());
+        project.open(new NullProgressMonitor());
+        return project;
+    }
+
+    private static void deleteRecursively(java.nio.file.Path root) throws IOException {
+        Files.walkFileTree(root, new SimpleFileVisitor<java.nio.file.Path>() {
+            @Override
+            public FileVisitResult visitFile(java.nio.file.Path file, BasicFileAttributes attrs) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(java.nio.file.Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static final class TestableImporter extends GradleBuildServerProjectImporter {
+        void setDirectories(Collection<java.nio.file.Path> directories) {
+            this.directories = directories;
+        }
+    }
+}

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.internal.resources.Project;
@@ -63,6 +64,15 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
     public static final String SETTINGS_GRADLE_DESCRIPTOR = "settings.gradle";
     public static final String SETTINGS_GRADLE_KTS_DESCRIPTOR = "settings.gradle.kts";
     public static final String ANDROID_MANIFEST = "AndroidManifest.xml";
+
+    /**
+     * jdt.ls creates a fresh importer instance for every workspace root, so
+     * this guard must be static to deduplicate the workspace-level
+     * {@code hasMultipleGradleRoots} fallback telemetry across the per-root
+     * {@code applies()} calls. It is sent at most once per session.
+     */
+    private static final AtomicBoolean multipleGradleRootsTelemetrySent = new AtomicBoolean(false);
+
     private boolean isResolved = true;
 
     @Override
@@ -81,9 +91,11 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
         // build (docs, scripts, ...) are fine.
         Collection<IPath> rootPaths = getPreferences().getRootPaths();
         if (rootPaths.size() != 1 && hasMultipleGradleRoots(rootPaths, monitor)) {
-            Telemetry telemetry = new Telemetry("hasMultipleGradleRoots", "true");
-            Utils.sendTelemetry(JavaLanguageServerPlugin.getProjectsManager().getConnection(),
-                    telemetry);
+            if (multipleGradleRootsTelemetrySent.compareAndSet(false, true)) {
+                Telemetry telemetry = new Telemetry("hasMultipleGradleRoots", "true");
+                Utils.sendTelemetry(JavaLanguageServerPlugin.getProjectsManager().getConnection(),
+                        telemetry);
+            }
             return false;
         }
 

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -71,20 +71,19 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
             return false;
         }
 
-        //TODO: support multi-root workspaces
-        Collection<IPath> rootPaths = getPreferences().getRootPaths();
-        if (rootPaths.size() != 1 && hasMultipleGradleRoots(rootPaths, monitor)) {
-            // The build server supports a single connection per workspace, so
-            // multi-root workspaces can only be handled when at most one root
-            // contains a Gradle build. Additional roots without any Gradle
-            // build (docs, scripts, ...) are fine.
-            Telemetry telemetry = new Telemetry("hasMultipleGradleRoots", "true");
-            Utils.sendTelemetry(JavaLanguageServerPlugin.getProjectsManager().getConnection(),
-                    telemetry);
+        if (!Utils.isBuildServerEnabled(getPreferences())) {
             return false;
         }
 
-        if (!Utils.isBuildServerEnabled(getPreferences())) {
+        // The build server supports a single connection per workspace, so
+        // multi-root workspaces can only be handled when at most one root
+        // contains a Gradle build. Additional roots without any Gradle
+        // build (docs, scripts, ...) are fine.
+        Collection<IPath> rootPaths = getPreferences().getRootPaths();
+        if (rootPaths.size() != 1 && hasMultipleGradleRoots(rootPaths, monitor)) {
+            Telemetry telemetry = new Telemetry("hasMultipleGradleRoots", "true");
+            Utils.sendTelemetry(JavaLanguageServerPlugin.getProjectsManager().getConnection(),
+                    telemetry);
             return false;
         }
 
@@ -147,8 +146,11 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
                     .includeNested(false)
                     .addExclusions("**/build") //default gradle build dir
                     .addExclusions("**/bin");
-            if (!gradleDetector.scan(monitor).isEmpty() && ++gradleRoots > 1) {
-                return true;
+            if (!gradleDetector.scan(monitor).isEmpty()) {
+                gradleRoots++;
+                if (gradleRoots > 1) {
+                    return true;
+                }
             }
         }
         return false;
@@ -320,7 +322,12 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
 
     @Override
     public void reset() {
-        // do nothing
+        // jdt.ls creates a fresh importer instance for every workspace root,
+        // but initialize() calls reset() whenever the root folder changes.
+        // Clear all root-scoped state here as a defensive guard in case an
+        // instance is ever reused for a different root.
+        directories = null;
+        isResolved = true;
     }
 
     /**

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerProjectImporter.java
@@ -72,7 +72,15 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
         }
 
         //TODO: support multi-root workspaces
-        if (getPreferences().getRootPaths().size() != 1) {
+        Collection<IPath> rootPaths = getPreferences().getRootPaths();
+        if (rootPaths.size() != 1 && hasMultipleGradleRoots(rootPaths, monitor)) {
+            // The build server supports a single connection per workspace, so
+            // multi-root workspaces can only be handled when at most one root
+            // contains a Gradle build. Additional roots without any Gradle
+            // build (docs, scripts, ...) are fine.
+            Telemetry telemetry = new Telemetry("hasMultipleGradleRoots", "true");
+            Utils.sendTelemetry(JavaLanguageServerPlugin.getProjectsManager().getConnection(),
+                    telemetry);
             return false;
         }
 
@@ -124,6 +132,26 @@ public class GradleBuildServerProjectImporter extends AbstractProjectImporter {
         Utils.sendTelemetry(JavaLanguageServerPlugin.getProjectsManager().getConnection(),
                 telemetry);
         return true;
+    }
+
+    /**
+     * Check whether more than one of the given workspace roots contains a
+     * Gradle build. Roots that do not contain any Gradle build file do not
+     * prevent the build server from handling the workspace.
+     */
+    private boolean hasMultipleGradleRoots(Collection<IPath> rootPaths, IProgressMonitor monitor) throws CoreException {
+        int gradleRoots = 0;
+        for (IPath rootPath : rootPaths) {
+            BasicFileDetector gradleDetector = new BasicFileDetector(rootPath.toFile().toPath(), BUILD_GRADLE_DESCRIPTOR,
+                    SETTINGS_GRADLE_DESCRIPTOR, BUILD_GRADLE_KTS_DESCRIPTOR, SETTINGS_GRADLE_KTS_DESCRIPTOR)
+                    .includeNested(false)
+                    .addExclusions("**/build") //default gradle build dir
+                    .addExclusions("**/bin");
+            if (!gradleDetector.scan(monitor).isEmpty() && ++gradleRoots > 1) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/Utils.java
@@ -257,6 +257,10 @@ public class Utils {
   }
 
   public static void sendTelemetry(JavaLanguageClient client, Object message) {
+    if (client == null) {
+      // no client connection, e.g. when running in tests
+      return;
+    }
     client.sendNotification(new ExecuteCommandParams("_java.gradle.buildServer.sendTelemetry",
         Arrays.asList(message)));
   }

--- a/extension/jdtls.ext/pom.xml
+++ b/extension/jdtls.ext/pom.xml
@@ -15,6 +15,7 @@
     <modules>
         <module>com.microsoft.gradle.bs.importer.target</module>
         <module>com.microsoft.gradle.bs.importer</module>
+        <module>com.microsoft.gradle.bs.importer.test</module>
     </modules>
     <build>
         <pluginManagement>


### PR DESCRIPTION
# Support multi-root workspaces with a single Gradle build in the build server importer

## Problem

Since the task/build server merge (#1512, released in 3.16.0), `GradleBuildServerProjectImporter.applies()` rejects **any** multi-root workspace:

```java
//TODO: support multi-root workspaces
if (getPreferences().getRootPaths().size() != 1) {
    return false;
}
```

This makes the importer fall back to Buildship even when only one workspace root contains a Gradle build and the remaining roots are plain folders (documentation, scripts, local secrets, ...). Buildship then resolves subproject dependencies of multi-project builds as JAR libraries instead of source project references, which surfaces as `missing required library: .../build/libs/*.jar` errors for every subproject right after a fresh import.

This is one of the causes behind #1587 ("Gradle build server falls back to buildship when there are multiple projects"); the only workaround so far is downgrading to 3.15.x, which predates the gate.

## Change

The build server holds a single connection per workspace, so true multi-Gradle-root workspaces still need to fall back to Buildship. But that constraint only concerns roots that actually contain a Gradle build. This PR narrows the gate accordingly:

- Multi-root workspaces are rejected only when **more than one root contains a Gradle build file** (`build.gradle(.kts)` / `settings.gradle(.kts)`, detected with the same `BasicFileDetector` configuration the importer already uses, including the `**/build` and `**/bin` exclusions).
- Workspaces with at most one Gradle root are handled by the build server exactly like single-root workspaces.
- Behavior for single-root workspaces and for workspaces with several Gradle roots is unchanged.
- A `hasMultipleGradleRoots` telemetry data point is sent on the remaining fallback path, consistent with the other fallback paths in this class (`hasBuildshipJavaProject`, `hasAndroidManifest`, `unableToDetermineRootFolder`).

## Validation

Tested with a workspace containing a Gradle multi-project build (root + 6 subprojects, `settings.gradle.kts` at the root) as one workspace root plus a non-Gradle folder as a second root, on a fresh JDT workspace:

- Before: importer bails out, Buildship imports the projects, every subproject reports `missing required library: .../build/libs/*-SNAPSHOT.jar`.
- After: the build server imports the projects (`GradleBuildServerProjectNature` in `.project`, `gradle.buildServer="true"` attributes in `.classpath`), subprojects are resolved as source project references, no library errors.