### PR TITLE
fix: task transport reconnect without JVM exit

### DIFF
--- a/extension/src/Extension.ts
+++ b/extension/src/Extension.ts
@@ -248,7 +248,7 @@ export class Extension {
     private async activate(): Promise<void> {
         this.registerGradleTestRunner();
         const activated = !!(await this.rootProjectsStore.getProjectRoots()).length;
-        if (!this.server.isReady()) {
+        if (!this.server.isStarted()) {
             await this.server.start();
         }
         await vscode.commands.executeCommand("setContext", "gradle:activated", activated);

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -56,6 +56,8 @@ export class TaskServerClient implements vscode.Disposable {
     private readonly _onDidConnectFail: vscode.EventEmitter<null> = new vscode.EventEmitter<null>();
     public readonly onDidConnect: vscode.Event<null> = this._onDidConnect.event;
     public readonly onDidConnectFail: vscode.Event<null> = this._onDidConnectFail.event;
+    private disposed = false;
+    private connecting = false;
 
     private readonly connectWaiter = new EventWaiter(this.onDidConnect);
 
@@ -65,10 +67,14 @@ export class TaskServerClient implements vscode.Disposable {
     }
 
     private handleServerStop = (): void => {
+        this.connecting = false;
         this.close();
     };
 
     public handleServerStart = (): Thenable<void> => {
+        if (this.rpcClient) {
+            return Promise.resolve();
+        }
         this.connectWaiter.reset();
         return vscode.window.withProgress(
             {
@@ -94,8 +100,16 @@ export class TaskServerClient implements vscode.Disposable {
     };
 
     private async connectToServer(): Promise<void> {
+        if (this.disposed || this.connecting || this.rpcClient) {
+            return;
+        }
+        this.connecting = true;
         try {
             const connection = await this.server.awaitTaskConnection();
+            if (this.disposed) {
+                connection.dispose();
+                return;
+            }
             this.rpcClient = new GradleJsonRpcClient(connection);
             // The task transport can die between gradle-server process exits
             // (peer reset, crash). Proactively tear down the stale client
@@ -106,12 +120,19 @@ export class TaskServerClient implements vscode.Disposable {
                 if (err) {
                     logger.error(`Gradle client connection closed unexpectedly: ${errorDetails(err)}`);
                 }
+                this.server.handleTaskConnectionClosed();
                 this.close();
+                if (!this.disposed && this.server.isStarted()) {
+                    this.connectWaiter.reset();
+                    void this.connectToServer();
+                }
             });
             logger.info("Gradle client connected to server");
             this._onDidConnect.fire(null);
         } catch (err) {
             await this.handleConnectError(err instanceof Error ? err : new Error(String(err)));
+        } finally {
+            this.connecting = false;
         }
     }
 
@@ -429,7 +450,7 @@ export class TaskServerClient implements vscode.Disposable {
         if (this.server.isAutoRestartPending()) {
             return;
         }
-        if (this.server.isReady()) {
+        if (this.server.isStarted()) {
             await this.showRestartMessage();
         } else {
             await this.server.showRestartMessage();
@@ -456,6 +477,7 @@ export class TaskServerClient implements vscode.Disposable {
     }
 
     public dispose(): void {
+        this.disposed = true;
         this.close();
         this._onDidConnect.dispose();
         this._onDidConnectFail.dispose();

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -70,6 +70,7 @@ export class TaskServerClient implements vscode.Disposable {
     private handleServerStop = (): void => {
         this.connecting = false;
         this.clearReconnectTimer();
+        this.connectWaiter.reset();
         this.close();
     };
 

--- a/extension/src/client/TaskServerClient.ts
+++ b/extension/src/client/TaskServerClient.ts
@@ -58,6 +58,7 @@ export class TaskServerClient implements vscode.Disposable {
     public readonly onDidConnectFail: vscode.Event<null> = this._onDidConnectFail.event;
     private disposed = false;
     private connecting = false;
+    private reconnectTimer: NodeJS.Timeout | undefined;
 
     private readonly connectWaiter = new EventWaiter(this.onDidConnect);
 
@@ -68,6 +69,7 @@ export class TaskServerClient implements vscode.Disposable {
 
     private handleServerStop = (): void => {
         this.connecting = false;
+        this.clearReconnectTimer();
         this.close();
     };
 
@@ -122,10 +124,7 @@ export class TaskServerClient implements vscode.Disposable {
                 }
                 this.server.handleTaskConnectionClosed();
                 this.close();
-                if (!this.disposed && this.server.isStarted()) {
-                    this.connectWaiter.reset();
-                    void this.connectToServer();
-                }
+                this.scheduleReconnect();
             });
             logger.info("Gradle client connected to server");
             this._onDidConnect.fire(null);
@@ -457,6 +456,25 @@ export class TaskServerClient implements vscode.Disposable {
         }
     };
 
+    private scheduleReconnect(): void {
+        if (this.disposed || !this.server.isStarted() || this.reconnectTimer) {
+            return;
+        }
+        this.connectWaiter.reset();
+        this.reconnectTimer = setTimeout(() => {
+            this.reconnectTimer = undefined;
+            void this.connectToServer();
+        }, 0);
+    }
+
+    private clearReconnectTimer(): void {
+        if (!this.reconnectTimer) {
+            return;
+        }
+        clearTimeout(this.reconnectTimer);
+        this.reconnectTimer = undefined;
+    }
+
     public async showRestartMessage(): Promise<void> {
         const OPT_RESTART = "Re-connect Client";
         const input = await vscode.window.showErrorMessage(
@@ -478,6 +496,7 @@ export class TaskServerClient implements vscode.Disposable {
 
     public dispose(): void {
         this.disposed = true;
+        this.clearReconnectTimer();
         this.close();
         this._onDidConnect.dispose();
         this._onDidConnectFail.dispose();

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -19,12 +19,9 @@ const STDERR_TAIL_LINES = 40;
 const STDERR_TAIL_PREVIEW_LINES = 3;
 const VIEW_LOG_ACTION = "View Log";
 const RELOAD_HINT = "Run 'Developer: Reload Window' if Gradle stops working.";
-// Bounded auto-restart for unexpected gradle-server exits (e.g. a task
-// transport break that kills the JVM). Relaunch transparently instead of
-// immediately asking the user to reload, and only fall back to the warning
-// once the retry budget is exhausted. The budget is per session (not reset on
-// recovery) to keep this conservative; a future refinement could reset it on a
-// successful reconnect.
+// Bounded auto-restart for unexpected gradle-server process exits. Task
+// transport disconnects are handled by the in-JVM reconnect loop and should not
+// normally reach this path.
 const MAX_AUTO_RESTARTS = 3;
 const AUTO_RESTART_DELAY_MS = 1_000;
 
@@ -118,6 +115,7 @@ export class GradleServer {
         const taskServerPipePath = this.pipeListener.pipePath;
         const args = [
             quoteArg(`--pipe=${taskServerPipePath}`),
+            quoteArg(`--parentPid=${process.pid}`),
             quoteArg(`--startBuildServer=${startBuildServer}`),
             quoteArg(`--languageServerPipePath=${this.languageServerPipePath}`),
         ];
@@ -159,6 +157,7 @@ export class GradleServer {
                 this._onDidStop.fire(null);
                 this.ready = false;
                 this.process?.removeAllListeners();
+                this.process = undefined;
                 this.pipeListener?.dispose();
                 this.pipeListener = undefined;
                 this.bspProxy.closeConnection();
@@ -194,6 +193,14 @@ export class GradleServer {
 
     public isReady(): boolean {
         return this.ready;
+    }
+
+    public isStarted(): boolean {
+        return this.process !== undefined;
+    }
+
+    public handleTaskConnectionClosed(): void {
+        this.ready = false;
     }
 
     public async showRestartMessage(): Promise<void> {
@@ -331,7 +338,6 @@ export class GradleServer {
     }
 
     private fireOnStart(): void {
-        this.ready = true;
         this._onDidStart.fire(null);
     }
 
@@ -355,6 +361,9 @@ export class GradleServer {
         if (!this.pipeListener) {
             return Promise.reject(new Error("Gradle task server pipe listener is not initialized."));
         }
-        return this.pipeListener.connection;
+        return this.pipeListener.waitForConnection().then((connection) => {
+            this.ready = true;
+            return connection;
+        });
     }
 }

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -139,7 +139,10 @@ export class GradleServer {
         this.process.stderr.on("data", this.logOutput);
         this.process.stderr.on("data", this.captureStderrTail);
         this.process
-            .on("error", (err: Error) => this.logger.error(err.message))
+            .on("error", (err: Error) => {
+                this.logger.error(err.message);
+                this.cleanupProcessState();
+            })
             .on("exit", async (code, signal) => {
                 this.flushPendingStderrLine();
                 const durationMs = Date.now() - this.processStartedAt;
@@ -154,13 +157,7 @@ export class GradleServer {
                         this.logger.warn(`  ${line}`);
                     }
                 }
-                this._onDidStop.fire(null);
-                this.ready = false;
-                this.process?.removeAllListeners();
-                this.process = undefined;
-                this.pipeListener?.dispose();
-                this.pipeListener = undefined;
-                this.bspProxy.closeConnection();
+                this.cleanupProcessState();
                 if (this.restarting) {
                     this.restarting = false;
                     await this.start();
@@ -269,6 +266,16 @@ export class GradleServer {
             this.logger.info(str);
         }
     };
+
+    private cleanupProcessState(): void {
+        this._onDidStop.fire(null);
+        this.ready = false;
+        this.process?.removeAllListeners();
+        this.process = undefined;
+        this.pipeListener?.dispose();
+        this.pipeListener = undefined;
+        this.bspProxy.closeConnection();
+    }
 
     private async killProcess(): Promise<void> {
         if (this.process) {

--- a/extension/src/test/unit/transport/pipeServer.test.ts
+++ b/extension/src/test/unit/transport/pipeServer.test.ts
@@ -115,6 +115,22 @@ describe(suiteName("createPipeListener"), () => {
         });
     });
 
+    it("uses a generic dispose reason after a task connection was established", async () => {
+        listener = await createPipeListener({ connectTimeoutMs: 2_000 });
+        await connectClient(listener.pipePath);
+        const connection = await listener.connection;
+        connection.dispose();
+
+        const pending = listener.connection;
+        listener.dispose();
+        listener = undefined;
+
+        await assert.rejects(pending, (err: Error) => {
+            assert.strictEqual(err.message, "Task pipe listener disposed");
+            return true;
+        });
+    });
+
     it("forwards vscode-jsonrpc protocol diagnostics to the supplied Logger", async () => {
         const errors: string[] = [];
         const spy: JsonRpcLogger = {

--- a/extension/src/test/unit/transport/pipeServer.test.ts
+++ b/extension/src/test/unit/transport/pipeServer.test.ts
@@ -4,7 +4,7 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import * as net from "net";
-import type { Logger as JsonRpcLogger } from "vscode-jsonrpc";
+import type { Logger as JsonRpcLogger, MessageConnection } from "vscode-jsonrpc";
 import { createPipeListener, PipeListener } from "../../../transport/jsonrpc";
 
 function suiteName(name: string): string {
@@ -77,6 +77,29 @@ describe(suiteName("createPipeListener"), () => {
         assert.ok(secondConnection, "expected the second task connection");
         assert.notStrictEqual(secondConnection, firstConnection);
         secondConnection.dispose();
+    });
+
+    it("returns the latest queued connection when multiple sockets arrive before a waiter", async () => {
+        listener = await createPipeListener({ connectTimeoutMs: 2_000 });
+        const seenConnections: MessageConnection[] = [];
+        const observedConnections = new Promise<void>((resolve) => {
+            listener!.onConnection((connection) => {
+                seenConnections.push(connection);
+                if (seenConnections.length === 2) {
+                    resolve();
+                }
+            });
+        });
+
+        await connectClient(listener.pipePath);
+        await connectClient(listener.pipePath);
+        await observedConnections;
+
+        assert.strictEqual(seenConnections.length, 2, "expected both inbound connections to be observed");
+        const connection = await listener.connection;
+        assert.strictEqual(connection, seenConnections[1], "expected the latest queued connection");
+
+        connection.dispose();
     });
 
     it("rejects the connection promise when dispose() is called before any JVM connects", async () => {

--- a/extension/src/test/unit/transport/pipeServer.test.ts
+++ b/extension/src/test/unit/transport/pipeServer.test.ts
@@ -18,13 +18,15 @@ function frame(body: string): string {
 
 describe(suiteName("createPipeListener"), () => {
     let listener: PipeListener | undefined;
-    let clientSock: net.Socket | undefined;
+    let clientSocks: net.Socket[] = [];
 
     afterEach(() => {
-        if (clientSock && !clientSock.destroyed) {
-            clientSock.destroy();
+        for (const clientSock of clientSocks) {
+            if (!clientSock.destroyed) {
+                clientSock.destroy();
+            }
         }
-        clientSock = undefined;
+        clientSocks = [];
         listener?.dispose();
         listener = undefined;
     });
@@ -33,11 +35,7 @@ describe(suiteName("createPipeListener"), () => {
         listener = await createPipeListener({ connectTimeoutMs: 2_000 });
         assert.ok(listener.pipePath, "expected a pipe path");
 
-        clientSock = net.connect(listener.pipePath);
-        await new Promise<void>((resolve, reject) => {
-            clientSock!.once("connect", () => resolve());
-            clientSock!.once("error", reject);
-        });
+        await connectClient(listener.pipePath);
 
         const connection = await listener.connection;
         assert.ok(connection, "expected a MessageConnection to resolve from the listener");
@@ -45,22 +43,41 @@ describe(suiteName("createPipeListener"), () => {
     });
 
     if (process.platform !== "win32") {
-        it("unlinks the Unix socket path after accepting the first connection", async () => {
+        it("keeps the Unix socket path available for reconnects until dispose", async () => {
             listener = await createPipeListener({ connectTimeoutMs: 2_000 });
-            assert.ok(fs.existsSync(listener.pipePath), "expected Unix socket path to exist while listening");
+            const pipePath = listener.pipePath;
+            assert.ok(fs.existsSync(pipePath), "expected Unix socket path to exist while listening");
 
-            clientSock = net.connect(listener.pipePath);
-            await new Promise<void>((resolve, reject) => {
-                clientSock!.once("connect", () => resolve());
-                clientSock!.once("error", reject);
-            });
+            await connectClient(pipePath);
 
             const connection = await listener.connection;
             assert.ok(connection, "expected a MessageConnection to resolve from the listener");
-            assert.strictEqual(fs.existsSync(listener.pipePath), false, "expected Unix socket path to be unlinked");
+            assert.strictEqual(fs.existsSync(pipePath), true, "expected Unix socket path to stay available");
             connection.dispose();
+
+            listener.dispose();
+            listener = undefined;
+            assert.strictEqual(fs.existsSync(pipePath), false, "expected Unix socket path to be unlinked on dispose");
         });
     }
+
+    it("accepts a new task connection after the previous socket closes", async () => {
+        listener = await createPipeListener({ connectTimeoutMs: 2_000 });
+
+        const firstSocket = await connectClient(listener.pipePath);
+        const firstConnection = await listener.connection;
+        assert.ok(firstConnection, "expected the first task connection");
+
+        firstSocket.destroy();
+        firstConnection.dispose();
+
+        const secondSocket = await connectClient(listener.pipePath);
+        const secondConnection = await listener.connection;
+        assert.ok(secondSocket, "expected the second socket to connect to the same pipe path");
+        assert.ok(secondConnection, "expected the second task connection");
+        assert.notStrictEqual(secondConnection, firstConnection);
+        secondConnection.dispose();
+    });
 
     it("rejects the connection promise when dispose() is called before any JVM connects", async () => {
         listener = await createPipeListener({ connectTimeoutMs: 10_000 });
@@ -92,11 +109,7 @@ describe(suiteName("createPipeListener"), () => {
 
         listener = await createPipeListener({ logger: spy, connectTimeoutMs: 2_000 });
 
-        clientSock = net.connect(listener.pipePath);
-        await new Promise<void>((resolve, reject) => {
-            clientSock!.once("connect", () => resolve());
-            clientSock!.once("error", reject);
-        });
+        const clientSock = await connectClient(listener.pipePath);
 
         const connection = await listener.connection;
         connection.listen();
@@ -113,4 +126,14 @@ describe(suiteName("createPipeListener"), () => {
 
         connection.dispose();
     });
+
+    async function connectClient(pipePath: string): Promise<net.Socket> {
+        const socket = net.connect(pipePath);
+        clientSocks.push(socket);
+        await new Promise<void>((resolve, reject) => {
+            socket.once("connect", () => resolve());
+            socket.once("error", reject);
+        });
+        return socket;
+    }
 });

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -80,6 +80,7 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
     let activeSocket: net.Socket | undefined;
     let disposed = false;
     let disposedReason: Error | undefined;
+    let hasAcceptedConnection = false;
     const pendingConnections: MessageConnection[] = [];
     const pendingWaiters: Array<{
         resolve: (connection: MessageConnection) => void;
@@ -122,6 +123,7 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
             socket.destroy();
             return;
         }
+        hasAcceptedConnection = true;
 
         if (activeSocket && !activeSocket.destroyed) {
             activeSocket.destroy();
@@ -168,7 +170,13 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
         onConnection: onConnectionEmitter.event,
         waitForConnection,
         dispose: () => {
-            teardown(new Error("Task pipe listener disposed before gradle-server connected"));
+            teardown(
+                new Error(
+                    hasAcceptedConnection
+                        ? "Task pipe listener disposed"
+                        : "Task pipe listener disposed before gradle-server connected"
+                )
+            );
         },
     };
 

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -79,6 +79,7 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
 
     let activeSocket: net.Socket | undefined;
     let disposed = false;
+    let disposedReason: Error | undefined;
     const pendingConnections: MessageConnection[] = [];
     const pendingWaiters: Array<{
         resolve: (connection: MessageConnection) => void;
@@ -89,7 +90,9 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
 
     const waitForConnection = (connectTimeoutMs = timeoutMs): Promise<MessageConnection> => {
         if (disposed) {
-            return Promise.reject(new Error("Task pipe listener disposed before gradle-server connected"));
+            return Promise.reject(
+                disposedReason ?? new Error("Task pipe listener disposed before gradle-server connected")
+            );
         }
         const queuedConnection = pendingConnections.shift();
         if (queuedConnection) {
@@ -154,7 +157,7 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
 
     server.on("error", (err) => {
         reportPipeFailure("taskPipeSetupFailure", err.message);
-        rejectPendingWaiters(err);
+        teardown(err);
     });
 
     return {
@@ -165,21 +168,26 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
         onConnection: onConnectionEmitter.event,
         waitForConnection,
         dispose: () => {
-            if (disposed) {
-                return;
-            }
-            disposed = true;
-            rejectPendingWaiters(new Error("Task pipe listener disposed before gradle-server connected"));
-            for (const connection of pendingConnections.splice(0)) {
-                connection.dispose();
-            }
-            closeServer(server, pipePath);
-            if (activeSocket && !activeSocket.destroyed) {
-                activeSocket.destroy();
-            }
-            onConnectionEmitter.dispose();
+            teardown(new Error("Task pipe listener disposed before gradle-server connected"));
         },
     };
+
+    function teardown(err: Error): void {
+        if (disposed) {
+            return;
+        }
+        disposed = true;
+        disposedReason = err;
+        rejectPendingWaiters(err);
+        for (const connection of pendingConnections.splice(0)) {
+            connection.dispose();
+        }
+        closeServer(server, pipePath);
+        if (activeSocket && !activeSocket.destroyed) {
+            activeSocket.destroy();
+        }
+        onConnectionEmitter.dispose();
+    }
 
     function rejectPendingWaiters(err: Error): void {
         for (const waiter of pendingWaiters.splice(0)) {

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -25,9 +25,19 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
 export interface PipeListener {
     /** Pipe path the JVM should be told to connect back to. */
     readonly pipePath: string;
-    /** Resolves with the next `MessageConnection` once the JVM connects; rejects on timeout or dispose. */
+    /**
+     * Convenience accessor that waits for the next `MessageConnection` using the
+     * default timeout. Each read registers a fresh waiter, so production code
+     * should prefer {@link waitForConnection}; this is kept for tests and simple
+     * call sites.
+     */
     readonly connection: Promise<MessageConnection>;
-    /** Fires every time the JVM establishes a new task transport session. */
+    /**
+     * Fires every time the JVM establishes a new task transport session.
+     * Currently consumed only by tests; exposed for future subscribers that need
+     * to observe every session without consuming the {@link waitForConnection}
+     * queue.
+     */
     readonly onConnection: Event<MessageConnection>;
     /** Wait for the next task transport session. */
     waitForConnection(connectTimeoutMs?: number): Promise<MessageConnection>;

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -4,6 +4,7 @@
 import * as fs from "fs";
 import * as net from "net";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
+import { Emitter, Event } from "vscode-jsonrpc";
 import { createMessageConnection, MessageConnection } from "vscode-jsonrpc/node";
 import { SocketMessageReader, SocketMessageWriter } from "vscode-jsonrpc/node";
 import type { Logger as JsonRpcLogger } from "vscode-jsonrpc";
@@ -15,7 +16,8 @@ import { getRandomPipeName } from "../../util/generateRandomPipeName";
  * The extension creates the pipe first, then spawns the `gradle-server` JVM with
  * `--pipe=<path>`. The JVM connects back as a pipe client (`TaskPipeServer` on
  * the Java side) and the resulting stream is wrapped in an LSP4J-compatible
- * `MessageConnection`.
+ * `MessageConnection`. The listener stays bound for the JVM lifetime so the
+ * task channel can reconnect without restarting the JVM.
  */
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
@@ -23,8 +25,12 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
 export interface PipeListener {
     /** Pipe path the JVM should be told to connect back to. */
     readonly pipePath: string;
-    /** Resolves with the `MessageConnection` once the JVM connects; rejects on timeout or socket error. */
+    /** Resolves with the next `MessageConnection` once the JVM connects; rejects on timeout or dispose. */
     readonly connection: Promise<MessageConnection>;
+    /** Fires every time the JVM establishes a new task transport session. */
+    readonly onConnection: Event<MessageConnection>;
+    /** Wait for the next task transport session. */
+    waitForConnection(connectTimeoutMs?: number): Promise<MessageConnection>;
     /** Tear down the listener and (if connected) the inbound socket. Safe to call repeatedly. */
     dispose(): void;
 }
@@ -61,85 +67,118 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
         });
     });
 
-    let acceptedSocket: net.Socket | undefined;
-    let timeoutHandle: NodeJS.Timeout | undefined;
+    let activeSocket: net.Socket | undefined;
     let disposed = false;
-    let rejectConnection: ((reason: Error) => void) | undefined;
+    const pendingConnections: MessageConnection[] = [];
+    const pendingWaiters: Array<{
+        resolve: (connection: MessageConnection) => void;
+        reject: (reason: Error) => void;
+        timeoutHandle?: NodeJS.Timeout;
+    }> = [];
+    const onConnectionEmitter = new Emitter<MessageConnection>();
 
-    const connection = new Promise<MessageConnection>((resolve, reject) => {
-        rejectConnection = reject;
-        timeoutHandle = setTimeout(() => {
-            const err = new Error(`Timed out after ${timeoutMs}ms waiting for gradle-server to connect to task pipe`);
-            rejectConnection = undefined;
-            reportPipeFailure("taskPipeConnectTimeout", err.message);
-            reject(err);
-            closeServer(server, pipePath);
-        }, timeoutMs);
-
-        server.on("connection", (socket) => {
-            if (acceptedSocket) {
-                // Already paired with a JVM; reject extra connections.
-                socket.destroy();
-                return;
+    const waitForConnection = (connectTimeoutMs = timeoutMs): Promise<MessageConnection> => {
+        if (disposed) {
+            return Promise.reject(new Error("Task pipe listener disposed before gradle-server connected"));
+        }
+        const queuedConnection = pendingConnections.shift();
+        if (queuedConnection) {
+            return Promise.resolve(queuedConnection);
+        }
+        return new Promise<MessageConnection>((resolve, reject) => {
+            const waiter = { resolve, reject, timeoutHandle: undefined as NodeJS.Timeout | undefined };
+            if (connectTimeoutMs > 0) {
+                waiter.timeoutHandle = setTimeout(() => {
+                    const waiterIndex = pendingWaiters.indexOf(waiter);
+                    if (waiterIndex >= 0) {
+                        pendingWaiters.splice(waiterIndex, 1);
+                    }
+                    const err = new Error(
+                        `Timed out after ${connectTimeoutMs}ms waiting for gradle-server to connect to task pipe`
+                    );
+                    reportPipeFailure("taskPipeConnectTimeout", err.message);
+                    reject(err);
+                }, connectTimeoutMs);
             }
-            acceptedSocket = socket;
-            if (timeoutHandle) {
-                clearTimeout(timeoutHandle);
-                timeoutHandle = undefined;
+            pendingWaiters.push(waiter);
+        });
+    };
+
+    server.on("connection", (socket) => {
+        if (disposed) {
+            socket.destroy();
+            return;
+        }
+
+        if (activeSocket && !activeSocket.destroyed) {
+            activeSocket.destroy();
+        }
+        activeSocket = socket;
+
+        const reader = new SocketMessageReader(socket);
+        const writer = new SocketMessageWriter(socket);
+
+        socket.on("error", (socketErr) => {
+            options.logger?.error(`gradle-server task pipe error: ${socketErr.message}`);
+            reportPipeFailure("taskPipeConnectionClosed", socketErr.message);
+        });
+        socket.on("close", (hadError) => {
+            if (activeSocket === socket) {
+                activeSocket = undefined;
             }
-            rejectConnection = undefined;
-            // Stop accepting further connections; the listener has served its purpose.
-            closeServer(server, pipePath);
-
-            const reader = new SocketMessageReader(socket);
-            const writer = new SocketMessageWriter(socket);
-
-            socket.on("error", (socketErr) => {
-                options.logger?.error(`gradle-server task pipe error: ${socketErr.message}`);
-                reportPipeFailure("taskPipeConnectionClosed", socketErr.message);
-            });
-            socket.on("close", (hadError) => {
-                options.logger?.info(`gradle-server task pipe closed${hadError ? " after error" : ""}`);
-            });
-
-            const conn = createMessageConnection(reader, writer, options.logger);
-            resolve(conn);
+            options.logger?.info(`gradle-server task pipe closed${hadError ? " after error" : ""}`);
         });
 
-        server.on("error", (err) => {
-            if (timeoutHandle) {
-                clearTimeout(timeoutHandle);
-                timeoutHandle = undefined;
+        const conn = createMessageConnection(reader, writer, options.logger);
+        const waiter = pendingWaiters.shift();
+        if (waiter) {
+            if (waiter.timeoutHandle) {
+                clearTimeout(waiter.timeoutHandle);
             }
-            rejectConnection = undefined;
-            reportPipeFailure("taskPipeSetupFailure", err.message);
-            reject(err);
-        });
+            waiter.resolve(conn);
+        } else {
+            pendingConnections.push(conn);
+        }
+        onConnectionEmitter.fire(conn);
+    });
+
+    server.on("error", (err) => {
+        reportPipeFailure("taskPipeSetupFailure", err.message);
+        rejectPendingWaiters(err);
     });
 
     return {
         pipePath,
-        connection,
+        get connection() {
+            return waitForConnection(timeoutMs);
+        },
+        onConnection: onConnectionEmitter.event,
+        waitForConnection,
         dispose: () => {
             if (disposed) {
                 return;
             }
             disposed = true;
-            if (timeoutHandle) {
-                clearTimeout(timeoutHandle);
-                timeoutHandle = undefined;
-            }
-            if (rejectConnection) {
-                const reject = rejectConnection;
-                rejectConnection = undefined;
-                reject(new Error("Task pipe listener disposed before gradle-server connected"));
+            rejectPendingWaiters(new Error("Task pipe listener disposed before gradle-server connected"));
+            for (const connection of pendingConnections.splice(0)) {
+                connection.dispose();
             }
             closeServer(server, pipePath);
-            if (acceptedSocket && !acceptedSocket.destroyed) {
-                acceptedSocket.destroy();
+            if (activeSocket && !activeSocket.destroyed) {
+                activeSocket.destroy();
             }
+            onConnectionEmitter.dispose();
         },
     };
+
+    function rejectPendingWaiters(err: Error): void {
+        for (const waiter of pendingWaiters.splice(0)) {
+            if (waiter.timeoutHandle) {
+                clearTimeout(waiter.timeoutHandle);
+            }
+            waiter.reject(err);
+        }
+    }
 }
 
 function closeServer(server: net.Server, pipePath: string): void {

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -137,7 +137,7 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
             }
             waiter.resolve(conn);
         } else {
-            pendingConnections.push(conn);
+            replacePendingConnection(conn);
         }
         onConnectionEmitter.fire(conn);
     });
@@ -178,6 +178,13 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
             }
             waiter.reject(err);
         }
+    }
+
+    function replacePendingConnection(connection: MessageConnection): void {
+        for (const pendingConnection of pendingConnections.splice(0)) {
+            pendingConnection.dispose();
+        }
+        pendingConnections.push(connection);
     }
 }
 

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
@@ -135,6 +135,10 @@ public class GradleServer {
 			logger.warn("Ignoring invalid parent process id: {}", parentPid);
 			return;
 		}
+		if (pid <= 0) {
+			logger.warn("Ignoring invalid parent process id: {}", parentPid);
+			return;
+		}
 		ProcessHandle parentProcess = ProcessHandle.of(pid).orElse(null);
 		if (parentProcess == null) {
 			logger.warn("Parent process {} was not found; exiting Gradle Server JVM", pid);

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
@@ -131,7 +131,8 @@ public class GradleServer {
 		}
 		ProcessHandle parentProcess = ProcessHandle.of(pid).orElse(null);
 		if (parentProcess == null) {
-			logger.warn("Parent process {} was not found; Gradle Server orphan watcher is disabled", pid);
+			logger.warn("Parent process {} was not found; exiting Gradle Server JVM", pid);
+			System.exit(0);
 			return;
 		}
 		Thread watcherThread = new Thread(() -> {

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
@@ -79,7 +79,7 @@ public class GradleServer {
 				}
 				if (!shutdownRequested.get()) {
 					logger.info("Reconnecting Gradle Server JSON-RPC task transport in {} ms", reconnectDelayMs);
-					if (!sleepBeforeReconnect(reconnectDelayMs)) {
+					if (!sleepQuietly(reconnectDelayMs)) {
 						break;
 					}
 					reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_TASK_RECONNECT_DELAY_MS);
@@ -100,7 +100,9 @@ public class GradleServer {
 		}, "gradle-jsonrpc-shutdown"));
 	}
 
-	private static boolean sleepBeforeReconnect(long delayMs) {
+	// Sleep for the given duration, returning false if the thread was
+	// interrupted (e.g. JVM shutdown) so callers can break out of their loop.
+	private static boolean sleepQuietly(long delayMs) {
 		try {
 			Thread.sleep(delayMs);
 			return true;
@@ -110,6 +112,10 @@ public class GradleServer {
 		}
 	}
 
+	// Cancel any in-flight Gradle builds when the task transport tears down.
+	// A build started over the now-dead task channel can no longer stream
+	// results back to the client, so we proactively cancel it instead of
+	// leaking a Gradle worker that nobody is listening to.
 	private static void cancelActiveBuilds() {
 		try {
 			GradleBuildCancellation.cancelBuilds();
@@ -136,8 +142,13 @@ public class GradleServer {
 			return;
 		}
 		Thread watcherThread = new Thread(() -> {
+			// Poll the parent's liveness rather than rely on the task channel: this
+			// keeps orphan cleanup working even while the task transport is healthy.
+			// Note: ProcessHandle tracks the original process, but on PID reuse a
+			// recycled id could read as alive; the interval is short and the worst
+			// case is a slightly delayed exit, so a simple poll is sufficient here.
 			while (parentProcess.isAlive()) {
-				if (!sleepBeforeReconnect(PARENT_PROCESS_CHECK_INTERVAL_MS)) {
+				if (!sleepQuietly(PARENT_PROCESS_CHECK_INTERVAL_MS)) {
 					return;
 				}
 			}

--- a/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
+++ b/gradle-server/src/main/java/com/github/badsyntax/gradle/GradleServer.java
@@ -8,18 +8,25 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class GradleServer {
 	private static final Logger logger = LoggerFactory.getLogger(GradleServer.class.getName());
+	private static final long INITIAL_TASK_RECONNECT_DELAY_MS = 500L;
+	private static final long MAX_TASK_RECONNECT_DELAY_MS = 5_000L;
+	private static final long PARENT_PROCESS_CHECK_INTERVAL_MS = 5_000L;
 
 	private GradleServer() {
 	}
 
 	public static void main(String[] args) throws Exception {
 		Map<String, String> params = Utils.parseArgs(args);
+
+		startParentProcessWatcher(params.get("parentPid"));
 
 		String taskServerPipeName = Utils.validateRequiredParam(params, "pipe");
 		startTaskServerThread(taskServerPipeName);
@@ -38,29 +45,106 @@ public class GradleServer {
 	}
 
 	private static void startTaskServerThread(String pipeName) {
-		ExecutorService workerExecutor = Executors.newCachedThreadPool(workerThreadFactory());
+		AtomicBoolean shutdownRequested = new AtomicBoolean(false);
+		AtomicReference<ExecutorService> activeWorkerExecutor = new AtomicReference<>();
 		Thread serverThread = new Thread(() -> {
-			int exitCode = 0;
-			try {
-				Future<Void> listening = TaskPipeServer.connectAndStart(pipeName, workerExecutor);
-				logger.info("Gradle Server JSON-RPC transport connected on task pipe");
-				listening.get();
-				logger.info("Gradle Server JSON-RPC transport closed");
-			} catch (Exception e) {
-				exitCode = 1;
-				logger.error("Gradle Server JSON-RPC transport failed", e);
-			} finally {
-				workerExecutor.shutdownNow();
+			long reconnectDelayMs = INITIAL_TASK_RECONNECT_DELAY_MS;
+			while (!shutdownRequested.get()) {
+				ExecutorService workerExecutor = Executors.newCachedThreadPool(workerThreadFactory());
+				activeWorkerExecutor.set(workerExecutor);
+				boolean connected = false;
+				try {
+					Future<Void> listening = TaskPipeServer.connectAndStart(pipeName, workerExecutor);
+					connected = true;
+					reconnectDelayMs = INITIAL_TASK_RECONNECT_DELAY_MS;
+					logger.info("Gradle Server JSON-RPC transport connected on task pipe");
+					listening.get();
+					logger.info("Gradle Server JSON-RPC transport closed");
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					break;
+				} catch (Exception e) {
+					if (shutdownRequested.get()) {
+						break;
+					}
+					if (connected) {
+						logger.error("Gradle Server JSON-RPC transport session failed; reconnecting", e);
+					} else {
+						logger.error("Gradle Server JSON-RPC transport connect failed; retrying", e);
+					}
+				} finally {
+					cancelActiveBuilds();
+					workerExecutor.shutdownNow();
+					activeWorkerExecutor.compareAndSet(workerExecutor, null);
+				}
+				if (!shutdownRequested.get()) {
+					logger.info("Reconnecting Gradle Server JSON-RPC task transport in {} ms", reconnectDelayMs);
+					if (!sleepBeforeReconnect(reconnectDelayMs)) {
+						break;
+					}
+					reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_TASK_RECONNECT_DELAY_MS);
+				}
 			}
-			logger.info("Exiting Gradle Server JVM because JSON-RPC task transport ended");
-			System.exit(exitCode);
+			logger.info("Gradle Server JSON-RPC task transport loop stopped");
 		}, "gradle-jsonrpc-server");
 		serverThread.start();
 
 		Runtime.getRuntime().addShutdownHook(new Thread(() -> {
 			logger.info("Shutting down Gradle Server JSON-RPC transport since JVM is shutting down");
-			workerExecutor.shutdownNow();
+			shutdownRequested.set(true);
+			cancelActiveBuilds();
+			ExecutorService workerExecutor = activeWorkerExecutor.get();
+			if (workerExecutor != null) {
+				workerExecutor.shutdownNow();
+			}
 		}, "gradle-jsonrpc-shutdown"));
+	}
+
+	private static boolean sleepBeforeReconnect(long delayMs) {
+		try {
+			Thread.sleep(delayMs);
+			return true;
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			return false;
+		}
+	}
+
+	private static void cancelActiveBuilds() {
+		try {
+			GradleBuildCancellation.cancelBuilds();
+		} catch (Exception e) {
+			logger.warn("Failed to cancel active Gradle builds while task transport is closing", e);
+		}
+	}
+
+	private static void startParentProcessWatcher(String parentPid) {
+		if (Strings.isNullOrEmpty(parentPid)) {
+			return;
+		}
+		long pid;
+		try {
+			pid = Long.parseLong(parentPid);
+		} catch (NumberFormatException e) {
+			logger.warn("Ignoring invalid parent process id: {}", parentPid);
+			return;
+		}
+		ProcessHandle parentProcess = ProcessHandle.of(pid).orElse(null);
+		if (parentProcess == null) {
+			logger.warn("Parent process {} was not found; Gradle Server orphan watcher is disabled", pid);
+			return;
+		}
+		Thread watcherThread = new Thread(() -> {
+			while (parentProcess.isAlive()) {
+				if (!sleepBeforeReconnect(PARENT_PROCESS_CHECK_INTERVAL_MS)) {
+					return;
+				}
+			}
+			logger.info("Parent process {} is no longer alive; exiting Gradle Server JVM", pid);
+			System.exit(0);
+		}, "gradle-parent-process-watcher");
+		watcherThread.setDaemon(true);
+		watcherThread.start();
 	}
 
 	private static void startBuildServerThread(String pipeName, String directory) {

--- a/gradle-server/src/test/java/com/github/badsyntax/gradle/transport/jsonrpc/TaskPipeServerTest.java
+++ b/gradle-server/src/test/java/com/github/badsyntax/gradle/transport/jsonrpc/TaskPipeServerTest.java
@@ -5,6 +5,7 @@ package com.github.badsyntax.gradle.transport.jsonrpc;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 
 import com.github.badsyntax.gradle.CancelBuildsReply;
@@ -16,10 +17,12 @@ import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.junit.After;
 import org.junit.Before;
@@ -99,6 +102,56 @@ public class TaskPipeServerTest {
 
 		CancelBuildsReply reply = CancelBuildsReply.parseFrom(JsonRpcCodec.decode(response.getReply()));
 		assertEquals("Cancel builds requested", reply.getMessage());
+	}
+
+	@Test
+	public void connectAndStart_reconnectsToSameUnixDomainSocket_afterTransportDisconnect() throws Exception {
+		Future<SocketChannel> firstAccepted = acceptExecutor.submit(() -> serverSocket.accept());
+		taskListening = TaskPipeServer.connectAndStart(socketPath.toString(), taskExecutor);
+		acceptedChannel = firstAccepted.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+		Launcher<GradleService> firstClientLauncher = createClientLauncher(acceptedChannel);
+		clientListening = firstClientLauncher.startListening();
+		assertCancelBuilds(firstClientLauncher);
+
+		acceptedChannel.close();
+		awaitTransportClosed(taskListening);
+		clientListening.cancel(true);
+		taskExecutor.shutdownNow();
+		taskExecutor = Executors.newCachedThreadPool();
+
+		Future<SocketChannel> secondAccepted = acceptExecutor.submit(() -> serverSocket.accept());
+		taskListening = TaskPipeServer.connectAndStart(socketPath.toString(), taskExecutor);
+		acceptedChannel = secondAccepted.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+		Launcher<GradleService> secondClientLauncher = createClientLauncher(acceptedChannel);
+		clientListening = secondClientLauncher.startListening();
+		assertCancelBuilds(secondClientLauncher);
+	}
+
+	private Launcher<GradleService> createClientLauncher(SocketChannel channel) {
+		return new Launcher.Builder<GradleService>().setLocalService(new NoopGradleClient())
+				.setRemoteInterface(GradleService.class).setInput(Channels.newInputStream(channel))
+				.setOutput(Channels.newOutputStream(channel)).setExecutorService(clientExecutor).create();
+	}
+
+	private void assertCancelBuilds(Launcher<GradleService> clientLauncher) throws Exception {
+		GradleResponse response = clientLauncher.getRemoteProxy().cancelBuilds(new GradleRequestParams(null, null))
+				.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+		assertNotNull(response);
+
+		CancelBuildsReply reply = CancelBuildsReply.parseFrom(JsonRpcCodec.decode(response.getReply()));
+		assertEquals("Cancel builds requested", reply.getMessage());
+	}
+
+	private void awaitTransportClosed(Future<Void> listening) throws Exception {
+		try {
+			listening.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+		} catch (ExecutionException expected) {
+			return;
+		} catch (TimeoutException e) {
+			fail("Expected task transport session to close after disconnect");
+		}
 	}
 
 	private static boolean isWindows() {


### PR DESCRIPTION
## Summary
- keep the Gradle task pipe listener bound for the gradle-server JVM lifetime so the task JSON-RPC channel can reconnect on the same pipe path
- replace task transport disconnect -> `System.exit` with an in-JVM reconnect loop and backoff
- pass the extension host pid to gradle-server and exit only when the parent process is gone, preserving orphan cleanup without coupling task disconnect to JVM shutdown
- mark only the task client unavailable on task channel close; Gradle LS and BSP stay untouched unless the JVM process actually exits

This supersedes the JVM-restart recovery direction from #1877 by fixing the task transport lifecycle coupling directly.

## Connection flow

```text
VS Code extension process
  └─ vscode-gradle extension
       ├─ creates the task pipe listener
       ├─ starts the gradle-server JVM with --pipe=<pipePath> --parentPid=<extensionHostPid>
       └─ waits for the JVM to connect back

gradle-server JVM
  └─ TaskPipeServer
       └─ connects as a client to the extension-owned pipe
```

The extension owns the pipe server/listener. The JVM is the pipe client. Once the socket is accepted, `TaskServerClient` wraps the `MessageConnection` in `GradleJsonRpcClient` and sends task RPCs to the JVM-side `GradleServiceImpl`.

```text
vscode-gradle
  -> JSON-RPC request: gradle/getBuild, gradle/runBuild, gradle/cancelBuild, ...
  -> gradle-server JVM / GradleServiceImpl
  -> Gradle Tooling API
  -> Gradle daemon / project build
```

## Reconnect state flow

Before this PR:

```text
task pipe disconnect
  -> TaskPipeServer listening ends
  -> GradleServer.java calls System.exit(...)
  -> whole gradle-server JVM exits
  -> Gradle LS / BSP are also torn down
```

After this PR:

```text
task pipe disconnect
  -> extension closes only the current GradleJsonRpcClient
  -> JVM cancels active Gradle builds for the lost task session
  -> JVM stays alive
  -> JVM task transport loop backs off and reconnects to the same pipe
  -> extension accepts the new connection
  -> TaskServerClient creates a new GradleJsonRpcClient
```

The recovered unit is the task JSON-RPC channel, not the whole JVM. Gradle LS and BSP remain in the same JVM and are not restarted for a task-pipe disconnect.

## Validation
- `cd extension; npm run compile:test`
- `cd extension; npm run lint:eslint`
- `cd extension; npm test`
- `./gradlew :gradle-server:test`
- `./gradlew :extension:buildProd`