### PR TITLE
chore: clean up unused Gradle server host options

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -83,7 +83,7 @@ export class Extension {
         }
 
         const statusBarItem = vscode.window.createStatusBarItem();
-        this.server = new GradleServer({ host: "localhost" }, context, serverLogger, transportLogger);
+        this.server = new GradleServer(context, serverLogger, transportLogger);
         this.taskServerClient = new TaskServerClient(this.server, statusBarItem);
         this.pinnedTasksStore = new PinnedTasksStore(context);
         this.recentTasksStore = new RecentTasksStore();

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -32,7 +32,6 @@ export class GradleServer {
     private readonly _onDidStart: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private readonly _onDidStop: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private ready = false;
-    private taskServerPipePath: string | undefined;
     private pipeListener: PipeListener | undefined;
     private restarting = false;
     public readonly onDidStart: vscode.Event<null> = this._onDidStart.event;
@@ -116,9 +115,9 @@ export class GradleServer {
         // on the no-Java path.
         this.pipeListener?.dispose();
         this.pipeListener = await createPipeListener({ logger: this.buildJsonRpcLogger() });
-        this.taskServerPipePath = this.pipeListener.pipePath;
+        const taskServerPipePath = this.pipeListener.pipePath;
         const args = [
-            quoteArg(`--pipe=${this.taskServerPipePath}`),
+            quoteArg(`--pipe=${taskServerPipePath}`),
             quoteArg(`--startBuildServer=${startBuildServer}`),
             quoteArg(`--languageServerPipePath=${this.languageServerPipePath}`),
         ];

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -28,10 +28,6 @@ const RELOAD_HINT = "Run 'Developer: Reload Window' if Gradle stops working.";
 const MAX_AUTO_RESTARTS = 3;
 const AUTO_RESTART_DELAY_MS = 1_000;
 
-export interface ServerOptions {
-    host: string;
-}
-
 export class GradleServer {
     private readonly _onDidStart: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private readonly _onDidStop: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
@@ -52,7 +48,6 @@ export class GradleServer {
     private autoRestartTimer: NodeJS.Timeout | undefined;
 
     constructor(
-        private readonly opts: ServerOptions,
         private readonly context: vscode.ExtensionContext,
         private readonly logger: Logger,
         private readonly transportLogger: Logger
@@ -362,9 +357,5 @@ export class GradleServer {
             return Promise.reject(new Error("Gradle task server pipe listener is not initialized."));
         }
         return this.pipeListener.connection;
-    }
-
-    public getOpts(): ServerOptions {
-        return this.opts;
     }
 }


### PR DESCRIPTION
## Summary
- remove the loopback-era `ServerOptions { host }` API from `GradleServer`
- stop passing `{ host: "localhost" }` when constructing the server
- avoid storing the task pipe path as server state when it is only needed to build the JVM launch argument
- keep Java debug/test TCP helpers untouched because they are JDWP attach ports, not task-server transport

## Validation
- `cd extension; npm run compile:test`
- `cd extension; npm run lint:eslint` (0 errors; existing warnings only)