### PR TITLE
fix: harden Gradle server pipe recovery and language server rebind

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { commands, window } from "vscode";
+import { window } from "vscode";
 import { logger, LogVerbosity, Logger } from "./logger";
 import { Api } from "./api";
 import { TaskServerClient } from "./client";
@@ -330,11 +330,11 @@ export class Extension {
 
     private async restartServer(): Promise<void> {
         await this.taskServerClient.cancelBuilds();
-        await commands.executeCommand("workbench.action.restartExtensionHost");
+        await this.server.restart();
     }
 
     private async showRestartWindow(): Promise<string | undefined> {
-        const msg = "Please restart the extension to make the change take effect. Restart now?";
+        const msg = "Please restart the Gradle server to make the change take effect. Restart now?";
         const selection = await window.showWarningMessage(msg, OPT_RESTART);
         return selection;
     }

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -248,7 +248,7 @@ export class Extension {
     private async activate(): Promise<void> {
         this.registerGradleTestRunner();
         const activated = !!(await this.rootProjectsStore.getProjectRoots()).length;
-        if (!this.server.isReady()) {
+        if (!this.server.isStarted()) {
             await this.server.start();
         }
         await vscode.commands.executeCommand("setContext", "gradle:activated", activated);

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -90,6 +90,14 @@ export class Extension {
         this.taskTerminalsStore = new TaskTerminalsStore();
         this.rootProjectsStore = new RootProjectsStore();
         this.gradleBuildContentProvider = new GradleBuildContentProvider(this.taskServerClient);
+        this.server.setLanguageServerInitializer((languageServerPipePath) =>
+            startLanguageClientAndWaitForConnection(
+                this.context,
+                this.gradleBuildContentProvider,
+                this.rootProjectsStore,
+                languageServerPipePath
+            )
+        );
         this.gradleTaskProvider = new GradleTaskProvider(
             this.rootProjectsStore,
             this.taskServerClient,
@@ -211,12 +219,6 @@ export class Extension {
         );
 
         this.taskServerClient.onDidConnect(() => this.refresh());
-        void startLanguageClientAndWaitForConnection(
-            this.context,
-            this.gradleBuildContentProvider,
-            this.rootProjectsStore,
-            this.server.getLanguageServerPipePath()
-        );
         void this.activate();
         void vscode.commands.executeCommand("setContext", "allowParallelRun", getAllowParallelRun());
         void vscode.commands.executeCommand("setContext", Context.ACTIVATION_CONTEXT_KEY, true);

--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -22,7 +22,7 @@ import { FileWatcher } from "./util/FileWatcher";
 import { DependencyTreeItem } from "./views/gradleTasks/DependencyTreeItem";
 import { GRADLE_DEPENDENCY_REVEAL } from "./views/gradleTasks/DependencyUtils";
 import { GradleDependencyProvider } from "./dependencies/GradleDependencyProvider";
-import { isLanguageServerStarted, startLanguageClientAndWaitForConnection } from "./languageServer/languageServer";
+import { isLanguageServerStarted, startLanguageClientAndWaitForPipeServer } from "./languageServer/languageServer";
 import { DefaultProjectsTreeDataProvider } from "./views/defaultProject/DefaultProjectsTreeDataProvider";
 import {
     CompletionKinds,
@@ -91,7 +91,7 @@ export class Extension {
         this.rootProjectsStore = new RootProjectsStore();
         this.gradleBuildContentProvider = new GradleBuildContentProvider(this.taskServerClient);
         this.server.setLanguageServerInitializer((languageServerPipePath) =>
-            startLanguageClientAndWaitForConnection(
+            startLanguageClientAndWaitForPipeServer(
                 this.context,
                 this.gradleBuildContentProvider,
                 this.rootProjectsStore,

--- a/extension/src/bs/BspProxy.ts
+++ b/extension/src/bs/BspProxy.ts
@@ -95,6 +95,10 @@ export class BspProxy {
         this.buildServerStart = started;
     }
 
+    public hasImporterSession(): boolean {
+        return this.jdtlsImporterConnector.hasImporterSession();
+    }
+
     public closeConnection(): void {
         try {
             this.buildServerConnector.close();

--- a/extension/src/bs/BuildServerConnector.ts
+++ b/extension/src/bs/BuildServerConnector.ts
@@ -9,8 +9,8 @@ import { sendInfo } from "vscode-extension-telemetry-wrapper";
  */
 export class BuildServerConnector {
     private serverConnection: rpc.MessageConnection | null = null;
-    private serverPipeServer: net.Server;
-    private serverPipePath: string;
+    private serverPipeServer: net.Server | undefined;
+    private serverPipePath = "";
 
     /**
      * Generates a random pipe name, creates a pipe server and
@@ -50,6 +50,8 @@ export class BuildServerConnector {
     public close(): void {
         this.serverConnection?.end();
         this.serverConnection?.dispose();
-        this.serverPipeServer.close();
+        this.serverConnection = null;
+        this.serverPipeServer?.close();
+        this.serverPipeServer = undefined;
     }
 }

--- a/extension/src/bs/JdtlsImporterConnector.ts
+++ b/extension/src/bs/JdtlsImporterConnector.ts
@@ -12,8 +12,8 @@ export const ON_WILL_IMPORTER_CONNECT = "_gradle.onWillImporterConnect";
  */
 export class JdtlsImporterConnector {
     private importerConnection: rpc.MessageConnection | null = null;
-    private importerPipeServer: net.Server;
-    private importerPipePath: string;
+    private importerPipeServer: net.Server | undefined;
+    private importerPipePath: string | undefined;
     private setPipePathPromise: Promise<void> | null = null;
     private readonly _onImporterReady: vscode.EventEmitter<string> = new vscode.EventEmitter<string>();
 
@@ -53,6 +53,10 @@ export class JdtlsImporterConnector {
     }
 
     public async setupImporterPipeStream(): Promise<void> {
+        const importerPipePath = this.importerPipePath;
+        if (!importerPipePath) {
+            throw new Error("JDT LS importer pipe path is not initialized.");
+        }
         return new Promise((resolve) => {
             this.importerPipeServer = net.createServer((socket: net.Socket) => {
                 this.importerConnection = rpc.createMessageConnection(
@@ -68,7 +72,7 @@ export class JdtlsImporterConnector {
                     proxyErrorStack: error.stack ? error.stack.toString() : "",
                 });
             });
-            this.importerPipeServer.listen(this.importerPipePath);
+            this.importerPipeServer.listen(importerPipePath);
         });
     }
 
@@ -80,9 +84,15 @@ export class JdtlsImporterConnector {
         return this.importerConnection;
     }
 
+    public hasImporterSession(): boolean {
+        return this.importerConnection !== null || this.importerPipePath !== undefined;
+    }
+
     public close(): void {
         this.importerConnection?.end();
         this.importerConnection?.dispose();
-        this.importerPipeServer.close();
+        this.importerConnection = null;
+        this.importerPipeServer?.close();
+        this.importerPipeServer = undefined;
     }
 }

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -413,12 +413,6 @@ export class TaskServerClient implements vscode.Disposable {
         logger.info("Build cancelled:", cancelled.getMessage());
     };
 
-    /**
-     * Invoked when establishing the JSON-RPC connection to the task server fails
-     * (e.g. the JVM exited before connecting back, or the pipe listener timed
-     * out). If the server process never came up, hand off to the server-level
-     * restart prompt; otherwise show the client-level reconnect prompt.
-     */
     private handleConnectError = async (e: Error): Promise<void> => {
         logger.error("Error connecting to gradle server:", e.message);
         this.close();
@@ -429,23 +423,15 @@ export class TaskServerClient implements vscode.Disposable {
         if (this.server.isAutoRestartPending()) {
             return;
         }
-        if (this.server.isReady()) {
-            await this.showRestartMessage();
-        } else {
-            await this.server.showRestartMessage();
+        // A named pipe / UDS connection is single-use: once its listener has
+        // timed out or failed, reconnecting only the client would wait on the
+        // same rejected promise. If the JVM is still alive, restart the Gradle
+        // server so it gets a fresh pipe path; if it already exited, the server
+        // exit handler owns the user prompt.
+        if (this.server.isProcessRunning()) {
+            await this.server.showRestartMessage(`Gradle client could not connect to the task server (${e.message}).`);
         }
     };
-
-    public async showRestartMessage(): Promise<void> {
-        const OPT_RESTART = "Re-connect Client";
-        const input = await vscode.window.showErrorMessage(
-            "The Gradle client was unable to connect. Try re-connecting.",
-            OPT_RESTART
-        );
-        if (input === OPT_RESTART) {
-            await this.handleServerStart();
-        }
-    }
 
     public close(): void {
         this.statusBarItem.hide();

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -26,6 +26,7 @@ let activeLanguageClient: LanguageClient | undefined;
 let languageClientDisposable: vscode.Disposable | undefined;
 let configurationDisposable: vscode.Disposable | undefined;
 let pendingPipeServer: vscode.Disposable | undefined;
+let cleanupDisposableRegistered = false;
 
 export async function startLanguageClientAndWaitForConnection(
     context: vscode.ExtensionContext,
@@ -33,6 +34,7 @@ export async function startLanguageClientAndWaitForConnection(
     rootProjectsStore: RootProjectsStore,
     languageServerPipePath: string
 ): Promise<void> {
+    registerLanguageServerCleanup(context);
     if (languageServerPipePath === "") {
         isLanguageServerStarted = false;
         return;
@@ -103,8 +105,20 @@ export async function startLanguageClientAndWaitForConnection(
         activeLanguageClient = languageClient;
         currentDisposables.client = currentClientDisposable;
         languageClientDisposable = currentClientDisposable;
-        context.subscriptions.push(pipeServer, currentClientDisposable, currentConfigurationDisposable);
     });
+}
+
+function registerLanguageServerCleanup(context: vscode.ExtensionContext): void {
+    if (cleanupDisposableRegistered) {
+        return;
+    }
+    cleanupDisposableRegistered = true;
+    context.subscriptions.push(
+        new vscode.Disposable(() => {
+            cleanupDisposableRegistered = false;
+            stopLanguageClient();
+        })
+    );
 }
 
 function stopLanguageClient(): void {

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -25,8 +25,13 @@ export let isLanguageServerStarted = false;
 let activeLanguageClient: LanguageClient | undefined;
 let languageClientDisposable: vscode.Disposable | undefined;
 let configurationDisposable: vscode.Disposable | undefined;
-let pendingPipeServer: vscode.Disposable | undefined;
+let pendingPipeServer: LanguageServerPipeServer | undefined;
 let cleanupDisposableRegistered = false;
+
+interface LanguageServerPipeServer extends vscode.Disposable {
+    readonly listening: Promise<void>;
+    readonly connection: Promise<StreamInfo>;
+}
 
 export async function startLanguageClientAndWaitForConnection(
     context: vscode.ExtensionContext,
@@ -46,16 +51,26 @@ export async function startLanguageClientAndWaitForConnection(
         });
         const pipeServer = createLanguageServerPipeServer(languageServerPipePath);
         pendingPipeServer = pipeServer;
-        await pipeServer.listening;
+        try {
+            await pipeServer.listening;
+        } catch (error) {
+            if (pendingPipeServer === pipeServer) {
+                pendingPipeServer = undefined;
+            }
+            pipeServer.dispose();
+            throw error;
+        }
         const currentDisposables: {
             client?: vscode.Disposable;
             configuration?: vscode.Disposable;
         } = {};
         const cleanupClosedClient = (): void => {
-            if (languageClientDisposable === currentDisposables.client) {
+            if (currentDisposables.client && languageClientDisposable === currentDisposables.client) {
+                const disposable = languageClientDisposable;
                 activeLanguageClient = undefined;
                 languageClientDisposable = undefined;
                 isLanguageServerStarted = false;
+                disposable.dispose();
             }
             if (configurationDisposable && configurationDisposable === currentDisposables.configuration) {
                 const disposable = configurationDisposable;
@@ -89,6 +104,7 @@ export async function startLanguageClientAndWaitForConnection(
             },
             (e) => {
                 const errorMessage = e instanceof Error ? e.message : String(e);
+                cleanupClosedClient();
                 void vscode.window.showErrorMessage(errorMessage);
             }
         );
@@ -124,24 +140,47 @@ function registerLanguageServerCleanup(context: vscode.ExtensionContext): void {
 function stopLanguageClient(): void {
     isLanguageServerStarted = false;
     const client = activeLanguageClient;
+    const disposable = languageClientDisposable;
     activeLanguageClient = undefined;
+    languageClientDisposable = undefined;
     pendingPipeServer?.dispose();
     pendingPipeServer = undefined;
     configurationDisposable?.dispose();
     configurationDisposable = undefined;
-    languageClientDisposable = undefined;
-    void client?.stop().catch(() => undefined);
+    if (disposable) {
+        disposable.dispose();
+        return;
+    }
+    void client?.stop().catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error("Failed to stop Gradle Language Server:", message);
+    });
 }
 
-function createLanguageServerPipeServer(pipeName: string): {
-    readonly listening: Promise<void>;
-    readonly connection: Promise<StreamInfo>;
-    dispose(): void;
-} {
+function createLanguageServerPipeServer(pipeName: string): LanguageServerPipeServer {
     const server = net.createServer();
     let settled = false;
+    let listeningSettled = false;
     let rejectConnection: ((reason: Error) => void) | undefined;
     let rejectListening: ((reason: Error) => void) | undefined;
+    const rejectPendingConnection = (error: Error): void => {
+        if (settled) {
+            return;
+        }
+        settled = true;
+        const reject = rejectConnection;
+        rejectConnection = undefined;
+        reject?.(error);
+    };
+    const rejectPendingListening = (error: Error): void => {
+        if (listeningSettled) {
+            return;
+        }
+        listeningSettled = true;
+        const reject = rejectListening;
+        rejectListening = undefined;
+        reject?.(error);
+    };
     const connection = new Promise<StreamInfo>((resolve, reject) => {
         rejectConnection = reject;
         server.on("connection", (stream) => {
@@ -160,15 +199,11 @@ function createLanguageServerPipeServer(pipeName: string): {
     const listening = new Promise<void>((resolve, reject) => {
         rejectListening = reject;
         server.on("error", (err) => {
-            rejectListening?.(err);
-            if (!settled) {
-                settled = true;
-                const rejectPendingConnection = rejectConnection;
-                rejectConnection = undefined;
-                rejectPendingConnection?.(err);
-            }
+            rejectPendingListening(err);
+            rejectPendingConnection(err);
         });
         server.listen(pipeName, () => {
+            listeningSettled = true;
             rejectListening = undefined;
             resolve();
         });
@@ -178,12 +213,9 @@ function createLanguageServerPipeServer(pipeName: string): {
         listening,
         connection,
         dispose: () => {
-            if (!settled) {
-                settled = true;
-                const reject = rejectConnection;
-                rejectConnection = undefined;
-                reject?.(new Error("Gradle language server pipe listener disposed before connection"));
-            }
+            const error = new Error("Gradle language server pipe listener disposed before connection");
+            rejectPendingConnection(error);
+            rejectPendingListening(error);
             try {
                 server.close();
             } catch {

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -33,18 +33,17 @@ interface LanguageServerPipeServer extends vscode.Disposable {
     readonly connection: Promise<StreamInfo>;
 }
 
-export async function startLanguageClientAndWaitForConnection(
+export async function startLanguageClientAndWaitForPipeServer(
     context: vscode.ExtensionContext,
     contentProvider: GradleBuildContentProvider,
     rootProjectsStore: RootProjectsStore,
     languageServerPipePath: string
 ): Promise<void> {
     registerLanguageServerCleanup(context);
+    stopLanguageClient();
     if (languageServerPipePath === "") {
-        isLanguageServerStarted = false;
         return;
     }
-    stopLanguageClient();
     await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (progress) => {
         progress.report({
             message: "Initializing Gradle Language Server",

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -3,7 +3,12 @@
 
 import * as net from "net";
 import * as vscode from "vscode";
-import { DidChangeConfigurationNotification, LanguageClientOptions } from "vscode-languageclient";
+import {
+    CloseAction,
+    DidChangeConfigurationNotification,
+    ErrorAction,
+    LanguageClientOptions,
+} from "vscode-languageclient";
 import { LanguageClient, StreamInfo } from "vscode-languageclient/node";
 import { GradleBuildContentProvider } from "../client/GradleBuildContentProvider";
 import { GradleBuild, GradleProject } from "../proto/gradle_pb";
@@ -17,6 +22,10 @@ import {
 } from "../util/config";
 
 export let isLanguageServerStarted = false;
+let activeLanguageClient: LanguageClient | undefined;
+let languageClientDisposable: vscode.Disposable | undefined;
+let configurationDisposable: vscode.Disposable | undefined;
+let pendingPipeServer: vscode.Disposable | undefined;
 
 export async function startLanguageClientAndWaitForConnection(
     context: vscode.ExtensionContext,
@@ -28,60 +37,146 @@ export async function startLanguageClientAndWaitForConnection(
         isLanguageServerStarted = false;
         return;
     }
-    void vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, (progress) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        return new Promise<void>(async (resolve) => {
-            progress.report({
-                message: "Initializing Gradle Language Server",
-            });
-            const clientOptions: LanguageClientOptions = {
-                documentSelector: [{ scheme: "file", language: "gradle" }],
-                initializationOptions: {
-                    settings: getGradleSettings(),
-                },
-            };
-            const serverOptions = () => awaitServerConnection(languageServerPipePath);
-            const languageClient = new LanguageClient("gradle", "Gradle Language Server", serverOptions, clientOptions);
-            void languageClient.onReady().then(
-                () => {
-                    isLanguageServerStarted = true;
-                    void handleLanguageServerStart(contentProvider, rootProjectsStore);
-                    resolve();
-                },
-                (e) => {
-                    const errorMessage = e instanceof Error ? e.message : String(e);
-                    void vscode.window.showErrorMessage(errorMessage);
-                    resolve();
-                }
-            );
-            const disposable = languageClient.start();
-
-            context.subscriptions.push(disposable);
-            context.subscriptions.push(
-                vscode.workspace.onDidChangeConfiguration((e) => {
-                    if (e.affectsConfiguration("java.import.gradle")) {
-                        languageClient.sendNotification(DidChangeConfigurationNotification.type, {
-                            settings: getGradleSettings(),
-                        });
-                    }
-                })
-            );
+    stopLanguageClient();
+    await vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, async (progress) => {
+        progress.report({
+            message: "Initializing Gradle Language Server",
         });
+        const pipeServer = createLanguageServerPipeServer(languageServerPipePath);
+        pendingPipeServer = pipeServer;
+        await pipeServer.listening;
+        const currentDisposables: {
+            client?: vscode.Disposable;
+            configuration?: vscode.Disposable;
+        } = {};
+        const cleanupClosedClient = (): void => {
+            if (languageClientDisposable === currentDisposables.client) {
+                activeLanguageClient = undefined;
+                languageClientDisposable = undefined;
+                isLanguageServerStarted = false;
+            }
+            if (configurationDisposable && configurationDisposable === currentDisposables.configuration) {
+                const disposable = configurationDisposable;
+                configurationDisposable = undefined;
+                disposable.dispose();
+            }
+            if (pendingPipeServer === pipeServer) {
+                pendingPipeServer.dispose();
+                pendingPipeServer = undefined;
+            }
+        };
+        const clientOptions: LanguageClientOptions = {
+            documentSelector: [{ scheme: "file", language: "gradle" }],
+            errorHandler: {
+                error: () => ErrorAction.Continue,
+                closed: () => {
+                    cleanupClosedClient();
+                    return CloseAction.DoNotRestart;
+                },
+            },
+            initializationOptions: {
+                settings: getGradleSettings(),
+            },
+        };
+        const serverOptions = () => pipeServer.connection;
+        const languageClient = new LanguageClient("gradle", "Gradle Language Server", serverOptions, clientOptions);
+        void languageClient.onReady().then(
+            () => {
+                isLanguageServerStarted = true;
+                void handleLanguageServerStart(contentProvider, rootProjectsStore);
+            },
+            (e) => {
+                const errorMessage = e instanceof Error ? e.message : String(e);
+                void vscode.window.showErrorMessage(errorMessage);
+            }
+        );
+        const currentConfigurationDisposable = vscode.workspace.onDidChangeConfiguration((e) => {
+            if (e.affectsConfiguration("java.import.gradle")) {
+                languageClient.sendNotification(DidChangeConfigurationNotification.type, {
+                    settings: getGradleSettings(),
+                });
+            }
+        });
+        currentDisposables.configuration = currentConfigurationDisposable;
+        configurationDisposable = currentConfigurationDisposable;
+        const currentClientDisposable = languageClient.start();
+        activeLanguageClient = languageClient;
+        currentDisposables.client = currentClientDisposable;
+        languageClientDisposable = currentClientDisposable;
+        context.subscriptions.push(pipeServer, currentClientDisposable, currentConfigurationDisposable);
     });
 }
 
-async function awaitServerConnection(pipeName: string): Promise<StreamInfo> {
-    return new Promise((resolve, reject) => {
-        const server = net.createServer((stream) => {
+function stopLanguageClient(): void {
+    isLanguageServerStarted = false;
+    const client = activeLanguageClient;
+    activeLanguageClient = undefined;
+    pendingPipeServer?.dispose();
+    pendingPipeServer = undefined;
+    configurationDisposable?.dispose();
+    configurationDisposable = undefined;
+    languageClientDisposable = undefined;
+    void client?.stop().catch(() => undefined);
+}
+
+function createLanguageServerPipeServer(pipeName: string): {
+    readonly listening: Promise<void>;
+    readonly connection: Promise<StreamInfo>;
+    dispose(): void;
+} {
+    const server = net.createServer();
+    let settled = false;
+    let rejectConnection: ((reason: Error) => void) | undefined;
+    let rejectListening: ((reason: Error) => void) | undefined;
+    const connection = new Promise<StreamInfo>((resolve, reject) => {
+        rejectConnection = reject;
+        server.on("connection", (stream) => {
+            if (settled) {
+                stream.destroy();
+                return;
+            }
+            settled = true;
+            rejectConnection = undefined;
             server.close();
             resolve({ reader: stream, writer: stream });
         });
-        server.on("error", reject);
-        server.listen(pipeName, () => {
-            server.removeListener("error", reject);
-        });
-        return server;
     });
+    void connection.catch(() => undefined);
+
+    const listening = new Promise<void>((resolve, reject) => {
+        rejectListening = reject;
+        server.on("error", (err) => {
+            rejectListening?.(err);
+            if (!settled) {
+                settled = true;
+                const rejectPendingConnection = rejectConnection;
+                rejectConnection = undefined;
+                rejectPendingConnection?.(err);
+            }
+        });
+        server.listen(pipeName, () => {
+            rejectListening = undefined;
+            resolve();
+        });
+    });
+
+    return {
+        listening,
+        connection,
+        dispose: () => {
+            if (!settled) {
+                settled = true;
+                const reject = rejectConnection;
+                rejectConnection = undefined;
+                reject?.(new Error("Gradle language server pipe listener disposed before connection"));
+            }
+            try {
+                server.close();
+            } catch {
+                // best-effort cleanup; listener may already be closed
+            }
+        },
+    };
 }
 
 function getGradleSettings(): unknown {

--- a/extension/src/languageServer/languageServer.ts
+++ b/extension/src/languageServer/languageServer.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 import * as net from "net";
+import * as fs from "fs";
 import * as vscode from "vscode";
 import {
     CloseAction,
@@ -189,7 +190,7 @@ function createLanguageServerPipeServer(pipeName: string): LanguageServerPipeSer
             }
             settled = true;
             rejectConnection = undefined;
-            server.close();
+            closeLanguageServerPipeServer(server, pipeName);
             resolve({ reader: stream, writer: stream });
         });
     });
@@ -198,6 +199,7 @@ function createLanguageServerPipeServer(pipeName: string): LanguageServerPipeSer
     const listening = new Promise<void>((resolve, reject) => {
         rejectListening = reject;
         server.on("error", (err) => {
+            cleanupPipePath(pipeName);
             rejectPendingListening(err);
             rejectPendingConnection(err);
         });
@@ -215,13 +217,29 @@ function createLanguageServerPipeServer(pipeName: string): LanguageServerPipeSer
             const error = new Error("Gradle language server pipe listener disposed before connection");
             rejectPendingConnection(error);
             rejectPendingListening(error);
-            try {
-                server.close();
-            } catch {
-                // best-effort cleanup; listener may already be closed
-            }
+            closeLanguageServerPipeServer(server, pipeName);
         },
     };
+}
+
+function closeLanguageServerPipeServer(server: net.Server, pipeName: string): void {
+    try {
+        server.close();
+    } catch {
+        // best-effort cleanup; listener may already be closed
+    }
+    cleanupPipePath(pipeName);
+}
+
+function cleanupPipePath(pipeName: string): void {
+    if (process.platform === "win32") {
+        return;
+    }
+    try {
+        fs.unlinkSync(pipeName);
+    } catch {
+        // best-effort; the socket file may already be gone
+    }
 }
 
 function getGradleSettings(): unknown {

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -152,17 +152,21 @@ export class GradleServer {
             this.processStartedAt = Date.now();
             this.stderrTail = [];
             this.pendingStderrLine = "";
-            this.process = cp.spawn(`"${cmd}"`, args, {
+            const childProcess = cp.spawn(`"${cmd}"`, args, {
                 cwd,
                 env,
                 shell: true,
             });
+            this.process = childProcess;
             this.processRunning = true;
-            this.process.stdout.on("data", this.logOutput);
-            this.process.stderr.on("data", this.logOutput);
-            this.process.stderr.on("data", this.captureStderrTail);
-            this.process
-                .on("error", (err: Error) => this.logger.error(err.message))
+            childProcess.stdout.on("data", this.logOutput);
+            childProcess.stderr.on("data", this.logOutput);
+            childProcess.stderr.on("data", this.captureStderrTail);
+            childProcess
+                .on("error", (err: Error) => {
+                    this.logger.error(err.message);
+                    void this.handleProcessError(childProcess, err);
+                })
                 .on("exit", async (code, signal) => {
                     this.flushPendingStderrLine();
                     const wasTaskTransportReady = this.ready;
@@ -181,8 +185,10 @@ export class GradleServer {
                     this._onDidStop.fire(null);
                     this.ready = false;
                     this.processRunning = false;
-                    this.process?.removeAllListeners();
-                    this.process = undefined;
+                    childProcess.removeAllListeners();
+                    if (this.process === childProcess) {
+                        this.process = undefined;
+                    }
                     this.pipeListener?.dispose();
                     this.pipeListener = undefined;
                     this.bspProxy.closeConnection();
@@ -222,6 +228,21 @@ export class GradleServer {
         } finally {
             this.starting = false;
         }
+    }
+
+    private async handleProcessError(process: cp.ChildProcessWithoutNullStreams, error: Error): Promise<void> {
+        if (this.process !== process) {
+            return;
+        }
+        this._onDidStop.fire(null);
+        this.ready = false;
+        this.processRunning = false;
+        process.removeAllListeners();
+        this.process = undefined;
+        this.pipeListener?.dispose();
+        this.pipeListener = undefined;
+        this.bspProxy.closeConnection();
+        await this.showRestartMessage(`Gradle server failed to start (${error.message}).`);
     }
 
     public isReady(): boolean {

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -47,6 +47,7 @@ export class GradleServer {
     private disposing = false;
     private autoRestartCount = 0;
     private autoRestartTimer: NodeJS.Timeout | undefined;
+    private restartMessagePromise: Promise<void> | undefined;
 
     constructor(
         private readonly context: vscode.ExtensionContext,
@@ -236,6 +237,16 @@ export class GradleServer {
     }
 
     public async showRestartMessage(reason?: string): Promise<void> {
+        if (this.restartMessagePromise) {
+            return this.restartMessagePromise;
+        }
+        this.restartMessagePromise = this.showRestartMessageOnce(reason).finally(() => {
+            this.restartMessagePromise = undefined;
+        });
+        return this.restartMessagePromise;
+    }
+
+    private async showRestartMessageOnce(reason?: string): Promise<void> {
         const message = reason
             ? `${reason} Restart the Gradle server?`
             : "No connection to Gradle server. Restart the Gradle server?";

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -2,12 +2,11 @@ import * as vscode from "vscode";
 import * as path from "path";
 import * as cp from "child_process";
 import * as kill from "tree-kill";
-import { commands } from "vscode";
 import type { Logger as JsonRpcLogger, MessageConnection } from "vscode-jsonrpc";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { getGradleServerCommand, getGradleServerEnv, quoteArg } from "./serverUtil";
 import { Logger } from "../logger/index";
-import { NO_JAVA_EXECUTABLE, OPT_RESTART, INSTALL_JDK } from "../constant";
+import { NO_JAVA_EXECUTABLE, INSTALL_JDK } from "../constant";
 import { extensionInstalled } from "../util/config";
 import { BspProxy } from "../bs/BspProxy";
 import { getRandomPipeName } from "../util/generateRandomPipeName";
@@ -18,7 +17,7 @@ const DOWNLOAD_PROGRESS_CHAR = ".";
 const STDERR_TAIL_LINES = 40;
 const STDERR_TAIL_PREVIEW_LINES = 3;
 const VIEW_LOG_ACTION = "View Log";
-const RELOAD_HINT = "Run 'Developer: Reload Window' if Gradle stops working.";
+const RESTART_GRADLE_SERVER_ACTION = "Restart Gradle Server";
 // Bounded auto-restart for unexpected gradle-server exits (e.g. a task
 // transport break that kills the JVM). Relaunch transparently instead of
 // immediately asking the user to reload, and only fall back to the warning
@@ -32,6 +31,8 @@ export class GradleServer {
     private readonly _onDidStart: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private readonly _onDidStop: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     private ready = false;
+    private starting = false;
+    private processRunning = false;
     private pipeListener: PipeListener | undefined;
     private restarting = false;
     public readonly onDidStart: vscode.Event<null> = this._onDidStart.event;
@@ -76,144 +77,177 @@ export class GradleServer {
         return this.languageServerPipePath;
     }
     public async start(): Promise<void> {
+        if (this.starting || this.processRunning) {
+            return;
+        }
+        this.starting = true;
         // Cancel any pending auto-restart so an explicit start()/restart()
         // never races with a scheduled relaunch into a double-spawn.
         if (this.autoRestartTimer) {
             clearTimeout(this.autoRestartTimer);
             this.autoRestartTimer = undefined;
         }
-        let startBuildServer = false;
-        if (extensionInstalled("redhat.java")) {
-            const isPrepared = this.bspProxy.prepareToStart();
-            if (isPrepared) {
-                startBuildServer = true;
-            } else {
-                this.logger.error("Gradle build server will not start due to pipe path generation failure");
+        this.ready = false;
+        try {
+            let startBuildServer = false;
+            if (extensionInstalled("redhat.java")) {
+                const isPrepared = this.bspProxy.prepareToStart();
+                if (isPrepared) {
+                    startBuildServer = true;
+                } else {
+                    this.logger.error("Gradle build server will not start due to pipe path generation failure");
+                }
             }
-        }
-        this.bspProxy.setBuildServerStarted(startBuildServer);
-        this.bspProxy.start();
-        const cwd = this.context.asAbsolutePath("lib");
-        const cmd = path.join(cwd, getGradleServerCommand());
-        const env = await getGradleServerEnv();
-        if (!env) {
-            sendInfo("", {
-                kind: "GradleServerEnvMissing",
-            });
-            const choice = extensionInstalled("vscjava.vscode-java-pack") ? [INSTALL_JDK] : [];
-            vscode.window.showErrorMessage(NO_JAVA_EXECUTABLE, ...choice).then((selection) => {
-                if (selection === INSTALL_JDK) {
-                    vscode.commands.executeCommand("java.installJdk");
-                }
-            });
-            return;
-        }
-        // The JVM connects back as a named-pipe / UDS client over JSON-RPC.
-        // Bind the pipe BEFORE spawning the JVM so the JVM never sees a
-        // connection race against our listener. The listener is created AFTER
-        // the env check so we don't leak a bound pipe + pending connect promise
-        // on the no-Java path.
-        this.pipeListener?.dispose();
-        this.pipeListener = await createPipeListener({ logger: this.buildJsonRpcLogger() });
-        const taskServerPipePath = this.pipeListener.pipePath;
-        const args = [
-            quoteArg(`--pipe=${taskServerPipePath}`),
-            quoteArg(`--startBuildServer=${startBuildServer}`),
-            quoteArg(`--languageServerPipePath=${this.languageServerPipePath}`),
-        ];
-        if (startBuildServer) {
-            const buildServerPipeName = this.bspProxy.getBuildServerPipeName();
-            const bundleDirectory = this.context.asAbsolutePath("server");
-            args.push(quoteArg(`--pipeName=${buildServerPipeName}`));
-            args.push(quoteArg(`--bundleDir=${bundleDirectory}`));
-        }
-        this.logger.debug(`Gradle Server cmd: ${cmd} ${args.join(" ")}`);
-
-        this.processStartedAt = Date.now();
-        this.stderrTail = [];
-        this.pendingStderrLine = "";
-        this.process = cp.spawn(`"${cmd}"`, args, {
-            cwd,
-            env,
-            shell: true,
-        });
-        this.process.stdout.on("data", this.logOutput);
-        this.process.stderr.on("data", this.logOutput);
-        this.process.stderr.on("data", this.captureStderrTail);
-        this.process
-            .on("error", (err: Error) => this.logger.error(err.message))
-            .on("exit", async (code, signal) => {
-                this.flushPendingStderrLine();
-                const durationMs = Date.now() - this.processStartedAt;
-                this.logger.warn(
-                    `Gradle server stopped (exitCode=${code ?? "null"}, signal=${
-                        signal ?? "none"
-                    }, durationMs=${durationMs})`
-                );
-                if (this.stderrTail.length > 0) {
-                    this.logger.warn("Gradle server stderr tail:");
-                    for (const line of this.stderrTail) {
-                        this.logger.warn(`  ${line}`);
+            this.bspProxy.setBuildServerStarted(startBuildServer);
+            this.bspProxy.start();
+            const cwd = this.context.asAbsolutePath("lib");
+            const cmd = path.join(cwd, getGradleServerCommand());
+            const env = await getGradleServerEnv();
+            if (!env) {
+                sendInfo("", {
+                    kind: "GradleServerEnvMissing",
+                });
+                const choice = extensionInstalled("vscjava.vscode-java-pack") ? [INSTALL_JDK] : [];
+                vscode.window.showErrorMessage(NO_JAVA_EXECUTABLE, ...choice).then((selection) => {
+                    if (selection === INSTALL_JDK) {
+                        vscode.commands.executeCommand("java.installJdk");
                     }
-                }
-                this._onDidStop.fire(null);
-                this.ready = false;
-                this.process?.removeAllListeners();
-                this.pipeListener?.dispose();
-                this.pipeListener = undefined;
-                this.bspProxy.closeConnection();
-                if (this.restarting) {
-                    this.restarting = false;
-                    await this.start();
-                    return;
-                }
-                if ((code !== null && code !== 0) || signal !== null) {
-                    // Decide on recovery first, then record a single
-                    // serverProcessExit event for every unexpected exit (kept
-                    // comparable to the historical baseline). autoRestartAttempt
-                    // carries the recovery outcome on the same event: "1".."N"
-                    // while self-healing, "" once we give up (budget exhausted
-                    // or disposing) and the user is prompted to reload.
-                    const willAutoRestart = this.tryAutoRestart(code, signal);
-                    sendInfo("", {
-                        kind: "serverProcessExit",
-                        data3: code !== null ? code.toString() : "",
-                        dataMsg: signal ?? "",
-                        autoRestartAttempt: willAutoRestart ? this.autoRestartCount.toString() : "",
-                        transport: "pipe",
-                    });
-                    if (willAutoRestart) {
+                });
+                return;
+            }
+            // The JVM connects back as a named-pipe / UDS client over JSON-RPC.
+            // Bind the pipe BEFORE spawning the JVM so the JVM never sees a
+            // connection race against our listener. The listener is created AFTER
+            // the env check so we don't leak a bound pipe + pending connect promise
+            // on the no-Java path.
+            this.pipeListener?.dispose();
+            this.pipeListener = await createPipeListener({ logger: this.buildJsonRpcLogger() });
+            const taskServerPipePath = this.pipeListener.pipePath;
+            const args = [
+                quoteArg(`--pipe=${taskServerPipePath}`),
+                quoteArg(`--startBuildServer=${startBuildServer}`),
+                quoteArg(`--languageServerPipePath=${this.languageServerPipePath}`),
+            ];
+            if (startBuildServer) {
+                const buildServerPipeName = this.bspProxy.getBuildServerPipeName();
+                const bundleDirectory = this.context.asAbsolutePath("server");
+                args.push(quoteArg(`--pipeName=${buildServerPipeName}`));
+                args.push(quoteArg(`--bundleDir=${bundleDirectory}`));
+            }
+            this.logger.debug(`Gradle Server cmd: ${cmd} ${args.join(" ")}`);
+
+            this.processStartedAt = Date.now();
+            this.stderrTail = [];
+            this.pendingStderrLine = "";
+            this.process = cp.spawn(`"${cmd}"`, args, {
+                cwd,
+                env,
+                shell: true,
+            });
+            this.processRunning = true;
+            this.process.stdout.on("data", this.logOutput);
+            this.process.stderr.on("data", this.logOutput);
+            this.process.stderr.on("data", this.captureStderrTail);
+            this.process
+                .on("error", (err: Error) => this.logger.error(err.message))
+                .on("exit", async (code, signal) => {
+                    this.flushPendingStderrLine();
+                    const wasTaskTransportReady = this.ready;
+                    const durationMs = Date.now() - this.processStartedAt;
+                    this.logger.warn(
+                        `Gradle server stopped (exitCode=${code ?? "null"}, signal=${
+                            signal ?? "none"
+                        }, durationMs=${durationMs})`
+                    );
+                    if (this.stderrTail.length > 0) {
+                        this.logger.warn("Gradle server stderr tail:");
+                        for (const line of this.stderrTail) {
+                            this.logger.warn(`  ${line}`);
+                        }
+                    }
+                    this._onDidStop.fire(null);
+                    this.ready = false;
+                    this.processRunning = false;
+                    this.process?.removeAllListeners();
+                    this.process = undefined;
+                    this.pipeListener?.dispose();
+                    this.pipeListener = undefined;
+                    this.bspProxy.closeConnection();
+                    if (this.restarting) {
+                        this.restarting = false;
+                        await this.start();
                         return;
                     }
-                    await this.handleUnexpectedExit(code, signal);
-                }
-            });
+                    if ((code !== null && code !== 0) || signal !== null) {
+                        // Decide on recovery first, then record a single
+                        // serverProcessExit event for every unexpected exit (kept
+                        // comparable to the historical baseline). autoRestartAttempt
+                        // carries the recovery outcome on the same event: "1".."N"
+                        // while self-healing, "" once we give up (budget exhausted
+                        // or disposing) and the user is prompted.
+                        const willAutoRestart = wasTaskTransportReady && this.tryAutoRestart(code, signal);
+                        sendInfo("", {
+                            kind: "serverProcessExit",
+                            data3: code !== null ? code.toString() : "",
+                            dataMsg: signal ?? "",
+                            autoRestartAttempt: willAutoRestart ? this.autoRestartCount.toString() : "",
+                            transport: "pipe",
+                        });
+                        if (willAutoRestart) {
+                            return;
+                        }
+                        await this.handleUnexpectedExit(code, signal);
+                    }
+                });
 
-        this.fireOnStart();
+            this.fireOnStart();
+        } catch (error) {
+            this.pipeListener?.dispose();
+            this.pipeListener = undefined;
+            this.processRunning = false;
+            throw error;
+        } finally {
+            this.starting = false;
+        }
     }
 
     public isReady(): boolean {
         return this.ready;
     }
 
-    public async showRestartMessage(): Promise<void> {
-        const selection = await vscode.window.showErrorMessage(
-            "No connection to gradle server. Try restarting the server.",
-            OPT_RESTART
-        );
+    public isStarted(): boolean {
+        return this.starting || this.processRunning || this.autoRestartTimer !== undefined;
+    }
+
+    public isProcessRunning(): boolean {
+        return this.processRunning;
+    }
+
+    public async showRestartMessage(reason?: string): Promise<void> {
+        const message = reason
+            ? `${reason} Restart the Gradle server?`
+            : "No connection to Gradle server. Restart the Gradle server?";
+        const selection = await vscode.window.showErrorMessage(message, RESTART_GRADLE_SERVER_ACTION);
         sendInfo("", {
             kind: "serverProcessExitRestart",
-            data3: selection === OPT_RESTART ? "true" : "false",
+            data3: selection === RESTART_GRADLE_SERVER_ACTION ? "true" : "false",
+            dataMsg: "gradleServer",
         });
-        if (selection === OPT_RESTART) {
-            await commands.executeCommand("workbench.action.restartExtensionHost");
+        if (selection === RESTART_GRADLE_SERVER_ACTION) {
+            await this.restart();
         }
     }
 
     public async restart(): Promise<void> {
         this.logger.info("Restarting gradle server");
-        this.restarting = true;
-        this.killProcess();
+        this.ready = false;
+        if (this.processRunning && this.process) {
+            this.restarting = true;
+            await this.killProcess();
+            return;
+        }
+        this.restarting = false;
+        await this.start();
     }
 
     private captureStderrTail = (data: Buffer | string): void => {
@@ -323,15 +357,25 @@ export class GradleServer {
         const detail = tailPreview
             ? `Last output: ${tailPreview}`
             : `See the "Gradle for Java" output channel for details.`;
-        const message = `Gradle server ${reason}. ${detail} ${RELOAD_HINT}`;
-        const selection = await vscode.window.showWarningMessage(message, VIEW_LOG_ACTION);
-        if (selection === VIEW_LOG_ACTION) {
+        const message = `Gradle server ${reason}. ${detail}`;
+        const selection = await vscode.window.showWarningMessage(
+            message,
+            RESTART_GRADLE_SERVER_ACTION,
+            VIEW_LOG_ACTION
+        );
+        if (selection === RESTART_GRADLE_SERVER_ACTION) {
+            sendInfo("", {
+                kind: "serverProcessExitRestart",
+                data3: "true",
+                dataMsg: "gradleServer",
+            });
+            await this.restart();
+        } else if (selection === VIEW_LOG_ACTION) {
             this.logger.getChannel()?.show(true);
         }
     }
 
     private fireOnStart(): void {
-        this.ready = true;
         this._onDidStart.fire(null);
     }
 
@@ -347,6 +391,8 @@ export class GradleServer {
         this.pipeListener?.dispose();
         this.pipeListener = undefined;
         this.ready = false;
+        this.processRunning = false;
+        this.process = undefined;
         this._onDidStart.dispose();
         this._onDidStop.dispose();
     }
@@ -355,6 +401,9 @@ export class GradleServer {
         if (!this.pipeListener) {
             return Promise.reject(new Error("Gradle task server pipe listener is not initialized."));
         }
-        return this.pipeListener.connection;
+        return this.pipeListener.connection.then((connection) => {
+            this.ready = true;
+            return connection;
+        });
     }
 }

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -18,6 +18,7 @@ const STDERR_TAIL_LINES = 40;
 const STDERR_TAIL_PREVIEW_LINES = 3;
 const VIEW_LOG_ACTION = "View Log";
 const RESTART_GRADLE_SERVER_ACTION = "Restart Gradle Server";
+const RESTART_EXTENSION_HOST_ACTION = "Restart Extension Host";
 // Bounded auto-restart for unexpected gradle-server exits (e.g. a task
 // transport break that kills the JVM). Relaunch transparently instead of
 // immediately asking the user to reload, and only fall back to the warning
@@ -191,10 +192,18 @@ export class GradleServer {
                     }
                     this.pipeListener?.dispose();
                     this.pipeListener = undefined;
+                    const wasBspImporterActive = this.bspProxy.hasImporterSession();
                     this.bspProxy.closeConnection();
                     if (this.restarting) {
                         this.restarting = false;
-                        await this.start();
+                        if (wasBspImporterActive) {
+                            this.logger.info(
+                                "Restarting extension host because Gradle Build Server importer is active"
+                            );
+                            await vscode.commands.executeCommand("workbench.action.restartExtensionHost");
+                        } else {
+                            await this.start();
+                        }
                         return;
                     }
                     if ((code !== null && code !== 0) || signal !== null) {
@@ -204,7 +213,8 @@ export class GradleServer {
                         // carries the recovery outcome on the same event: "1".."N"
                         // while self-healing, "" once we give up (budget exhausted
                         // or disposing) and the user is prompted.
-                        const willAutoRestart = wasTaskTransportReady && this.tryAutoRestart(code, signal);
+                        const willAutoRestart =
+                            wasTaskTransportReady && !wasBspImporterActive && this.tryAutoRestart(code, signal);
                         sendInfo("", {
                             kind: "serverProcessExit",
                             data3: code !== null ? code.toString() : "",
@@ -215,7 +225,7 @@ export class GradleServer {
                         if (willAutoRestart) {
                             return;
                         }
-                        await this.handleUnexpectedExit(code, signal);
+                        await this.handleUnexpectedExit(code, signal, wasBspImporterActive);
                     }
                 });
 
@@ -257,32 +267,55 @@ export class GradleServer {
         return this.processRunning;
     }
 
-    public async showRestartMessage(reason?: string): Promise<void> {
+    public async showRestartMessage(reason?: string, requiresExtensionHostRestart = false): Promise<void> {
         if (this.restartMessagePromise) {
             return this.restartMessagePromise;
         }
-        this.restartMessagePromise = this.showRestartMessageOnce(reason).finally(() => {
+        this.restartMessagePromise = this.showRestartMessageOnce(reason, requiresExtensionHostRestart).finally(() => {
             this.restartMessagePromise = undefined;
         });
         return this.restartMessagePromise;
     }
 
-    private async showRestartMessageOnce(reason?: string): Promise<void> {
-        const message = reason
-            ? `${reason} Restart the Gradle server?`
-            : "No connection to Gradle server. Restart the Gradle server?";
-        const selection = await vscode.window.showErrorMessage(message, RESTART_GRADLE_SERVER_ACTION);
+    private async showRestartMessageOnce(reason?: string, requiresExtensionHostRestart = false): Promise<void> {
+        const restartExtensionHost = requiresExtensionHostRestart || this.isBspImporterActive();
+        const message = this.buildRestartMessage(reason, restartExtensionHost);
+        const action = restartExtensionHost ? RESTART_EXTENSION_HOST_ACTION : RESTART_GRADLE_SERVER_ACTION;
+        const selection = await vscode.window.showErrorMessage(message, action);
         sendInfo("", {
             kind: "serverProcessExitRestart",
-            data3: selection === RESTART_GRADLE_SERVER_ACTION ? "true" : "false",
-            dataMsg: "gradleServer",
+            data3: selection === action ? "true" : "false",
+            dataMsg: restartExtensionHost ? "extensionHost" : "gradleServer",
         });
-        if (selection === RESTART_GRADLE_SERVER_ACTION) {
-            await this.restart();
+        if (selection === action) {
+            if (restartExtensionHost) {
+                await vscode.commands.executeCommand("workbench.action.restartExtensionHost");
+            } else {
+                await this.restart();
+            }
         }
     }
 
+    private buildRestartMessage(reason: string | undefined, restartExtensionHost: boolean): string {
+        if (!restartExtensionHost) {
+            return reason
+                ? `${reason} Restart the Gradle server?`
+                : "No connection to Gradle server. Restart the Gradle server?";
+        }
+        const prefix = reason ? `${reason} ` : "No connection to Gradle server. ";
+        return `${prefix}Restart the extension host to restore Gradle Build Server integration?`;
+    }
+
+    private isBspImporterActive(): boolean {
+        return this.bspProxy?.hasImporterSession() ?? false;
+    }
+
     public async restart(): Promise<void> {
+        if (this.isBspImporterActive()) {
+            this.logger.info("Restarting extension host because Gradle Build Server importer is active");
+            await vscode.commands.executeCommand("workbench.action.restartExtensionHost");
+            return;
+        }
         this.logger.info("Restarting gradle server");
         this.ready = false;
         if (this.processRunning && this.process) {
@@ -380,7 +413,7 @@ export class GradleServer {
                 this.logger.error(
                     `Gradle server auto-restart failed: ${error instanceof Error ? error.message : String(error)}`
                 );
-                void this.handleUnexpectedExit(code, signal);
+                void this.handleUnexpectedExit(code, signal, this.isBspImporterActive());
             });
         }, AUTO_RESTART_DELAY_MS);
         return true;
@@ -393,7 +426,11 @@ export class GradleServer {
         return this.autoRestartTimer !== undefined;
     }
 
-    private async handleUnexpectedExit(code: number | null, signal: NodeJS.Signals | null): Promise<void> {
+    private async handleUnexpectedExit(
+        code: number | null,
+        signal: NodeJS.Signals | null,
+        requiresExtensionHostRestart = false
+    ): Promise<void> {
         const reason = signal
             ? `was terminated by signal ${signal}`
             : `exited unexpectedly with code ${code ?? "null"}`;
@@ -402,18 +439,21 @@ export class GradleServer {
             ? `Last output: ${tailPreview}`
             : `See the "Gradle for Java" output channel for details.`;
         const message = `Gradle server ${reason}. ${detail}`;
-        const selection = await vscode.window.showWarningMessage(
-            message,
-            RESTART_GRADLE_SERVER_ACTION,
-            VIEW_LOG_ACTION
-        );
-        if (selection === RESTART_GRADLE_SERVER_ACTION) {
+        const restartAction = requiresExtensionHostRestart
+            ? RESTART_EXTENSION_HOST_ACTION
+            : RESTART_GRADLE_SERVER_ACTION;
+        const selection = await vscode.window.showWarningMessage(message, restartAction, VIEW_LOG_ACTION);
+        if (selection === restartAction) {
             sendInfo("", {
                 kind: "serverProcessExitRestart",
                 data3: "true",
-                dataMsg: "gradleServer",
+                dataMsg: requiresExtensionHostRestart ? "extensionHost" : "gradleServer",
             });
-            await this.restart();
+            if (requiresExtensionHostRestart) {
+                await vscode.commands.executeCommand("workbench.action.restartExtensionHost");
+            } else {
+                await this.restart();
+            }
         } else if (selection === VIEW_LOG_ACTION) {
             this.logger.getChannel()?.show(true);
         }

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -35,10 +35,11 @@ export class GradleServer {
     private processRunning = false;
     private pipeListener: PipeListener | undefined;
     private restarting = false;
+    private languageServerInitializer: (pipePath: string) => Promise<void> = async () => undefined;
     public readonly onDidStart: vscode.Event<null> = this._onDidStart.event;
     public readonly onDidStop: vscode.Event<null> = this._onDidStop.event;
     private process?: cp.ChildProcessWithoutNullStreams;
-    private languageServerPipePath: string;
+    private languageServerPipePath = "";
     private bspProxy: BspProxy;
     private processStartedAt = 0;
     private stderrTail: string[] = [];
@@ -52,7 +53,6 @@ export class GradleServer {
         private readonly logger: Logger,
         private readonly transportLogger: Logger
     ) {
-        this.setLanguageServerPipePath();
         this.bspProxy = new BspProxy(this.context, logger);
     }
 
@@ -73,9 +73,10 @@ export class GradleServer {
         }
     }
 
-    public getLanguageServerPipePath(): string {
-        return this.languageServerPipePath;
+    public setLanguageServerInitializer(initializer: (pipePath: string) => Promise<void>): void {
+        this.languageServerInitializer = initializer;
     }
+
     public async start(): Promise<void> {
         if (this.starting || this.processRunning) {
             return;
@@ -114,6 +115,17 @@ export class GradleServer {
                     }
                 });
                 return;
+            }
+            this.setLanguageServerPipePath();
+            try {
+                await this.languageServerInitializer(this.languageServerPipePath);
+            } catch (error) {
+                this.logger.error(
+                    `Gradle language server pipe initialization failed: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`
+                );
+                this.languageServerPipePath = "";
             }
             // The JVM connects back as a named-pipe / UDS client over JSON-RPC.
             // Bind the pipe BEFORE spawning the JVM so the JVM never sees a

--- a/extension/src/test/unit/GradleServer.test.ts
+++ b/extension/src/test/unit/GradleServer.test.ts
@@ -20,6 +20,11 @@ type GradleServerInternals = {
     _onDidStop: { fire(value: null): void };
     showRestartMessage: SinonStub<[string?], Promise<void>>;
     handleProcessError(process: cp.ChildProcessWithoutNullStreams, error: Error): Promise<void>;
+    handleUnexpectedExit(
+        code: number | null,
+        signal: NodeJS.Signals | null,
+        requiresExtensionHostRestart: boolean
+    ): Promise<void>;
 };
 
 describe(suiteName("GradleServer recovery"), () => {
@@ -44,6 +49,55 @@ describe(suiteName("GradleServer recovery"), () => {
         resolvePrompt(undefined);
         await Promise.all([firstPrompt, secondPrompt]);
         assert.strictEqual(showErrorMessageStub.calledOnce, true);
+    });
+
+    it("uses extension host restart when prompting with an active BSP importer session", async () => {
+        const showErrorMessageStub = (sinon.stub(vscode.window, "showErrorMessage") as SinonStub).resolves(
+            "Restart Extension Host"
+        );
+        const executeCommandStub = sinon.stub(vscode.commands, "executeCommand").resolves();
+        const server = Object.assign(Object.create(GradleServer.prototype), {
+            bspProxy: { hasImporterSession: sinon.stub().returns(true) },
+        }) as GradleServer;
+
+        await server.showRestartMessage("Gradle server failed.");
+
+        assert.strictEqual(showErrorMessageStub.calledOnce, true);
+        const [message, action] = showErrorMessageStub.firstCall.args;
+        assert.match(String(message), /extension host/i);
+        assert.strictEqual(action, "Restart Extension Host");
+        assert.strictEqual(executeCommandStub.calledOnceWith("workbench.action.restartExtensionHost"), true);
+    });
+
+    it("routes direct restart to the extension host when BSP importer is active", async () => {
+        const executeCommandStub = sinon.stub(vscode.commands, "executeCommand").resolves();
+        const logger = { info: sinon.stub() };
+        const server = Object.assign(Object.create(GradleServer.prototype), {
+            bspProxy: { hasImporterSession: sinon.stub().returns(true) },
+            logger,
+        }) as GradleServer;
+
+        await server.restart();
+
+        assert.strictEqual(logger.info.calledOnce, true);
+        assert.strictEqual(executeCommandStub.calledOnceWith("workbench.action.restartExtensionHost"), true);
+    });
+
+    it("uses extension host restart for unexpected exits when BSP importer is active", async () => {
+        const showWarningMessageStub = (sinon.stub(vscode.window, "showWarningMessage") as SinonStub).resolves(
+            "Restart Extension Host"
+        );
+        const executeCommandStub = sinon.stub(vscode.commands, "executeCommand").resolves();
+        const server = Object.assign(Object.create(GradleServer.prototype), {
+            stderrTail: [],
+            logger: { getChannel: sinon.stub() },
+        }) as GradleServerInternals;
+
+        await server.handleUnexpectedExit(1, null, true);
+
+        assert.strictEqual(showWarningMessageStub.calledOnce, true);
+        assert.strictEqual(showWarningMessageStub.firstCall.args[1], "Restart Extension Host");
+        assert.strictEqual(executeCommandStub.calledOnceWith("workbench.action.restartExtensionHost"), true);
     });
 
     it("cleans up pending startup state when the child process emits error", async () => {

--- a/extension/src/test/unit/GradleServer.test.ts
+++ b/extension/src/test/unit/GradleServer.test.ts
@@ -1,4 +1,6 @@
 import * as assert from "assert";
+import type * as cp from "child_process";
+import { EventEmitter } from "events";
 import * as sinon from "sinon";
 import { SinonStub } from "sinon";
 import * as vscode from "vscode";
@@ -8,6 +10,17 @@ function suiteName(name: string): string {
     const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
     return `${prefix}${name}`;
 }
+
+type GradleServerInternals = {
+    process?: cp.ChildProcessWithoutNullStreams;
+    processRunning: boolean;
+    ready: boolean;
+    pipeListener?: { dispose(): void };
+    bspProxy: { closeConnection(): void };
+    _onDidStop: { fire(value: null): void };
+    showRestartMessage: SinonStub<[string?], Promise<void>>;
+    handleProcessError(process: cp.ChildProcessWithoutNullStreams, error: Error): Promise<void>;
+};
 
 describe(suiteName("GradleServer recovery"), () => {
     afterEach(() => {
@@ -31,5 +44,36 @@ describe(suiteName("GradleServer recovery"), () => {
         resolvePrompt(undefined);
         await Promise.all([firstPrompt, secondPrompt]);
         assert.strictEqual(showErrorMessageStub.calledOnce, true);
+    });
+
+    it("cleans up pending startup state when the child process emits error", async () => {
+        const childProcess = new EventEmitter() as cp.ChildProcessWithoutNullStreams;
+        const pipeListener = { dispose: sinon.stub() };
+        const bspProxy = { closeConnection: sinon.stub() };
+        const onDidStop = { fire: sinon.stub() };
+        const server = Object.assign(Object.create(GradleServer.prototype), {
+            process: childProcess,
+            processRunning: true,
+            ready: true,
+            pipeListener,
+            bspProxy,
+            _onDidStop: onDidStop,
+            showRestartMessage: sinon.stub().resolves(),
+        }) as GradleServerInternals;
+
+        await server.handleProcessError(childProcess, new Error("spawn failed"));
+
+        assert.strictEqual(server.ready, false);
+        assert.strictEqual(server.processRunning, false);
+        assert.strictEqual(server.process, undefined);
+        assert.strictEqual(server.pipeListener, undefined);
+        assert.strictEqual(pipeListener.dispose.calledOnce, true);
+        assert.strictEqual(bspProxy.closeConnection.calledOnce, true);
+        assert.strictEqual(onDidStop.fire.calledOnceWith(null), true);
+        const restartReason = server.showRestartMessage.firstCall.args[0];
+        if (typeof restartReason !== "string") {
+            assert.fail("Expected restart prompt reason");
+        }
+        assert.match(restartReason, /failed to start/i);
     });
 });

--- a/extension/src/test/unit/GradleServer.test.ts
+++ b/extension/src/test/unit/GradleServer.test.ts
@@ -1,0 +1,35 @@
+import * as assert from "assert";
+import * as sinon from "sinon";
+import { SinonStub } from "sinon";
+import * as vscode from "vscode";
+import { GradleServer } from "../../server";
+
+function suiteName(name: string): string {
+    const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
+    return `${prefix}${name}`;
+}
+
+describe(suiteName("GradleServer recovery"), () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it("deduplicates concurrent restart prompts", async () => {
+        let resolvePrompt: (selection: string | undefined) => void = () => undefined;
+        const promptSelection = new Promise<string | undefined>((resolve) => {
+            resolvePrompt = resolve;
+        });
+        const showErrorMessageStub = (sinon.stub(vscode.window, "showErrorMessage") as SinonStub).returns(
+            promptSelection
+        );
+        const server = Object.create(GradleServer.prototype) as GradleServer;
+
+        const firstPrompt = server.showRestartMessage("first failure");
+        const secondPrompt = server.showRestartMessage("second failure");
+
+        assert.strictEqual(showErrorMessageStub.calledOnce, true);
+        resolvePrompt(undefined);
+        await Promise.all([firstPrompt, secondPrompt]);
+        assert.strictEqual(showErrorMessageStub.calledOnce, true);
+    });
+});

--- a/extension/src/test/unit/TaskServerClient.test.ts
+++ b/extension/src/test/unit/TaskServerClient.test.ts
@@ -1,0 +1,105 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import { TaskServerClient } from "../../client/TaskServerClient";
+import { logger } from "../../logger";
+import { GradleServer } from "../../server";
+import { buildMockOutputChannel } from "../testUtil";
+
+function suiteName(name: string): string {
+    const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
+    return `${prefix}${name}`;
+}
+
+function createStatusBarItem(): vscode.StatusBarItem {
+    return {
+        hide: sinon.stub(),
+        show: sinon.stub(),
+        dispose: sinon.stub(),
+    } as unknown as vscode.StatusBarItem;
+}
+
+function createServer(options: {
+    connection: Promise<unknown>;
+    autoRestartPending?: boolean;
+    processRunning?: boolean;
+}): {
+    server: GradleServer;
+    showRestartMessage: sinon.SinonStub;
+} {
+    const showRestartMessage = sinon.stub().resolves();
+    return {
+        server: {
+            onDidStart: sinon.stub().returns({ dispose: sinon.stub() }),
+            onDidStop: sinon.stub().returns({ dispose: sinon.stub() }),
+            awaitTaskConnection: sinon.stub().returns(options.connection),
+            isAutoRestartPending: sinon.stub().returns(options.autoRestartPending ?? false),
+            isProcessRunning: sinon.stub().returns(options.processRunning ?? true),
+            showRestartMessage,
+        } as unknown as GradleServer,
+        showRestartMessage,
+    };
+}
+
+describe(suiteName("TaskServerClient recovery"), () => {
+    let withProgressStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        logger.reset();
+        logger.setLoggingChannel(buildMockOutputChannel());
+        withProgressStub = sinon.stub(vscode.window, "withProgress").callsFake((_options, task) => {
+            const progress = { report: sinon.stub() };
+            const tokenSource = new vscode.CancellationTokenSource();
+            return task(progress, tokenSource.token) as Thenable<unknown>;
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        logger.reset();
+    });
+
+    it("prompts to restart the Gradle server when pipe connection fails while the JVM is running", async () => {
+        const { server, showRestartMessage } = createServer({
+            connection: Promise.reject(new Error("pipe connect timeout")),
+            processRunning: true,
+        });
+        const client = new TaskServerClient(server, createStatusBarItem());
+
+        await client.handleServerStart();
+
+        assert.strictEqual(withProgressStub.calledOnce, true);
+        assert.strictEqual(showRestartMessage.calledOnce, true);
+        assert.match(showRestartMessage.firstCall.args[0], /could not connect to the task server/i);
+        assert.match(showRestartMessage.firstCall.args[0], /pipe connect timeout/i);
+        client.dispose();
+    });
+
+    it("does not show a second prompt when auto-restart is already pending", async () => {
+        const { server, showRestartMessage } = createServer({
+            connection: Promise.reject(new Error("listener disposed")),
+            autoRestartPending: true,
+            processRunning: true,
+        });
+        const client = new TaskServerClient(server, createStatusBarItem());
+
+        await client.handleServerStart();
+
+        assert.strictEqual(showRestartMessage.called, false);
+        client.dispose();
+    });
+
+    it("lets the server exit handler own the prompt when the JVM already exited", async () => {
+        const { server, showRestartMessage } = createServer({
+            connection: Promise.reject(new Error("listener disposed")),
+            processRunning: false,
+        });
+        const client = new TaskServerClient(server, createStatusBarItem());
+
+        await client.handleServerStart();
+
+        assert.strictEqual(showRestartMessage.called, false);
+        client.dispose();
+    });
+});


### PR DESCRIPTION
## Summary

Harden Gradle server recovery after the task JSON-RPC transport moved from loopback TCP to one-shot named pipe / Unix domain socket transport.

This PR replaces loopback-era recovery behavior with Gradle-server-aware recovery: task transport failures and Gradle server configuration refreshes recover by restarting the Gradle server JVM with fresh pipe paths when BSP has not been activated. If the JDT LS BSP importer has already participated, recovery falls back to restarting the extension host so the importer/BSP connection is rebuilt instead of silently leaving Build Server integration stale.

## Why

Named pipe / UDS transport has a different lifecycle from loopback TCP:

- The VS Code extension creates the pipe listener first.
- The Gradle server JVM connects back as a client.
- The task pipe listener is consumed by the first successful connection and is not reusable for a later JVM.

Because of that, a client-only reconnect cannot recover a failed or stale task pipe. Recovery must create a fresh pipe path and restart the Gradle server JVM.

The same constraint applies to the Gradle Language Server pipe when the extension host stays alive. If the task pipe is recreated but the Gradle LS pipe is reused, task APIs can recover while Gradle language features stay attached to a stale one-shot pipe. This PR rebinds the Gradle LS pipe before each Gradle JVM start so both task and language-server channels point at the new JVM.

BSP is the exception for this short-term PR: the JDT LS importer can cache its build-server connection and may not re-run `_gradle.onWillImporterConnect` when only the Gradle JVM restarts. Until the medium-term BSP lifecycle split in #1878 is implemented, this PR avoids claiming JVM-only recovery for active BSP sessions.

## Changes

- Split Gradle server lifecycle state:
  - `isStarted()` now covers startup in progress, JVM running, or pending auto-restart.
  - `isReady()` now means the task JSON-RPC pipe is actually connected.
- Replace client-only pipe reconnect handling with a `Restart Gradle Server` recovery path when BSP has not been activated.
- Restart only the Gradle server JVM for pipe recovery and Gradle-server-affecting configuration changes when BSP importer state is not active.
- Fall back to `Restart Extension Host` once the JDT LS BSP importer session is observed, including manual restart, unexpected-exit recovery, spawn-failure recovery, and restart-in-progress races.
- Skip bounded auto-restart for active BSP importer sessions to avoid silently breaking Build Server integration.
- Rebind the Gradle Language Server pipe and `LanguageClient` transport before each Gradle JVM start.
- Disable the Gradle Language Client's built-in close restart because `GradleServer` owns restart sequencing for the shared JVM and one-shot pipes.
- Treat Gradle LS pipe setup failure as non-fatal for core task-server startup.
- Scope bounded auto-restart to unexpected exits after a successful task transport connection.
- Deduplicate concurrent restart prompts when task pipe connect failure and JVM exit race.
- Clean up Gradle LS rebind resources on close/startup failure: dispose dynamic client/configuration/pipe resources directly, reject pending pipe/listening promises on disposal, and keep one extension-deactivation cleanup registration.
- Clear server state on child process spawn failures so pending task pipe connections fail fast and future restarts are not blocked.
- Add unit coverage for task pipe connect-failure recovery prompt ownership, restart prompt deduplication, BSP-active extension-host fallback, and child process spawn-error cleanup.

## Recovery flow

```mermaid
stateDiagram-v2
    [*] --> Idle
    Idle --> Starting: start()
    Starting --> BindingLanguageServerPipe: fresh LS pipe
    BindingLanguageServerPipe --> BindingTaskPipe: fresh task pipe
    BindingTaskPipe --> ProcessRunning: spawn Gradle JVM
    ProcessRunning --> Ready: task pipe connected
    ProcessRunning --> PromptGradleRestart: task pipe connect failed and BSP inactive
    ProcessRunning --> PromptExtensionHostRestart: task pipe connect failed and BSP active
    Ready --> AutoRestartPending: unexpected JVM exit and BSP inactive
    AutoRestartPending --> Starting: retry with fresh pipes
    Ready --> PromptGradleRestart: restart budget exhausted and BSP inactive
    Ready --> PromptExtensionHostRestart: unexpected JVM exit and BSP active
    PromptGradleRestart --> Starting: Restart Gradle Server
    PromptExtensionHostRestart --> Idle: Restart Extension Host
```

## Notes

The `java.gradle.buildServer.enabled` change still reloads the window because it writes the JDT LS clean-workspace marker and needs vscode-java/JDT LS to reinitialize BSP state. Gradle-server-affecting settings handled in `Extension.ts` now use JVM-only restart only before BSP importer activation; after BSP importer activation they use extension-host restart for safety.

Medium-term BSP lifecycle work is tracked in #1878. The intended medium-term shape is to keep task + Gradle LS in JVM A and split BSP into a stable singleton JVM B so task transport recovery no longer risks Build Server integration.

The BSP-active fallback in this PR is intentionally conservative and temporary. It may over-classify BSP as active once the JDT LS importer has announced its pipe path, which can disable lightweight JVM-only recovery in Java Gradle workspaces. That tradeoff is acceptable only because this PR is expected to be followed by the JVM A/B split before the next prerelease; #1877 should not be treated as the long-term shipped BSP recovery model. The follow-up JVM A/B PR should remove or redefine this fallback so task/Gradle-LS recovery is no longer gated by importer pipe-path/session state.

## Verification

- `cd extension; npm run compile:test`
- `cd extension; npm run lint:eslint` (0 errors; existing warnings only)
- `cd extension; npm test`