### PR TITLE
fix: honor JPMS arg type when aggregating classpath attributes

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/jpms/JpmsUtils.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/jpms/JpmsUtils.java
@@ -154,7 +154,7 @@ public class JpmsUtils {
 
     private static String getAggregatedValue(Set<String> availableModules, JpmsArguments jpmsArgs, JpmsArgType type) {
         StringBuilder sb = new StringBuilder();
-        for (Iterator<Entry<String, Set<String>>> it = jpmsArgs.getGroupedArgumentsByType(JpmsArgType.ADD_EXPORTS).entrySet().iterator(); it.hasNext();) {
+        for (Iterator<Entry<String, Set<String>>> it = jpmsArgs.getGroupedArgumentsByType(type).entrySet().iterator(); it.hasNext();) {
             Entry<String, Set<String>> valueEntry = it.next();
             String moduleName = valueEntry.getKey();
             Set<String> values = valueEntry.getValue();


### PR DESCRIPTION
## Problem

`JpmsUtils.getAggregatedValue(Set<String>, JpmsArguments, JpmsArgType type)` ignores its `type` parameter and always reads from the `ADD_EXPORTS` map:

```java
jpmsArgs.getGroupedArgumentsByType(JpmsArgType.ADD_EXPORTS)
```

It is called once per type in `updateJpmsAttributesForClasspathEntry` (for `ADD_EXPORTS`, `ADD_OPENS`, `ADD_READS`, `PATCH_MODULE`), but the value source is hard-coded to `ADD_EXPORTS`. Combined with the `it.remove()` that drains the map, this means:

- `--add-opens`, `--add-reads` and `--patch-module` compiler arguments reported by the build server are silently dropped and never written as JDT classpath attributes.
- `--add-exports` values can leak into the wrong attribute type (e.g. an `ADD_OPENS` attribute gets `add-exports` values, which also have an incompatible value format vs `add-reads`).

As a result, modular (JPMS) Gradle projects lose their non-exports module options after import, which can break compilation / launching under the default Java Test Runner.

## Fix

Use the `type` argument that was passed in instead of the hard-coded `ADD_EXPORTS`.

## Verification

`./mvnw -o clean verify -DskipTests` under `extension/jdtls.ext` builds successfully (Eclipse compiler, 62 source files).