### PR TITLE
fix: prevent gradle-server crashes and add transport disconnect telemetry

### DIFF
--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -210,7 +210,9 @@ export class GradleServer {
         );
         sendInfo("", {
             kind: "serverProcessExitRestart",
-            data3: selection === OPT_RESTART ? "true" : "false",
+            // Encode the choice in dataMsg; the telemetry sink only persists
+            // kind and dataMsg, so the boolean would be dropped if sent in data3.
+            dataMsg: JSON.stringify({ restartChosen: selection === OPT_RESTART }),
         });
         if (selection === OPT_RESTART) {
             await commands.executeCommand("workbench.action.restartExtensionHost");

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -13,6 +13,7 @@ import { BspProxy } from "../bs/BspProxy";
 import { getRandomPipeName } from "../util/generateRandomPipeName";
 import { createPipeListener, PipeListener } from "../transport/jsonrpc";
 import { shouldAutoRestart } from "./autoRestartPolicy";
+import { buildServerProcessExitInfo } from "./serverProcessExitInfo";
 const SERVER_LOGLEVEL_REGEX = /^\[([A-Z]+)\](.*)$/;
 const DOWNLOAD_PROGRESS_CHAR = ".";
 const STDERR_TAIL_LINES = 40;
@@ -166,16 +167,18 @@ export class GradleServer {
                 if ((code !== null && code !== 0) || signal !== null) {
                     // Decide on recovery first, then record a single
                     // serverProcessExit event for every unexpected exit (kept
-                    // comparable to the historical baseline). autoRestartAttempt
-                    // carries the recovery outcome on the same event: "1".."N"
-                    // while self-healing, "" once we give up (budget exhausted
-                    // or disposing) and the user is prompted to reload.
+                    // comparable to the historical baseline). The exit code,
+                    // signal and recovery outcome are JSON-encoded into dataMsg
+                    // because the telemetry sink only persists kind and dataMsg;
+                    // the exit code previously lived in data3 and was dropped, so
+                    // unexpected exits could not be attributed. None of these
+                    // fields carry user data.
                     const willAutoRestart = this.tryAutoRestart(code, signal);
                     sendInfo("", {
                         kind: "serverProcessExit",
-                        data3: code !== null ? code.toString() : "",
-                        dataMsg: signal ?? "",
-                        autoRestartAttempt: willAutoRestart ? this.autoRestartCount.toString() : "",
+                        dataMsg: JSON.stringify(
+                            buildServerProcessExitInfo(code, signal, willAutoRestart ? this.autoRestartCount : 0)
+                        ),
                         transport: "pipe",
                     });
                     if (willAutoRestart) {

--- a/extension/src/server/serverProcessExitInfo.ts
+++ b/extension/src/server/serverProcessExitInfo.ts
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/**
+ * Structured diagnostics recorded with the `serverProcessExit` telemetry event.
+ *
+ * These fields are JSON-encoded into the event's `dataMsg` because the telemetry
+ * sink only persists `kind` and `dataMsg`. The gradle-server exit code used to be
+ * sent in `data3`, which is dropped, so unexpected exits could not be attributed
+ * (non-zero exit code vs. signal-kill). All fields are low-cardinality
+ * diagnostics and never carry user data.
+ */
+export interface ServerProcessExitInfo {
+    /** Process exit code, or null when the process was terminated by a signal. */
+    code: number | null;
+    /** Terminating signal name (e.g. "SIGKILL"), or null on a code-based exit. */
+    signal: string | null;
+    /**
+     * Bounded auto-restart attempt number (1..N) while self-healing is in
+     * progress, or 0 once recovery is abandoned (attempt budget exhausted or the
+     * server is being disposed) and the user is prompted to reload.
+     */
+    autoRestartAttempt: number;
+}
+
+/**
+ * Assemble the {@link ServerProcessExitInfo} payload from a Node child-process
+ * exit. Kept as a pure function so the telemetry contract is unit-testable
+ * independently of process spawning.
+ */
+export function buildServerProcessExitInfo(
+    code: number | null,
+    signal: NodeJS.Signals | null,
+    autoRestartAttempt: number
+): ServerProcessExitInfo {
+    return {
+        code,
+        signal: signal ?? null,
+        autoRestartAttempt,
+    };
+}

--- a/extension/src/test/unit/config.test.ts
+++ b/extension/src/test/unit/config.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as assert from "assert";
+import * as sinon from "sinon";
+import * as vscode from "vscode";
+import * as telemetry from "vscode-extension-telemetry-wrapper";
+import * as jdkUtils from "../../util/jdkUtils";
+import { findValidJavaHome } from "../../util/config";
+
+function suiteName(name: string): string {
+    const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
+    return `${prefix}${name}`;
+}
+
+describe(suiteName("findValidJavaHome"), () => {
+    let savedJavaHome: string | undefined;
+
+    beforeEach(() => {
+        savedJavaHome = process.env.JAVA_HOME;
+        delete process.env.JAVA_HOME;
+        // No java.* home settings and no java.configuration.runtimes configured,
+        // so resolution falls through to the discovered-JDK scan under test.
+        sinon.stub(vscode.workspace, "getConfiguration").returns({
+            get: (_section: string, defaultValue?: unknown) => defaultValue ?? null,
+        } as unknown as vscode.WorkspaceConfiguration);
+    });
+
+    afterEach(() => {
+        if (savedJavaHome === undefined) {
+            delete process.env.JAVA_HOME;
+        } else {
+            process.env.JAVA_HOME = savedJavaHome;
+        }
+        sinon.restore();
+    });
+
+    it("skips a JDK with an unresolved version instead of crashing", async () => {
+        sinon.stub(jdkUtils, "listJdks").resolves([
+            { homedir: "/jdk-no-version" } as any, // version === undefined
+            { homedir: "/jdk17", version: { major: 17 } } as any,
+        ]);
+        const sendInfoStub = sinon.stub(telemetry, "sendInfo");
+
+        const result = await findValidJavaHome();
+
+        assert.strictEqual(result, "/jdk17");
+        assert.ok(
+            sendInfoStub.calledOnceWith("", sinon.match({ kind: "jdkVersionUnresolved" })),
+            "expected jdkVersionUnresolved telemetry to be sent"
+        );
+    });
+
+    it("returns undefined without throwing when every discovered JDK lacks a version", async () => {
+        sinon.stub(jdkUtils, "listJdks").resolves([{ homedir: "/jdk-no-version" } as any]);
+        sinon.stub(telemetry, "sendInfo");
+
+        const result = await findValidJavaHome();
+
+        assert.strictEqual(result, undefined);
+    });
+
+    it("does not emit telemetry when every discovered JDK has a resolved version", async () => {
+        sinon.stub(jdkUtils, "listJdks").resolves([{ homedir: "/jdk17", version: { major: 17 } } as any]);
+        const sendInfoStub = sinon.stub(telemetry, "sendInfo");
+
+        const result = await findValidJavaHome();
+
+        assert.strictEqual(result, "/jdk17");
+        assert.strictEqual(sendInfoStub.called, false);
+    });
+});

--- a/extension/src/test/unit/serverProcessExitInfo.test.ts
+++ b/extension/src/test/unit/serverProcessExitInfo.test.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import { buildServerProcessExitInfo } from "../../server/serverProcessExitInfo";
+
+function suiteName(name: string): string {
+    const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
+    return `${prefix}${name}`;
+}
+
+describe(suiteName("buildServerProcessExitInfo"), () => {
+    it("captures the exit code on a code-based exit", () => {
+        const info = buildServerProcessExitInfo(1, null, 2);
+        assert.deepStrictEqual(info, { code: 1, signal: null, autoRestartAttempt: 2 });
+    });
+
+    it("captures the signal name on a signal-based termination", () => {
+        const info = buildServerProcessExitInfo(null, "SIGKILL", 0);
+        assert.deepStrictEqual(info, { code: null, signal: "SIGKILL", autoRestartAttempt: 0 });
+    });
+
+    it("round-trips through JSON so the exit code survives in dataMsg", () => {
+        const dataMsg = JSON.stringify(buildServerProcessExitInfo(0, null, 0));
+        assert.deepStrictEqual(JSON.parse(dataMsg), { code: 0, signal: null, autoRestartAttempt: 0 });
+    });
+});

--- a/extension/src/test/unit/transport/pipeServer.test.ts
+++ b/extension/src/test/unit/transport/pipeServer.test.ts
@@ -28,7 +28,7 @@ describe(suiteName("createPipeListener"), () => {
         sendInfoStub = sinon.stub(telemetry, "sendInfo");
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         for (const clientSock of clientSocks) {
             if (!clientSock.destroyed) {
                 clientSock.destroy();
@@ -37,6 +37,10 @@ describe(suiteName("createPipeListener"), () => {
         clientSocks = [];
         listener?.dispose();
         listener = undefined;
+        // dispose() destroys the socket and its `close` handler emits telemetry on
+        // a later tick; let those callbacks run while the stub is still installed
+        // so restore() does not expose the real telemetry implementation.
+        await new Promise((resolve) => setImmediate(resolve));
         sinon.restore();
     });
 

--- a/extension/src/test/unit/transport/pipeServer.test.ts
+++ b/extension/src/test/unit/transport/pipeServer.test.ts
@@ -4,8 +4,11 @@
 import * as assert from "assert";
 import * as fs from "fs";
 import * as net from "net";
-import type { Logger as JsonRpcLogger, MessageConnection } from "vscode-jsonrpc";
+import * as sinon from "sinon";
+import * as telemetry from "vscode-extension-telemetry-wrapper";
+import type { Logger as JsonRpcLogger, Message, MessageConnection } from "vscode-jsonrpc";
 import { createPipeListener, PipeListener } from "../../../transport/jsonrpc";
+import { SafeSocketMessageWriter } from "../../../transport/jsonrpc/pipeServer";
 
 function suiteName(name: string): string {
     const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
@@ -175,4 +178,106 @@ describe(suiteName("createPipeListener"), () => {
         });
         return socket;
     }
+});
+
+describe(suiteName("SafeSocketMessageWriter"), () => {
+    let server: net.Server | undefined;
+    let pairSocks: net.Socket[] = [];
+
+    const ping: Message = { jsonrpc: "2.0", method: "ping" } as Message;
+
+    afterEach(() => {
+        for (const sock of pairSocks) {
+            if (!sock.destroyed) {
+                sock.destroy();
+            }
+        }
+        pairSocks = [];
+        server?.close();
+        server = undefined;
+        sinon.restore();
+    });
+
+    // Establish a connected loopback socket pair: `local` is what the writer
+    // writes to, `remote` is the peer that receives the framed bytes.
+    function connectPair(): Promise<{ local: net.Socket; remote: net.Socket }> {
+        return new Promise((resolve, reject) => {
+            let local!: net.Socket;
+            const srv = net.createServer((remote) => {
+                pairSocks.push(remote);
+                resolve({ local, remote });
+            });
+            server = srv;
+            srv.once("error", reject);
+            srv.listen(0, "127.0.0.1", () => {
+                const { port } = srv.address() as net.AddressInfo;
+                local = net.connect(port, "127.0.0.1");
+                pairSocks.push(local);
+                local.once("error", () => {
+                    /* ignore; teardown destroys the socket */
+                });
+            });
+        });
+    }
+
+    it("delivers a message while the socket is writable", async () => {
+        const { local, remote } = await connectPair();
+        const writer = new SafeSocketMessageWriter(local);
+        const sendInfoStub = sinon.stub(telemetry, "sendInfo");
+        let sawError = false;
+        writer.onError(() => (sawError = true));
+
+        const received = new Promise<string>((resolve) => {
+            remote.once("data", (data: Buffer) => resolve(data.toString("utf8")));
+        });
+
+        await writer.write(ping);
+
+        const payload = await received;
+        assert.ok(payload.includes("ping"), `expected the framed message to arrive, got: ${payload}`);
+        assert.strictEqual(sawError, false, "did not expect an error while the socket was writable");
+        assert.strictEqual(sendInfoStub.called, false, "did not expect telemetry for a successful write");
+    });
+
+    it("does not throw 'write after end' once the socket is destroyed", async () => {
+        const { local } = await connectPair();
+        const writer = new SafeSocketMessageWriter(local);
+        const sendInfoStub = sinon.stub(telemetry, "sendInfo");
+        const errors: Error[] = [];
+        writer.onError(([err]) => errors.push(err));
+
+        local.destroy();
+        // Allow Node to mark the socket destroyed before we attempt the write.
+        await new Promise((resolve) => setImmediate(resolve));
+
+        await assert.doesNotReject(
+            writer.write(ping),
+            "writing to a destroyed task pipe must resolve, not throw write-after-end"
+        );
+        assert.ok(errors.length >= 1, "expected the write failure to be routed through the onError event");
+        assert.ok(
+            sendInfoStub.calledWith("", sinon.match({ kind: "taskPipeWriteAfterEnd" })),
+            "expected taskPipeWriteAfterEnd telemetry to be reported once the pipe is torn down"
+        );
+    });
+
+    it("reports the torn-down pipe telemetry at most once per writer", async () => {
+        const { local } = await connectPair();
+        const writer = new SafeSocketMessageWriter(local);
+        const sendInfoStub = sinon.stub(telemetry, "sendInfo");
+        writer.onError(() => {
+            /* swallow; assertions below cover the telemetry */
+        });
+
+        local.destroy();
+        await new Promise((resolve) => setImmediate(resolve));
+
+        await writer.write(ping);
+        await writer.write(ping);
+
+        const writeAfterEndCalls = sendInfoStub
+            .getCalls()
+            .filter((call) => call.args[1] && (call.args[1] as { kind?: string }).kind === "taskPipeWriteAfterEnd");
+        assert.strictEqual(writeAfterEndCalls.length, 1, "expected taskPipeWriteAfterEnd to be reported only once");
+    });
 });

--- a/extension/src/test/unit/transport/pipeServer.test.ts
+++ b/extension/src/test/unit/transport/pipeServer.test.ts
@@ -22,6 +22,11 @@ function frame(body: string): string {
 describe(suiteName("createPipeListener"), () => {
     let listener: PipeListener | undefined;
     let clientSocks: net.Socket[] = [];
+    let sendInfoStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        sendInfoStub = sinon.stub(telemetry, "sendInfo");
+    });
 
     afterEach(() => {
         for (const clientSock of clientSocks) {
@@ -32,6 +37,7 @@ describe(suiteName("createPipeListener"), () => {
         clientSocks = [];
         listener?.dispose();
         listener = undefined;
+        sinon.restore();
     });
 
     it("binds a task pipe and resolves the connection promise on first inbound socket", async () => {
@@ -168,6 +174,52 @@ describe(suiteName("createPipeListener"), () => {
 
         connection.dispose();
     });
+
+    it("emits taskPipeDisconnected with outcome 'disposed' when the listener is torn down", async () => {
+        listener = await createPipeListener({ connectTimeoutMs: 2_000 });
+        await connectClient(listener.pipePath);
+        await listener.connection;
+
+        listener.dispose();
+        listener = undefined;
+
+        await waitFor(() => disconnectCalls().length >= 1);
+        const last = disconnectCalls().pop()!;
+        assert.strictEqual(last.outcome, "disposed", "expected an extension-initiated teardown to be classified");
+        assert.strictEqual(typeof last.durationMs, "number", "expected the connection lifetime to be recorded");
+    });
+
+    it("emits taskPipeDisconnected when the JVM side closes the task socket", async () => {
+        listener = await createPipeListener({ connectTimeoutMs: 2_000 });
+        const clientSock = await connectClient(listener.pipePath);
+        await listener.connection;
+
+        clientSock.end();
+
+        await waitFor(() => disconnectCalls().some((d) => d.outcome !== "disposed"));
+        const drop = disconnectCalls().find((d) => d.outcome !== "disposed")!;
+        assert.ok(
+            drop.outcome === "peerClosed" || drop.outcome === "error",
+            `expected a peer-initiated drop, got outcome=${drop.outcome}`
+        );
+    });
+
+    function disconnectCalls(): Array<{ outcome: string; durationMs: number; hadError: boolean }> {
+        return sendInfoStub
+            .getCalls()
+            .filter((call) => (call.args[1] as { kind?: string } | undefined)?.kind === "taskPipeDisconnected")
+            .map((call) => JSON.parse((call.args[1] as { dataMsg: string }).dataMsg));
+    }
+
+    async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+        const start = Date.now();
+        while (!predicate()) {
+            if (Date.now() - start > timeoutMs) {
+                throw new Error("timed out waiting for the expected telemetry");
+            }
+            await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+    }
 
     async function connectClient(pipePath: string): Promise<net.Socket> {
         const socket = net.connect(pipePath);

--- a/extension/src/test/unit/transport/pipeServer.test.ts
+++ b/extension/src/test/unit/transport/pipeServer.test.ts
@@ -242,15 +242,17 @@ describe(suiteName("SafeSocketMessageWriter"), () => {
 
     const ping: Message = { jsonrpc: "2.0", method: "ping" } as Message;
 
-    afterEach(() => {
+    afterEach(async () => {
         for (const sock of pairSocks) {
             if (!sock.destroyed) {
                 sock.destroy();
             }
         }
         pairSocks = [];
-        server?.close();
-        server = undefined;
+        if (server) {
+            await new Promise<void>((resolve) => server!.close(() => resolve()));
+            server = undefined;
+        }
         sinon.restore();
     });
 

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -34,10 +34,12 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
  * through the writer's error event, so callers and in-flight requests settle via
  * the normal connection-close path instead of crashing the extension host.
  *
- * The same tear-down previously surfaced as an `unhandlederror` crash rather
- * than a clean socket `error` event, so the disconnect went unrecorded by
- * {@link reportPipeFailure}. We emit `taskPipeWriteAfterEnd` once per writer to
- * keep that signal observable after the crash is suppressed.
+ * The same tear-down previously crashed the extension host: the synchronous
+ * `socket.write()` throw escaped as an unhandled promise rejection and surfaced
+ * in telemetry as an `unhandlederror` event rather than a clean socket `error`
+ * event, so the disconnect went unrecorded by {@link reportPipeFailure}. We emit
+ * `taskPipeWriteAfterEnd` once per writer to keep that signal observable after
+ * the crash is suppressed.
  */
 export class SafeSocketMessageWriter extends SocketMessageWriter {
     private writeFailureReported = false;

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -126,6 +126,9 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
     let disposed = false;
     let disposedReason: Error | undefined;
     let hasAcceptedConnection = false;
+    // Sockets we intentionally tear down to accept a fresh reconnect; tracked so
+    // their close is classified as an expected handover rather than a drop.
+    const supersededSockets = new WeakSet<net.Socket>();
     const pendingConnections: MessageConnection[] = [];
     const pendingWaiters: Array<{
         resolve: (connection: MessageConnection) => void;
@@ -171,22 +174,31 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
         hasAcceptedConnection = true;
 
         if (activeSocket && !activeSocket.destroyed) {
+            supersededSockets.add(activeSocket);
             activeSocket.destroy();
         }
         activeSocket = socket;
 
         const reader = new SocketMessageReader(socket);
         const writer = new SafeSocketMessageWriter(socket);
+        const connectedAt = Date.now();
+        let lastSocketError: Error | undefined;
 
         socket.on("error", (socketErr) => {
+            lastSocketError = socketErr;
             options.logger?.error(`gradle-server task pipe error: ${socketErr.message}`);
-            reportPipeFailure("taskPipeConnectionClosed", socketErr.message);
         });
         socket.on("close", (hadError) => {
             if (activeSocket === socket) {
                 activeSocket = undefined;
             }
             options.logger?.info(`gradle-server task pipe closed${hadError ? " after error" : ""}`);
+            reportPipeDisconnect({
+                outcome: classifyDisconnect(disposed, supersededSockets.has(socket), hadError),
+                hadError,
+                durationMs: Date.now() - connectedAt,
+                reason: lastSocketError?.message,
+            });
         });
 
         const conn = createMessageConnection(reader, writer, options.logger);
@@ -283,6 +295,46 @@ function reportPipeFailure(kind: string, message: string): void {
     sendInfo("", {
         kind,
         dataMsg: message,
+        transport: "pipe",
+    });
+}
+
+/**
+ * Classification of how a task pipe socket ended, recorded with every
+ * {@link reportPipeDisconnect} so post-release dashboards can separate expected
+ * teardown from genuine drops:
+ * - `disposed`: the extension tore the listener down (shutdown / reload).
+ * - `superseded`: replaced by a fresh JVM reconnect on the same listener.
+ * - `error`: the socket closed after an I/O error (ECONNRESET, EPIPE, ...).
+ * - `peerClosed`: the JVM closed the stream cleanly (FIN) without an error.
+ */
+type DisconnectOutcome = "disposed" | "superseded" | "error" | "peerClosed";
+
+function classifyDisconnect(disposed: boolean, superseded: boolean, hadError: boolean): DisconnectOutcome {
+    if (disposed) {
+        return "disposed";
+    }
+    if (superseded) {
+        return "superseded";
+    }
+    return hadError ? "error" : "peerClosed";
+}
+
+/**
+ * Record that a task pipe socket ended. The structured payload is stringified
+ * into `dataMsg` because the filtered telemetry cluster drops arbitrary custom
+ * fields; only `kind` and `dataMsg` survive. `reason` carries the Node error
+ * code (e.g. `read ECONNRESET`) and never a user path.
+ */
+function reportPipeDisconnect(detail: {
+    outcome: DisconnectOutcome;
+    hadError: boolean;
+    durationMs: number;
+    reason?: string;
+}): void {
+    sendInfo("", {
+        kind: "taskPipeDisconnected",
+        dataMsg: JSON.stringify(detail),
         transport: "pipe",
     });
 }

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -4,7 +4,7 @@
 import * as fs from "fs";
 import * as net from "net";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
-import { Emitter, Event } from "vscode-jsonrpc";
+import { Emitter, Event, Message } from "vscode-jsonrpc";
 import { createMessageConnection, MessageConnection } from "vscode-jsonrpc/node";
 import { SocketMessageReader, SocketMessageWriter } from "vscode-jsonrpc/node";
 import type { Logger as JsonRpcLogger } from "vscode-jsonrpc";
@@ -21,6 +21,51 @@ import { getRandomPipeName } from "../../util/generateRandomPipeName";
  */
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 30_000;
+
+/**
+ * A {@link SocketMessageWriter} that never lets a write on an already
+ * ended/destroyed socket escape as an unhandled `write after end` rejection.
+ *
+ * The task transport tears the writable side down (peer reset, JVM exit,
+ * `dispose()`) before vscode-jsonrpc observes reader EOF and transitions the
+ * connection to Closed. In that window an outbound message would call
+ * `socket.write()` on a finished stream, which Node throws synchronously. We
+ * guard the writable state up front and route any residual TOCTOU failure
+ * through the writer's error event, so callers and in-flight requests settle via
+ * the normal connection-close path instead of crashing the extension host.
+ *
+ * The same tear-down previously surfaced as an `unhandlederror` crash rather
+ * than a clean socket `error` event, so the disconnect went unrecorded by
+ * {@link reportPipeFailure}. We emit `taskPipeWriteAfterEnd` once per writer to
+ * keep that signal observable after the crash is suppressed.
+ */
+export class SafeSocketMessageWriter extends SocketMessageWriter {
+    private writeFailureReported = false;
+
+    public constructor(private readonly pipeSocket: net.Socket) {
+        super(pipeSocket);
+    }
+
+    public async write(msg: Message): Promise<void> {
+        if (!this.pipeSocket.writable || this.pipeSocket.writableEnded || this.pipeSocket.destroyed) {
+            this.handleWriteFailure(new Error("gradle-server task pipe is no longer writable"), msg);
+            return;
+        }
+        try {
+            await super.write(msg);
+        } catch (err) {
+            this.handleWriteFailure(err instanceof Error ? err : new Error(String(err)), msg);
+        }
+    }
+
+    private handleWriteFailure(error: Error, msg: Message): void {
+        this.fireError(error, msg);
+        if (!this.writeFailureReported) {
+            this.writeFailureReported = true;
+            reportPipeFailure("taskPipeWriteAfterEnd", error.message);
+        }
+    }
+}
 
 export interface PipeListener {
     /** Pipe path the JVM should be told to connect back to. */
@@ -131,7 +176,7 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
         activeSocket = socket;
 
         const reader = new SocketMessageReader(socket);
-        const writer = new SocketMessageWriter(socket);
+        const writer = new SafeSocketMessageWriter(socket);
 
         socket.on("error", (socketErr) => {
             options.logger?.error(`gradle-server task pipe error: ${socketErr.message}`);

--- a/extension/src/transport/jsonrpc/pipeServer.ts
+++ b/extension/src/transport/jsonrpc/pipeServer.ts
@@ -182,10 +182,12 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
         const reader = new SocketMessageReader(socket);
         const writer = new SafeSocketMessageWriter(socket);
         const connectedAt = Date.now();
-        let lastSocketError: Error | undefined;
+        let lastSocketErrorCode: string | undefined;
 
         socket.on("error", (socketErr) => {
-            lastSocketError = socketErr;
+            // Keep only the low-cardinality, path-free Node error code for telemetry;
+            // the full message still goes to the local logger.
+            lastSocketErrorCode = (socketErr as NodeJS.ErrnoException).code;
             options.logger?.error(`gradle-server task pipe error: ${socketErr.message}`);
         });
         socket.on("close", (hadError) => {
@@ -197,7 +199,7 @@ export async function createPipeListener(options: PipeListenerOptions = {}): Pro
                 outcome: classifyDisconnect(disposed, supersededSockets.has(socket), hadError),
                 hadError,
                 durationMs: Date.now() - connectedAt,
-                reason: lastSocketError?.message,
+                reason: lastSocketErrorCode,
             });
         });
 
@@ -322,9 +324,8 @@ function classifyDisconnect(disposed: boolean, superseded: boolean, hadError: bo
 
 /**
  * Record that a task pipe socket ended. The structured payload is stringified
- * into `dataMsg` because the filtered telemetry cluster drops arbitrary custom
- * fields; only `kind` and `dataMsg` survive. `reason` carries the Node error
- * code (e.g. `read ECONNRESET`) and never a user path.
+ * into `dataMsg` because the telemetry sink only persists `kind` and `dataMsg`.
+ * `reason` carries the Node error code (e.g. `ECONNRESET`) and never a user path.
  */
 function reportPipeDisconnect(detail: {
     outcome: DisconnectOutcome;

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -6,6 +6,7 @@ import { RootProject } from "../rootProject/RootProject";
 import * as fse from "fs-extra";
 import * as path from "path";
 import { findDefaultRuntimeFromSettings, getMajorVersion, listJdks } from "./jdkUtils";
+import { sendInfo } from "vscode-extension-telemetry-wrapper";
 type AutoDetect = "on" | "off";
 export const REQUIRED_JDK_VERSION = 17;
 
@@ -59,7 +60,18 @@ export async function findValidJavaHome(): Promise<string | undefined> {
 
     // Search valid JDKs from env.JAVA_HOME, env.PATH, SDKMAN, jEnv, jabba, common directories
     const javaRuntimes = await listJdks();
-    const validJdks = javaRuntimes.find((r) => r.version!.major >= REQUIRED_JDK_VERSION);
+    // Some discovered JDKs report an unparseable version (`version` is
+    // undefined). Reading `.major` off them previously threw and aborted
+    // extension activation, so the gradle-server never started. Track how
+    // often this happens so the failure mode stays visible after the fix.
+    const unresolvedVersionCount = javaRuntimes.filter((r) => r.version?.major === undefined).length;
+    if (unresolvedVersionCount > 0) {
+        sendInfo("", {
+            kind: "jdkVersionUnresolved",
+            dataMsg: JSON.stringify({ unresolved: unresolvedVersionCount, total: javaRuntimes.length }),
+        });
+    }
+    const validJdks = javaRuntimes.find((r) => (r.version?.major ?? 0) >= REQUIRED_JDK_VERSION);
     if (validJdks !== undefined) {
         return validJdks.homedir;
     }


### PR DESCRIPTION
## Summary

The pipe-based Gradle task transport (#1875, #1879) regressed extension-host stability relative to the previous gRPC transport (tracked in #1860). Two concrete crash classes were identified as a meaningful share of the extension-host crashes seen on the nightly transport. This PR fixes both and adds structured telemetry so transport disconnects remain observable going forward.

## Fix 1 — `findValidJavaHome` crash on JDKs with an unresolved version

`findValidJavaHome` dereferenced `r.version!.major` with a non-null assertion, but `jdkUtils.listJdks()` (→ `findRuntimes({ withVersion: true })`) returns runtimes whose `version` is **optional** (undefined when the JDK's release file can't be parsed). A single such JDK on the machine threw during activation, aborting `Extension.activate()` so gradle-server never started. The line has existed since #1512 (2024-07-22) and is also present in the current stable build (`e916b259`); it simply surfaces more often on multi-JDK setups.

- Skip JDKs with an unresolved version (`r.version?.major ?? 0`) instead of dereferencing, mirroring the existing safe pattern in `jdkUtils.ts`.
- Add `jdkVersionUnresolved` telemetry (`dataMsg = {unresolved, total}`) for visibility into how often discovery hits unparseable JDKs.

## Fix 2 — guard the task pipe writer against write-after-end

When the gradle-server task socket's writable side is torn down (peer reset, JVM exit, `dispose()`) **before** vscode-jsonrpc observes reader EOF and closes the connection, an outbound message calls `socket.write()` on a finished stream and Node throws `write after end` synchronously → unhandled rejection → extension-host crash.

- Add `SafeSocketMessageWriter` (subclass of `SocketMessageWriter`) that checks socket writability before writing and routes any residual TOCTOU failure through the writer's `onError` event instead of letting it escape. In-flight requests still settle via the normal connection-close path.
- Add `taskPipeWriteAfterEnd` telemetry (once per writer) — this tear-down previously surfaced only as a crash, never as a clean socket `error`, so it was otherwise unobservable.

## Disconnect tracking telemetry

The previous socket-close telemetry (`taskPipeConnectionClosed`) only fired from the socket `error` handler, which rarely fires in practice — real drops surface as a clean FIN, a write-after-end crash, or a reconnect handover, leaving disconnects largely unobservable.

This PR records one **`taskPipeDisconnected`** event on every socket `close`, with a classified `outcome` and timing JSON-encoded into `dataMsg`:

- `outcome`: `disposed` (extension teardown) / `superseded` (JVM reconnect handover) / `error` (closed after an I/O error) / `peerClosed` (clean FIN from the JVM)
- `hadError`, `durationMs` (connection lifetime — short values flag startup-phase instability), `reason` (Node error code; no paths)

## Telemetry events added

| kind | location | purpose |
| --- | --- | --- |
| `jdkVersionUnresolved` | `util/config.ts` | JDK discovery hit an unparseable version (Fix 1 root cause) |
| `taskPipeWriteAfterEnd` | `transport/jsonrpc/pipeServer.ts` | a write raced socket teardown (Fix 2 signal) |
| `taskPipeDisconnected` | `transport/jsonrpc/pipeServer.ts` | every task pipe close, classified by outcome |

All payloads carry only categorical fields and counts — no file paths or user data.

## Testing

- `config.test.ts` — skip-unresolved-JDK + telemetry, no-throw when all JDKs lack a version, no telemetry when all resolve.
- `pipeServer.test.ts` — writer: delivers while writable / no write-after-end once destroyed / once-per-writer telemetry dedup; listener: `disposed` and peer-close `taskPipeDisconnected` outcomes.
- `tsc`, eslint and prettier are clean.

## Follow-up

A share of the remaining crashes report only generic wrapper messages without actionable stacks; classifying those needs structured telemetry at the relevant catch sites and is left to a follow-up.

Related: #1860, #1875, #1879
