### PR TITLE
fix: surface a clear prompt when JAVA_HOME points at an invalid directory

### DIFF
--- a/extension/src/constant.ts
+++ b/extension/src/constant.ts
@@ -23,7 +23,7 @@ export const NO_JAVA_EXECUTABLE =
 
 export const javaHomeInvalidDirMessage = (javaHome: string, envVar = "JAVA_HOME"): string =>
     `${envVar} is set to '${javaHome}', but it does not contain a usable Java executable. ` +
-    `Point ${envVar} at a valid JDK 17 or higher, set the 'java.jdt.ls.java.home' setting, or unset ${envVar} to use a 'java' from your PATH.`;
+    `Point ${envVar} at a valid JDK 17 or higher, set the 'java.jdt.ls.java.home' setting, or clear your Java home env vars to use a 'java' from your PATH.`;
 
 export const OPT_RESTART = "Restart";
 

--- a/extension/src/constant.ts
+++ b/extension/src/constant.ts
@@ -21,9 +21,9 @@ export const GRADLE_BUILD_FILE_NAMES = ["build.gradle", "settings.gradle", "buil
 export const NO_JAVA_EXECUTABLE =
     "JDK 17 or higher is required. Please set a valid Java home path to 'java.jdt.ls.java.home' setting or JAVA_HOME environment variable. Or ensure a valid Java executable is in your PATH.";
 
-export const javaHomeInvalidDirMessage = (javaHome: string): string =>
-    `JAVA_HOME is set to '${javaHome}', but it does not contain a Java executable. ` +
-    "Point JAVA_HOME at a valid JDK 17 or higher, set the 'java.jdt.ls.java.home' setting, or unset JAVA_HOME to use a 'java' from your PATH.";
+export const javaHomeInvalidDirMessage = (javaHome: string, envVar = "JAVA_HOME"): string =>
+    `${envVar} is set to '${javaHome}', but it does not contain a Java executable. ` +
+    `Point ${envVar} at a valid JDK 17 or higher, set the 'java.jdt.ls.java.home' setting, or unset ${envVar} to use a 'java' from your PATH.`;
 
 export const OPT_RESTART = "Restart";
 

--- a/extension/src/constant.ts
+++ b/extension/src/constant.ts
@@ -21,6 +21,10 @@ export const GRADLE_BUILD_FILE_NAMES = ["build.gradle", "settings.gradle", "buil
 export const NO_JAVA_EXECUTABLE =
     "JDK 17 or higher is required. Please set a valid Java home path to 'java.jdt.ls.java.home' setting or JAVA_HOME environment variable. Or ensure a valid Java executable is in your PATH.";
 
+export const javaHomeInvalidDirMessage = (javaHome: string): string =>
+    `JAVA_HOME is set to '${javaHome}', but it does not contain a Java executable. ` +
+    "Point JAVA_HOME at a valid JDK 17 or higher, set the 'java.jdt.ls.java.home' setting, or unset JAVA_HOME to use a 'java' from your PATH.";
+
 export const OPT_RESTART = "Restart";
 
 export const INSTALL_JDK = "Install JDK";

--- a/extension/src/constant.ts
+++ b/extension/src/constant.ts
@@ -22,7 +22,7 @@ export const NO_JAVA_EXECUTABLE =
     "JDK 17 or higher is required. Please set a valid Java home path to 'java.jdt.ls.java.home' setting or JAVA_HOME environment variable. Or ensure a valid Java executable is in your PATH.";
 
 export const javaHomeInvalidDirMessage = (javaHome: string, envVar = "JAVA_HOME"): string =>
-    `${envVar} is set to '${javaHome}', but it does not contain a Java executable. ` +
+    `${envVar} is set to '${javaHome}', but it does not contain a usable Java executable. ` +
     `Point ${envVar} at a valid JDK 17 or higher, set the 'java.jdt.ls.java.home' setting, or unset ${envVar} to use a 'java' from your PATH.`;
 
 export const OPT_RESTART = "Restart";

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -98,7 +98,7 @@ export class GradleServer {
             const missingJava = getMissingJavaInfo();
             const message =
                 missingJava.reason === "javaHomeInvalidDir"
-                    ? javaHomeInvalidDirMessage(missingJava.javaHome!, missingJava.envVar)
+                    ? javaHomeInvalidDirMessage(missingJava.javaHome, missingJava.envVar)
                     : NO_JAVA_EXECUTABLE;
             sendInfo("", {
                 kind: "GradleServerEnvMissing",

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -7,8 +7,8 @@ import type { Logger as JsonRpcLogger, MessageConnection } from "vscode-jsonrpc"
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { getGradleServerCommand, getGradleServerEnv, quoteArg } from "./serverUtil";
 import { Logger } from "../logger/index";
-import { NO_JAVA_EXECUTABLE, OPT_RESTART, INSTALL_JDK } from "../constant";
-import { extensionInstalled } from "../util/config";
+import { NO_JAVA_EXECUTABLE, OPT_RESTART, INSTALL_JDK, javaHomeInvalidDirMessage } from "../constant";
+import { extensionInstalled, getMissingJavaInfo } from "../util/config";
 import { BspProxy } from "../bs/BspProxy";
 import { getRandomPipeName } from "../util/generateRandomPipeName";
 import { createPipeListener, PipeListener } from "../transport/jsonrpc";
@@ -95,11 +95,18 @@ export class GradleServer {
         const cmd = path.join(cwd, getGradleServerCommand());
         const env = await getGradleServerEnv();
         if (!env) {
+            const missingJava = getMissingJavaInfo();
+            const message =
+                missingJava.reason === "javaHomeInvalidDir"
+                    ? javaHomeInvalidDirMessage(missingJava.javaHome!)
+                    : NO_JAVA_EXECUTABLE;
             sendInfo("", {
                 kind: "GradleServerEnvMissing",
+                dataMsg: JSON.stringify({ reason: missingJava.reason }),
             });
+            this.logger.error(message);
             const choice = extensionInstalled("vscjava.vscode-java-pack") ? [INSTALL_JDK] : [];
-            vscode.window.showErrorMessage(NO_JAVA_EXECUTABLE, ...choice).then((selection) => {
+            vscode.window.showErrorMessage(message, ...choice).then((selection) => {
                 if (selection === INSTALL_JDK) {
                     vscode.commands.executeCommand("java.installJdk");
                 }

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -6,7 +6,7 @@ import { commands } from "vscode";
 import type { Logger as JsonRpcLogger, MessageConnection } from "vscode-jsonrpc";
 import { sendInfo } from "vscode-extension-telemetry-wrapper";
 import { getGradleServerCommand, getGradleServerEnv, quoteArg } from "./serverUtil";
-import { Logger } from "../logger/index";
+import { Logger, LogVerbosity } from "../logger/index";
 import { NO_JAVA_EXECUTABLE, OPT_RESTART, INSTALL_JDK, javaHomeInvalidDirMessage } from "../constant";
 import { extensionInstalled, getMissingJavaInfo } from "../util/config";
 import { BspProxy } from "../bs/BspProxy";
@@ -104,7 +104,11 @@ export class GradleServer {
                 kind: "GradleServerEnvMissing",
                 dataMsg: JSON.stringify({ reason: missingJava.reason }),
             });
-            this.logger.error(message);
+            // Log to the Output channel at ERROR verbosity, but bypass logger.error()
+            // so the message (which may contain the user's JAVA_HOME path) is not sent
+            // as telemetry. Telemetry attribution comes from the low-cardinality
+            // GradleServerEnvMissing event above instead.
+            this.logger.log(message, LogVerbosity.ERROR);
             const choice = extensionInstalled("vscjava.vscode-java-pack") ? [INSTALL_JDK] : [];
             vscode.window.showErrorMessage(message, ...choice).then((selection) => {
                 if (selection === INSTALL_JDK) {

--- a/extension/src/server/GradleServer.ts
+++ b/extension/src/server/GradleServer.ts
@@ -98,7 +98,7 @@ export class GradleServer {
             const missingJava = getMissingJavaInfo();
             const message =
                 missingJava.reason === "javaHomeInvalidDir"
-                    ? javaHomeInvalidDirMessage(missingJava.javaHome!)
+                    ? javaHomeInvalidDirMessage(missingJava.javaHome!, missingJava.envVar)
                     : NO_JAVA_EXECUTABLE;
             sendInfo("", {
                 kind: "GradleServerEnvMissing",

--- a/extension/src/test/unit/config.test.ts
+++ b/extension/src/test/unit/config.test.ts
@@ -5,6 +5,7 @@
 import * as assert from "assert";
 import * as sinon from "sinon";
 import * as path from "path";
+import * as fs from "fs";
 import * as fse from "fs-extra";
 import { JAVA_FILENAME } from "jdk-utils";
 import * as vscode from "vscode";
@@ -116,6 +117,14 @@ describe(suiteName("checkEnvJavaExecutable"), () => {
     it("returns false when JAVA_HOME is set but its bin/java is missing or not executable", () => {
         process.env.JAVA_HOME = "/opt/broken";
         sinon.stub(fse, "accessSync").throws(new Error("ENOENT"));
+
+        assert.strictEqual(checkEnvJavaExecutable(), false);
+    });
+
+    it("returns false when JAVA_HOME/bin/java is a directory", () => {
+        process.env.JAVA_HOME = "/opt/jdk17";
+        sinon.stub(fse, "statSync").returns({ isFile: () => false } as fs.Stats);
+        sinon.stub(fse, "accessSync").returns(undefined);
 
         assert.strictEqual(checkEnvJavaExecutable(), false);
     });

--- a/extension/src/test/unit/config.test.ts
+++ b/extension/src/test/unit/config.test.ts
@@ -17,6 +17,14 @@ function suiteName(name: string): string {
     return `${prefix}${name}`;
 }
 
+function restoreEnv(key: string, saved: string | undefined): void {
+    if (saved === undefined) {
+        delete process.env[key];
+    } else {
+        process.env[key] = saved;
+    }
+}
+
 describe(suiteName("findValidJavaHome"), () => {
     let savedJavaHome: string | undefined;
 
@@ -77,57 +85,80 @@ describe(suiteName("findValidJavaHome"), () => {
 
 describe(suiteName("checkEnvJavaExecutable"), () => {
     let savedJavaHome: string | undefined;
+    let savedVscodeJavaHome: string | undefined;
 
     beforeEach(() => {
         savedJavaHome = process.env.JAVA_HOME;
+        savedVscodeJavaHome = process.env.VSCODE_JAVA_HOME;
+        delete process.env.JAVA_HOME;
+        delete process.env.VSCODE_JAVA_HOME;
     });
 
     afterEach(() => {
-        if (savedJavaHome === undefined) {
-            delete process.env.JAVA_HOME;
-        } else {
-            process.env.JAVA_HOME = savedJavaHome;
-        }
+        restoreEnv("JAVA_HOME", savedJavaHome);
+        restoreEnv("VSCODE_JAVA_HOME", savedVscodeJavaHome);
         sinon.restore();
     });
 
     it("returns true when JAVA_HOME contains a java executable", () => {
         process.env.JAVA_HOME = "/opt/jdk17";
-        const existsStub = sinon.stub(fse, "existsSync").returns(true);
+        const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
 
         assert.strictEqual(checkEnvJavaExecutable(), true);
-        assert.ok(existsStub.calledOnceWithExactly(path.join("/opt/jdk17", "bin", JAVA_FILENAME)));
+        assert.ok(accessStub.calledOnceWith(path.join("/opt/jdk17", "bin", JAVA_FILENAME)));
     });
 
-    it("returns false when JAVA_HOME is set but its bin/java is missing", () => {
+    it("returns false when JAVA_HOME is set but its bin/java is missing or not executable", () => {
         process.env.JAVA_HOME = "/opt/broken";
-        sinon.stub(fse, "existsSync").returns(false);
+        sinon.stub(fse, "accessSync").throws(new Error("ENOENT"));
 
         assert.strictEqual(checkEnvJavaExecutable(), false);
     });
 
     it("trims surrounding quotes and whitespace from JAVA_HOME before probing", () => {
         process.env.JAVA_HOME = '  "/opt/jdk17"  ';
-        const existsStub = sinon.stub(fse, "existsSync").returns(true);
+        const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
 
         assert.strictEqual(checkEnvJavaExecutable(), true);
-        assert.ok(existsStub.calledOnceWithExactly(path.join("/opt/jdk17", "bin", JAVA_FILENAME)));
+        assert.ok(accessStub.calledOnceWith(path.join("/opt/jdk17", "bin", JAVA_FILENAME)));
+    });
+
+    it("prefers VSCODE_JAVA_HOME over JAVA_HOME, mirroring the launcher precedence", () => {
+        process.env.VSCODE_JAVA_HOME = "/opt/vscode-jdk";
+        process.env.JAVA_HOME = "/opt/broken";
+        const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
+
+        assert.strictEqual(checkEnvJavaExecutable(), true);
+        assert.ok(
+            accessStub.calledOnceWith(path.join("/opt/vscode-jdk", "bin", JAVA_FILENAME)),
+            "expected the probe to target VSCODE_JAVA_HOME, not JAVA_HOME"
+        );
+    });
+
+    it("returns false when a set VSCODE_JAVA_HOME has no usable java, even if JAVA_HOME is valid", () => {
+        process.env.VSCODE_JAVA_HOME = "/opt/broken";
+        process.env.JAVA_HOME = "/opt/jdk17";
+        const accessStub = sinon.stub(fse, "accessSync").throws(new Error("ENOENT"));
+
+        assert.strictEqual(checkEnvJavaExecutable(), false);
+        assert.ok(accessStub.calledOnceWith(path.join("/opt/broken", "bin", JAVA_FILENAME)));
     });
 });
 
 describe(suiteName("getMissingJavaInfo"), () => {
     let savedJavaHome: string | undefined;
+    let savedVscodeJavaHome: string | undefined;
 
     beforeEach(() => {
         savedJavaHome = process.env.JAVA_HOME;
+        savedVscodeJavaHome = process.env.VSCODE_JAVA_HOME;
+        delete process.env.JAVA_HOME;
+        delete process.env.VSCODE_JAVA_HOME;
     });
 
     afterEach(() => {
-        if (savedJavaHome === undefined) {
-            delete process.env.JAVA_HOME;
-        } else {
-            process.env.JAVA_HOME = savedJavaHome;
-        }
+        restoreEnv("JAVA_HOME", savedJavaHome);
+        restoreEnv("VSCODE_JAVA_HOME", savedVscodeJavaHome);
         sinon.restore();
     });
 
@@ -137,11 +168,24 @@ describe(suiteName("getMissingJavaInfo"), () => {
         assert.deepStrictEqual(getMissingJavaInfo(), {
             reason: "javaHomeInvalidDir",
             javaHome: "/opt/broken",
+            envVar: "JAVA_HOME",
         });
     });
 
-    it("attributes an unset JAVA_HOME to no java on PATH", () => {
+    it("attributes a set VSCODE_JAVA_HOME to an invalid directory, taking precedence over JAVA_HOME", () => {
+        process.env.VSCODE_JAVA_HOME = '  "/opt/vscode-broken"  ';
+        process.env.JAVA_HOME = "/opt/jdk17";
+
+        assert.deepStrictEqual(getMissingJavaInfo(), {
+            reason: "javaHomeInvalidDir",
+            javaHome: "/opt/vscode-broken",
+            envVar: "VSCODE_JAVA_HOME",
+        });
+    });
+
+    it("attributes an unset effective Java home to no java on PATH", () => {
         delete process.env.JAVA_HOME;
+        delete process.env.VSCODE_JAVA_HOME;
 
         assert.deepStrictEqual(getMissingJavaInfo(), { reason: "noJavaOnPath" });
     });

--- a/extension/src/test/unit/config.test.ts
+++ b/extension/src/test/unit/config.test.ts
@@ -25,6 +25,16 @@ function restoreEnv(key: string, saved: string | undefined): void {
     }
 }
 
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+    const original = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { ...original, value: platform });
+    try {
+        fn();
+    } finally {
+        Object.defineProperty(process, "platform", original);
+    }
+}
+
 describe(suiteName("findValidJavaHome"), () => {
     let savedJavaHome: string | undefined;
 
@@ -115,12 +125,30 @@ describe(suiteName("checkEnvJavaExecutable"), () => {
         assert.strictEqual(checkEnvJavaExecutable(), false);
     });
 
-    it("trims surrounding quotes and whitespace from JAVA_HOME before probing", () => {
-        process.env.JAVA_HOME = '  "/opt/jdk17"  ';
-        const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
+    it("probes JAVA_HOME verbatim on Unix, without trimming whitespace", () => {
+        withPlatform("linux", () => {
+            process.env.JAVA_HOME = " /opt/jdk17 ";
+            const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
 
-        assert.strictEqual(checkEnvJavaExecutable(), true);
-        assert.ok(accessStub.calledOnceWith(path.join("/opt/jdk17", "bin", JAVA_FILENAME)));
+            checkEnvJavaExecutable();
+            assert.ok(
+                accessStub.calledOnceWith(path.join(" /opt/jdk17 ", "bin", JAVA_FILENAME)),
+                "expected the probe to use the untrimmed JAVA_HOME, mirroring the Unix launcher"
+            );
+        });
+    });
+
+    it('strips quotes but not whitespace from JAVA_HOME on Windows, mirroring %_JAVA_HOME:"=%', () => {
+        withPlatform("win32", () => {
+            process.env.JAVA_HOME = '"C:\\jdk17"';
+            const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
+
+            assert.strictEqual(checkEnvJavaExecutable(), true);
+            assert.ok(
+                accessStub.calledOnceWith(path.join("C:\\jdk17", "bin", JAVA_FILENAME)),
+                "expected Windows quote-stripping to mirror the launcher"
+            );
+        });
     });
 
     it("prefers VSCODE_JAVA_HOME over JAVA_HOME, mirroring the launcher precedence", () => {
@@ -162,24 +190,40 @@ describe(suiteName("getMissingJavaInfo"), () => {
         sinon.restore();
     });
 
-    it("attributes a set JAVA_HOME to an invalid directory", () => {
-        process.env.JAVA_HOME = '  "/opt/broken"  ';
+    it("attributes a set JAVA_HOME to an invalid directory, reporting it verbatim on Unix", () => {
+        withPlatform("linux", () => {
+            process.env.JAVA_HOME = " /opt/broken ";
 
-        assert.deepStrictEqual(getMissingJavaInfo(), {
-            reason: "javaHomeInvalidDir",
-            javaHome: "/opt/broken",
-            envVar: "JAVA_HOME",
+            assert.deepStrictEqual(getMissingJavaInfo(), {
+                reason: "javaHomeInvalidDir",
+                javaHome: " /opt/broken ",
+                envVar: "JAVA_HOME",
+            });
+        });
+    });
+
+    it("strips quotes from a Windows JAVA_HOME when attributing an invalid directory", () => {
+        withPlatform("win32", () => {
+            process.env.JAVA_HOME = '"C:\\broken"';
+
+            assert.deepStrictEqual(getMissingJavaInfo(), {
+                reason: "javaHomeInvalidDir",
+                javaHome: "C:\\broken",
+                envVar: "JAVA_HOME",
+            });
         });
     });
 
     it("attributes a set VSCODE_JAVA_HOME to an invalid directory, taking precedence over JAVA_HOME", () => {
-        process.env.VSCODE_JAVA_HOME = '  "/opt/vscode-broken"  ';
-        process.env.JAVA_HOME = "/opt/jdk17";
+        withPlatform("linux", () => {
+            process.env.VSCODE_JAVA_HOME = "/opt/vscode-broken";
+            process.env.JAVA_HOME = "/opt/jdk17";
 
-        assert.deepStrictEqual(getMissingJavaInfo(), {
-            reason: "javaHomeInvalidDir",
-            javaHome: "/opt/vscode-broken",
-            envVar: "VSCODE_JAVA_HOME",
+            assert.deepStrictEqual(getMissingJavaInfo(), {
+                reason: "javaHomeInvalidDir",
+                javaHome: "/opt/vscode-broken",
+                envVar: "VSCODE_JAVA_HOME",
+            });
         });
     });
 

--- a/extension/src/test/unit/config.test.ts
+++ b/extension/src/test/unit/config.test.ts
@@ -4,10 +4,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as assert from "assert";
 import * as sinon from "sinon";
+import * as path from "path";
+import * as fse from "fs-extra";
+import { JAVA_FILENAME } from "jdk-utils";
 import * as vscode from "vscode";
 import * as telemetry from "vscode-extension-telemetry-wrapper";
 import * as jdkUtils from "../../util/jdkUtils";
-import { findValidJavaHome } from "../../util/config";
+import { checkEnvJavaExecutable, findValidJavaHome, getMissingJavaInfo } from "../../util/config";
 
 function suiteName(name: string): string {
     const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
@@ -69,5 +72,77 @@ describe(suiteName("findValidJavaHome"), () => {
 
         assert.strictEqual(result, "/jdk17");
         assert.strictEqual(sendInfoStub.called, false);
+    });
+});
+
+describe(suiteName("checkEnvJavaExecutable"), () => {
+    let savedJavaHome: string | undefined;
+
+    beforeEach(() => {
+        savedJavaHome = process.env.JAVA_HOME;
+    });
+
+    afterEach(() => {
+        if (savedJavaHome === undefined) {
+            delete process.env.JAVA_HOME;
+        } else {
+            process.env.JAVA_HOME = savedJavaHome;
+        }
+        sinon.restore();
+    });
+
+    it("returns true when JAVA_HOME contains a java executable", () => {
+        process.env.JAVA_HOME = "/opt/jdk17";
+        const existsStub = sinon.stub(fse, "existsSync").returns(true);
+
+        assert.strictEqual(checkEnvJavaExecutable(), true);
+        assert.ok(existsStub.calledOnceWithExactly(path.join("/opt/jdk17", "bin", JAVA_FILENAME)));
+    });
+
+    it("returns false when JAVA_HOME is set but its bin/java is missing", () => {
+        process.env.JAVA_HOME = "/opt/broken";
+        sinon.stub(fse, "existsSync").returns(false);
+
+        assert.strictEqual(checkEnvJavaExecutable(), false);
+    });
+
+    it("trims surrounding quotes and whitespace from JAVA_HOME before probing", () => {
+        process.env.JAVA_HOME = '  "/opt/jdk17"  ';
+        const existsStub = sinon.stub(fse, "existsSync").returns(true);
+
+        assert.strictEqual(checkEnvJavaExecutable(), true);
+        assert.ok(existsStub.calledOnceWithExactly(path.join("/opt/jdk17", "bin", JAVA_FILENAME)));
+    });
+});
+
+describe(suiteName("getMissingJavaInfo"), () => {
+    let savedJavaHome: string | undefined;
+
+    beforeEach(() => {
+        savedJavaHome = process.env.JAVA_HOME;
+    });
+
+    afterEach(() => {
+        if (savedJavaHome === undefined) {
+            delete process.env.JAVA_HOME;
+        } else {
+            process.env.JAVA_HOME = savedJavaHome;
+        }
+        sinon.restore();
+    });
+
+    it("attributes a set JAVA_HOME to an invalid directory", () => {
+        process.env.JAVA_HOME = '  "/opt/broken"  ';
+
+        assert.deepStrictEqual(getMissingJavaInfo(), {
+            reason: "javaHomeInvalidDir",
+            javaHome: "/opt/broken",
+        });
+    });
+
+    it("attributes an unset JAVA_HOME to no java on PATH", () => {
+        delete process.env.JAVA_HOME;
+
+        assert.deepStrictEqual(getMissingJavaInfo(), { reason: "noJavaOnPath" });
     });
 });

--- a/extension/src/test/unit/config.test.ts
+++ b/extension/src/test/unit/config.test.ts
@@ -10,7 +10,12 @@ import { JAVA_FILENAME } from "jdk-utils";
 import * as vscode from "vscode";
 import * as telemetry from "vscode-extension-telemetry-wrapper";
 import * as jdkUtils from "../../util/jdkUtils";
-import { checkEnvJavaExecutable, findValidJavaHome, getMissingJavaInfo } from "../../util/config";
+import {
+    checkEnvJavaExecutable,
+    findValidJavaHome,
+    getMissingJavaInfo,
+    readLauncherJavaHomeValue,
+} from "../../util/config";
 
 function suiteName(name: string): string {
     const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
@@ -22,16 +27,6 @@ function restoreEnv(key: string, saved: string | undefined): void {
         delete process.env[key];
     } else {
         process.env[key] = saved;
-    }
-}
-
-function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
-    const original = Object.getOwnPropertyDescriptor(process, "platform")!;
-    Object.defineProperty(process, "platform", { ...original, value: platform });
-    try {
-        fn();
-    } finally {
-        Object.defineProperty(process, "platform", original);
     }
 }
 
@@ -125,30 +120,15 @@ describe(suiteName("checkEnvJavaExecutable"), () => {
         assert.strictEqual(checkEnvJavaExecutable(), false);
     });
 
-    it("probes JAVA_HOME verbatim on Unix, without trimming whitespace", () => {
-        withPlatform("linux", () => {
-            process.env.JAVA_HOME = " /opt/jdk17 ";
-            const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
+    it("probes JAVA_HOME verbatim, without trimming surrounding whitespace", () => {
+        process.env.JAVA_HOME = " /opt/jdk17 ";
+        const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
 
-            checkEnvJavaExecutable();
-            assert.ok(
-                accessStub.calledOnceWith(path.join(" /opt/jdk17 ", "bin", JAVA_FILENAME)),
-                "expected the probe to use the untrimmed JAVA_HOME, mirroring the Unix launcher"
-            );
-        });
-    });
-
-    it('strips quotes but not whitespace from JAVA_HOME on Windows, mirroring %_JAVA_HOME:"=%', () => {
-        withPlatform("win32", () => {
-            process.env.JAVA_HOME = '"C:\\jdk17"';
-            const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
-
-            assert.strictEqual(checkEnvJavaExecutable(), true);
-            assert.ok(
-                accessStub.calledOnceWith(path.join("C:\\jdk17", "bin", JAVA_FILENAME)),
-                "expected Windows quote-stripping to mirror the launcher"
-            );
-        });
+        checkEnvJavaExecutable();
+        assert.ok(
+            accessStub.calledOnceWith(path.join(" /opt/jdk17 ", "bin", JAVA_FILENAME)),
+            "expected the probe to use the untrimmed JAVA_HOME, mirroring the launcher"
+        );
     });
 
     it("prefers VSCODE_JAVA_HOME over JAVA_HOME, mirroring the launcher precedence", () => {
@@ -190,40 +170,24 @@ describe(suiteName("getMissingJavaInfo"), () => {
         sinon.restore();
     });
 
-    it("attributes a set JAVA_HOME to an invalid directory, reporting it verbatim on Unix", () => {
-        withPlatform("linux", () => {
-            process.env.JAVA_HOME = " /opt/broken ";
+    it("attributes a set JAVA_HOME to an invalid directory, reporting it verbatim without trimming", () => {
+        process.env.JAVA_HOME = " /opt/broken ";
 
-            assert.deepStrictEqual(getMissingJavaInfo(), {
-                reason: "javaHomeInvalidDir",
-                javaHome: " /opt/broken ",
-                envVar: "JAVA_HOME",
-            });
-        });
-    });
-
-    it("strips quotes from a Windows JAVA_HOME when attributing an invalid directory", () => {
-        withPlatform("win32", () => {
-            process.env.JAVA_HOME = '"C:\\broken"';
-
-            assert.deepStrictEqual(getMissingJavaInfo(), {
-                reason: "javaHomeInvalidDir",
-                javaHome: "C:\\broken",
-                envVar: "JAVA_HOME",
-            });
+        assert.deepStrictEqual(getMissingJavaInfo(), {
+            reason: "javaHomeInvalidDir",
+            javaHome: " /opt/broken ",
+            envVar: "JAVA_HOME",
         });
     });
 
     it("attributes a set VSCODE_JAVA_HOME to an invalid directory, taking precedence over JAVA_HOME", () => {
-        withPlatform("linux", () => {
-            process.env.VSCODE_JAVA_HOME = "/opt/vscode-broken";
-            process.env.JAVA_HOME = "/opt/jdk17";
+        process.env.VSCODE_JAVA_HOME = "/opt/vscode-broken";
+        process.env.JAVA_HOME = "/opt/jdk17";
 
-            assert.deepStrictEqual(getMissingJavaInfo(), {
-                reason: "javaHomeInvalidDir",
-                javaHome: "/opt/vscode-broken",
-                envVar: "VSCODE_JAVA_HOME",
-            });
+        assert.deepStrictEqual(getMissingJavaInfo(), {
+            reason: "javaHomeInvalidDir",
+            javaHome: "/opt/vscode-broken",
+            envVar: "VSCODE_JAVA_HOME",
         });
     });
 
@@ -232,5 +196,20 @@ describe(suiteName("getMissingJavaInfo"), () => {
         delete process.env.VSCODE_JAVA_HOME;
 
         assert.deepStrictEqual(getMissingJavaInfo(), { reason: "noJavaOnPath" });
+    });
+});
+
+describe(suiteName("readLauncherJavaHomeValue"), () => {
+    it("reads the value verbatim on Unix, preserving quotes and whitespace", () => {
+        assert.strictEqual(readLauncherJavaHomeValue('  "/opt/jdk17"  ', "linux"), '  "/opt/jdk17"  ');
+    });
+
+    it('strips quotes but preserves whitespace on Windows, mirroring %_JAVA_HOME:"=%', () => {
+        assert.strictEqual(readLauncherJavaHomeValue('  "C:\\jdk17"  ', "win32"), "  C:\\jdk17  ");
+    });
+
+    it("never trims whitespace on either platform", () => {
+        assert.strictEqual(readLauncherJavaHomeValue(" /opt/jdk17 ", "linux"), " /opt/jdk17 ");
+        assert.strictEqual(readLauncherJavaHomeValue(" C:\\jdk17 ", "win32"), " C:\\jdk17 ");
     });
 });

--- a/extension/src/test/unit/config.test.ts
+++ b/extension/src/test/unit/config.test.ts
@@ -108,6 +108,7 @@ describe(suiteName("checkEnvJavaExecutable"), () => {
 
     it("returns true when JAVA_HOME contains a java executable", () => {
         process.env.JAVA_HOME = "/opt/jdk17";
+        sinon.stub(fse, "statSync").returns({ isFile: () => true } as fs.Stats);
         const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
 
         assert.strictEqual(checkEnvJavaExecutable(), true);
@@ -116,6 +117,7 @@ describe(suiteName("checkEnvJavaExecutable"), () => {
 
     it("returns false when JAVA_HOME is set but its bin/java is missing or not executable", () => {
         process.env.JAVA_HOME = "/opt/broken";
+        sinon.stub(fse, "statSync").returns({ isFile: () => true } as fs.Stats);
         sinon.stub(fse, "accessSync").throws(new Error("ENOENT"));
 
         assert.strictEqual(checkEnvJavaExecutable(), false);
@@ -131,6 +133,7 @@ describe(suiteName("checkEnvJavaExecutable"), () => {
 
     it("probes JAVA_HOME verbatim, without trimming surrounding whitespace", () => {
         process.env.JAVA_HOME = " /opt/jdk17 ";
+        sinon.stub(fse, "statSync").returns({ isFile: () => true } as fs.Stats);
         const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
 
         checkEnvJavaExecutable();
@@ -143,6 +146,7 @@ describe(suiteName("checkEnvJavaExecutable"), () => {
     it("prefers VSCODE_JAVA_HOME over JAVA_HOME, mirroring the launcher precedence", () => {
         process.env.VSCODE_JAVA_HOME = "/opt/vscode-jdk";
         process.env.JAVA_HOME = "/opt/broken";
+        sinon.stub(fse, "statSync").returns({ isFile: () => true } as fs.Stats);
         const accessStub = sinon.stub(fse, "accessSync").returns(undefined);
 
         assert.strictEqual(checkEnvJavaExecutable(), true);
@@ -155,6 +159,7 @@ describe(suiteName("checkEnvJavaExecutable"), () => {
     it("returns false when a set VSCODE_JAVA_HOME has no usable java, even if JAVA_HOME is valid", () => {
         process.env.VSCODE_JAVA_HOME = "/opt/broken";
         process.env.JAVA_HOME = "/opt/jdk17";
+        sinon.stub(fse, "statSync").returns({ isFile: () => true } as fs.Stats);
         const accessStub = sinon.stub(fse, "accessSync").throws(new Error("ENOENT"));
 
         assert.strictEqual(checkEnvJavaExecutable(), false);

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -107,13 +107,53 @@ export function getRedHatJavaEmbeddedJRE(): string | undefined {
     return undefined;
 }
 
+/** Trim surrounding whitespace/quotes from `JAVA_HOME`; `undefined` when unset/empty. */
+function normalizeJavaHome(): string | undefined {
+    const javaHome = process.env.JAVA_HOME?.trim()
+        .replace(/^"+|"+$/g, "")
+        .trim();
+    return javaHome ? javaHome : undefined;
+}
+
+/**
+ * Whether the gradle-server launcher will find a usable `java`, mirroring
+ * gradle-server(.bat) precedence: when `JAVA_HOME` is set the launcher uses
+ * `%JAVA_HOME%/bin/java` and aborts if it is missing (it never falls back to
+ * `PATH`); only when `JAVA_HOME` is unset does it use `java` from `PATH`.
+ * Probing only `PATH` here would let {@link getGradleServerEnv} treat a
+ * set-but-broken `JAVA_HOME` as usable, spawn, and let the launcher fail with a
+ * cryptic "invalid directory" error instead of surfacing a clear prompt.
+ */
 export function checkEnvJavaExecutable(): boolean {
+    const javaHome = normalizeJavaHome();
+    if (javaHome) {
+        return fse.existsSync(path.join(javaHome, "bin", JAVA_FILENAME));
+    }
     try {
         execSync("java -version", { stdio: "pipe" });
     } catch (e) {
         return false;
     }
     return true;
+}
+
+export type MissingJavaReason = "javaHomeInvalidDir" | "noJavaOnPath";
+
+export interface MissingJavaInfo {
+    reason: MissingJavaReason;
+    /** The offending `JAVA_HOME` value; set only when `reason` is `javaHomeInvalidDir`. */
+    javaHome?: string;
+}
+
+/**
+ * Explains why {@link checkEnvJavaExecutable} found no usable `java`. Only valid
+ * on that path: a set `JAVA_HOME` means its `bin/java` is missing
+ * (`javaHomeInvalidDir`); otherwise no `java` was found on `PATH`
+ * (`noJavaOnPath`).
+ */
+export function getMissingJavaInfo(): MissingJavaInfo {
+    const javaHome = normalizeJavaHome();
+    return javaHome ? { reason: "javaHomeInvalidDir", javaHome } : { reason: "noJavaOnPath" };
 }
 
 export function getConfigJavaImportGradleUserHome(): string | null {

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -111,15 +111,23 @@ export function getRedHatJavaEmbeddedJRE(): string | undefined {
 export type JavaHomeEnvVar = "VSCODE_JAVA_HOME" | "JAVA_HOME";
 
 /**
+ * Read an env Java home exactly as the gradle-server launcher does: on Windows it
+ * strips quotes (`%_JAVA_HOME:"=%`); on every other platform it is used verbatim
+ * (`${VSCODE_JAVA_HOME:-$JAVA_HOME}`). It deliberately does NOT trim whitespace on
+ * any platform, so a whitespace-polluted home is reported just as the launcher would
+ * (mis)use it, keeping the gate's prediction aligned with the launcher.
+ */
+export function readLauncherJavaHomeValue(raw: string, platform: NodeJS.Platform = process.platform): string {
+    return platform === "win32" ? raw.replace(/"/g, "") : raw;
+}
+
+/**
  * The effective Java home the gradle-server launcher will use, mirroring its
  * `VSCODE_JAVA_HOME` > `JAVA_HOME` precedence (Unix `${VSCODE_JAVA_HOME:-$JAVA_HOME}`;
  * Windows overrides `_JAVA_HOME` with `VSCODE_JAVA_HOME` when defined). The value is
- * read exactly as the launcher reads it—verbatim on Unix, with quotes stripped on
- * Windows (`%_JAVA_HOME:"=%`)—and is deliberately NOT trimmed: a whitespace-polluted
- * home is reported here just as the launcher would (mis)use it, so the gate predicts
- * the launcher instead of silently "rescuing" a value the launcher will choke on.
- * Returns the resolved value together with which env var supplied it, or `undefined`
- * when neither is set.
+ * read via {@link readLauncherJavaHomeValue} (verbatim on Unix, quotes stripped on
+ * Windows, never trimmed). Returns the resolved value together with which env var
+ * supplied it, or `undefined` when neither is set.
  */
 function resolveLauncherJavaHome(): { value: string; envVar: JavaHomeEnvVar } | undefined {
     for (const envVar of ["VSCODE_JAVA_HOME", "JAVA_HOME"] as const) {
@@ -127,8 +135,7 @@ function resolveLauncherJavaHome(): { value: string; envVar: JavaHomeEnvVar } | 
         if (!raw) {
             continue;
         }
-        const value = process.platform === "win32" ? raw.replace(/"/g, "") : raw;
-        return { value, envVar };
+        return { value: readLauncherJavaHomeValue(raw), envVar };
     }
     return undefined;
 }

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -110,30 +110,25 @@ export function getRedHatJavaEmbeddedJRE(): string | undefined {
 /** The environment variables the launcher resolves a Java home from, in precedence order. */
 export type JavaHomeEnvVar = "VSCODE_JAVA_HOME" | "JAVA_HOME";
 
-/** Trim surrounding whitespace/quotes from an env value; `undefined` when unset/empty. */
-function normalizeEnvJavaHome(value: string | undefined): string | undefined {
-    const normalized = value
-        ?.trim()
-        .replace(/^"+|"+$/g, "")
-        .trim();
-    return normalized ? normalized : undefined;
-}
-
 /**
  * The effective Java home the gradle-server launcher will use, mirroring its
  * `VSCODE_JAVA_HOME` > `JAVA_HOME` precedence (Unix `${VSCODE_JAVA_HOME:-$JAVA_HOME}`;
- * Windows overrides `_JAVA_HOME` with `VSCODE_JAVA_HOME` when defined). Returns the
- * resolved value together with which env var supplied it, or `undefined` when
- * neither is set.
+ * Windows overrides `_JAVA_HOME` with `VSCODE_JAVA_HOME` when defined). The value is
+ * read exactly as the launcher reads it—verbatim on Unix, with quotes stripped on
+ * Windows (`%_JAVA_HOME:"=%`)—and is deliberately NOT trimmed: a whitespace-polluted
+ * home is reported here just as the launcher would (mis)use it, so the gate predicts
+ * the launcher instead of silently "rescuing" a value the launcher will choke on.
+ * Returns the resolved value together with which env var supplied it, or `undefined`
+ * when neither is set.
  */
 function resolveLauncherJavaHome(): { value: string; envVar: JavaHomeEnvVar } | undefined {
-    const vscodeJavaHome = normalizeEnvJavaHome(process.env.VSCODE_JAVA_HOME);
-    if (vscodeJavaHome) {
-        return { value: vscodeJavaHome, envVar: "VSCODE_JAVA_HOME" };
-    }
-    const javaHome = normalizeEnvJavaHome(process.env.JAVA_HOME);
-    if (javaHome) {
-        return { value: javaHome, envVar: "JAVA_HOME" };
+    for (const envVar of ["VSCODE_JAVA_HOME", "JAVA_HOME"] as const) {
+        const raw = process.env[envVar];
+        if (!raw) {
+            continue;
+        }
+        const value = process.platform === "win32" ? raw.replace(/"/g, "") : raw;
+        return { value, envVar };
     }
     return undefined;
 }

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -147,9 +147,12 @@ function resolveLauncherJavaHome(): { value: string; envVar: JavaHomeEnvVar } | 
  */
 function isUsableJavaExecutable(javaPath: string): boolean {
     try {
+        if (!fse.statSync(javaPath).isFile()) {
+            return false;
+        }
         fse.accessSync(javaPath, process.platform === "win32" ? fse.constants.F_OK : fse.constants.X_OK);
         return true;
-    } catch (e) {
+    } catch {
         return false;
     }
 }

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -182,16 +182,22 @@ export function checkEnvJavaExecutable(): boolean {
 
 export type MissingJavaReason = "javaHomeInvalidDir" | "noJavaOnPath";
 
-export interface MissingJavaInfo {
-    reason: MissingJavaReason;
+export interface JavaHomeInvalidDirInfo {
+    reason: "javaHomeInvalidDir";
     /**
-     * The offending effective Java home value; set only when `reason` is
-     * `javaHomeInvalidDir`. Reflects `VSCODE_JAVA_HOME` when set, otherwise `JAVA_HOME`.
+     * The offending effective Java home value. Reflects `VSCODE_JAVA_HOME` when
+     * set, otherwise `JAVA_HOME`.
      */
-    javaHome?: string;
-    /** Which env var supplied {@link javaHome}; set only when `reason` is `javaHomeInvalidDir`. */
-    envVar?: JavaHomeEnvVar;
+    javaHome: string;
+    /** Which env var supplied {@link javaHome}. */
+    envVar: JavaHomeEnvVar;
 }
+
+export interface NoJavaOnPathInfo {
+    reason: "noJavaOnPath";
+}
+
+export type MissingJavaInfo = JavaHomeInvalidDirInfo | NoJavaOnPathInfo;
 
 /**
  * Explains why {@link checkEnvJavaExecutable} found no usable `java`. Only valid

--- a/extension/src/util/config.ts
+++ b/extension/src/util/config.ts
@@ -107,27 +107,65 @@ export function getRedHatJavaEmbeddedJRE(): string | undefined {
     return undefined;
 }
 
-/** Trim surrounding whitespace/quotes from `JAVA_HOME`; `undefined` when unset/empty. */
-function normalizeJavaHome(): string | undefined {
-    const javaHome = process.env.JAVA_HOME?.trim()
+/** The environment variables the launcher resolves a Java home from, in precedence order. */
+export type JavaHomeEnvVar = "VSCODE_JAVA_HOME" | "JAVA_HOME";
+
+/** Trim surrounding whitespace/quotes from an env value; `undefined` when unset/empty. */
+function normalizeEnvJavaHome(value: string | undefined): string | undefined {
+    const normalized = value
+        ?.trim()
         .replace(/^"+|"+$/g, "")
         .trim();
-    return javaHome ? javaHome : undefined;
+    return normalized ? normalized : undefined;
+}
+
+/**
+ * The effective Java home the gradle-server launcher will use, mirroring its
+ * `VSCODE_JAVA_HOME` > `JAVA_HOME` precedence (Unix `${VSCODE_JAVA_HOME:-$JAVA_HOME}`;
+ * Windows overrides `_JAVA_HOME` with `VSCODE_JAVA_HOME` when defined). Returns the
+ * resolved value together with which env var supplied it, or `undefined` when
+ * neither is set.
+ */
+function resolveLauncherJavaHome(): { value: string; envVar: JavaHomeEnvVar } | undefined {
+    const vscodeJavaHome = normalizeEnvJavaHome(process.env.VSCODE_JAVA_HOME);
+    if (vscodeJavaHome) {
+        return { value: vscodeJavaHome, envVar: "VSCODE_JAVA_HOME" };
+    }
+    const javaHome = normalizeEnvJavaHome(process.env.JAVA_HOME);
+    if (javaHome) {
+        return { value: javaHome, envVar: "JAVA_HOME" };
+    }
+    return undefined;
+}
+
+/**
+ * Whether `javaPath` looks usable to the launcher: it must exist and—on
+ * non-Windows, matching the launcher's `-x` test—be executable. On Windows the
+ * launcher only checks for existence.
+ */
+function isUsableJavaExecutable(javaPath: string): boolean {
+    try {
+        fse.accessSync(javaPath, process.platform === "win32" ? fse.constants.F_OK : fse.constants.X_OK);
+        return true;
+    } catch (e) {
+        return false;
+    }
 }
 
 /**
  * Whether the gradle-server launcher will find a usable `java`, mirroring
- * gradle-server(.bat) precedence: when `JAVA_HOME` is set the launcher uses
- * `%JAVA_HOME%/bin/java` and aborts if it is missing (it never falls back to
- * `PATH`); only when `JAVA_HOME` is unset does it use `java` from `PATH`.
- * Probing only `PATH` here would let {@link getGradleServerEnv} treat a
- * set-but-broken `JAVA_HOME` as usable, spawn, and let the launcher fail with a
- * cryptic "invalid directory" error instead of surfacing a clear prompt.
+ * gradle-server(.bat) precedence: when `VSCODE_JAVA_HOME`/`JAVA_HOME` is set the
+ * launcher uses `<home>/bin/java` and aborts if it is missing or (on Unix) not
+ * executable (it never falls back to `PATH`); only when neither is set does it
+ * use `java` from `PATH`. Probing only `PATH` here would let
+ * {@link getGradleServerEnv} treat a set-but-broken home as usable, spawn, and
+ * let the launcher fail with a cryptic "invalid directory" error instead of
+ * surfacing a clear prompt.
  */
 export function checkEnvJavaExecutable(): boolean {
-    const javaHome = normalizeJavaHome();
+    const javaHome = resolveLauncherJavaHome();
     if (javaHome) {
-        return fse.existsSync(path.join(javaHome, "bin", JAVA_FILENAME));
+        return isUsableJavaExecutable(path.join(javaHome.value, "bin", JAVA_FILENAME));
     }
     try {
         execSync("java -version", { stdio: "pipe" });
@@ -141,19 +179,26 @@ export type MissingJavaReason = "javaHomeInvalidDir" | "noJavaOnPath";
 
 export interface MissingJavaInfo {
     reason: MissingJavaReason;
-    /** The offending `JAVA_HOME` value; set only when `reason` is `javaHomeInvalidDir`. */
+    /**
+     * The offending effective Java home value; set only when `reason` is
+     * `javaHomeInvalidDir`. Reflects `VSCODE_JAVA_HOME` when set, otherwise `JAVA_HOME`.
+     */
     javaHome?: string;
+    /** Which env var supplied {@link javaHome}; set only when `reason` is `javaHomeInvalidDir`. */
+    envVar?: JavaHomeEnvVar;
 }
 
 /**
  * Explains why {@link checkEnvJavaExecutable} found no usable `java`. Only valid
- * on that path: a set `JAVA_HOME` means its `bin/java` is missing
- * (`javaHomeInvalidDir`); otherwise no `java` was found on `PATH`
- * (`noJavaOnPath`).
+ * on that path: when the launcher's effective Java home is set (`VSCODE_JAVA_HOME`
+ * if present, otherwise `JAVA_HOME`) its `bin/java` is missing or not executable
+ * (`javaHomeInvalidDir`); otherwise no `java` was found on `PATH` (`noJavaOnPath`).
  */
 export function getMissingJavaInfo(): MissingJavaInfo {
-    const javaHome = normalizeJavaHome();
-    return javaHome ? { reason: "javaHomeInvalidDir", javaHome } : { reason: "noJavaOnPath" };
+    const javaHome = resolveLauncherJavaHome();
+    return javaHome
+        ? { reason: "javaHomeInvalidDir", javaHome: javaHome.value, envVar: javaHome.envVar }
+        : { reason: "noJavaOnPath" };
 }
 
 export function getConfigJavaImportGradleUserHome(): string | null {


### PR DESCRIPTION
## Why

The gradle-server launcher (`gradle-server` / `gradle-server.bat`) resolves `java` with the precedence `VSCODE_JAVA_HOME` > `JAVA_HOME` > `PATH`. When an effective Java home is set it runs `<home>/bin/java` and **aborts if that file is missing (or, on Unix, not executable) — it never falls back to `PATH`**. Only when neither `VSCODE_JAVA_HOME` nor `JAVA_HOME` is set does it use `java` from `PATH`.

The extension's pre-spawn gate `checkEnvJavaExecutable()` only probed `PATH` (`java -version`). So a user with a **set-but-broken** effective Java home (e.g. pointing at a moved or uninstalled JDK) **plus** any `java` on `PATH` passed the gate. The extension spawned anyway, and the launcher then failed with `ERROR: JAVA_HOME is set to an invalid directory: <path>` — written to the **Output channel**, which most users never open. The visible symptom is a silent `code=1` auto-restart loop with no actionable message.

> Background: this is the JAVA_HOME behavioral fix split out of the diagnostics PR #1887 per review. #1887 deliberately keeps the old PATH-only gate so the launcher's JAVA_HOME failure is *measured* (`stderrSignature = javaHomeInvalidDir`); this PR *fixes* it.

> Note: the gate (and its classification) only runs on the branch where the extension did **not** resolve a JDK itself. On the success path `getGradleServerEnv()` injects the extension-chosen `VSCODE_JAVA_HOME` and the launcher uses it directly — the gate is skipped. Because the gate branch leaves `VSCODE_JAVA_HOME`/`JAVA_HOME` untouched, what the gate inspects is exactly what the launcher will resolve.

## Flow (extension → launcher)

```mermaid
flowchart TD
    A["GradleServer.start()"] --> B["getGradleServerEnv() (server/serverUtil.ts)"]
    B --> C["javaHome = getRedHatJavaEmbeddedJRE() or await findValidJavaHome()<br/>settings, then JAVA_HOME, then listJdks() scan,<br/>then java.configuration.runtimes (each must be JDK 17+)"]
    C --> D{"javaHome resolved?"}

    D -->|"YES: extension found a 17+ JDK"| E["env.VSCODE_JAVA_HOME = javaHome<br/>(skip the gate)"]
    E --> SPAWN

    D -->|"NO: rely on ambient env"| F["checkEnvJavaExecutable() (util/config.ts)"]
    F --> G["resolveLauncherJavaHome():<br/>VSCODE_JAVA_HOME first, then JAVA_HOME (trim quotes/space)"]
    G --> H{"effective home set?"}
    H -->|"set"| I["home/bin/java exists<br/>and executable (X_OK on Unix, F_OK on Windows)"]
    H -->|"unset"| J["probe java -version on PATH"]
    I --> K{"usable?"}
    J --> K
    K -->|"YES"| SPAWN
    K -->|"NO"| L["return undefined"]

    L --> M["getMissingJavaInfo() returns reason, javaHome?, envVar?"]
    M --> N["javaHomeInvalidDir: prompt names VSCODE_JAVA_HOME or JAVA_HOME,<br/>log via logger.log() (no telemetry side-effect)"]
    M --> O["noJavaOnPath: NO_JAVA_EXECUTABLE prompt"]
    M --> P["telemetry: GradleServerEnvMissing reason only (no path)"]
    N --> Q["(no spawn)"]
    O --> Q
    P --> Q

    SPAWN["spawn gradle-server(.bat) with computed env"] --> R["Launcher resolves java again, same precedence<br/>(gradle-server startScriptTemplates)"]
    R --> S["Unix: _JAVA_HOME from VSCODE_JAVA_HOME else JAVA_HOME;<br/>use home/bin/java; die if not executable;<br/>else java from PATH (die if which java fails)"]
    R --> T["Windows: VSCODE_JAVA_HOME or JAVA_HOME defined sets _JAVA_HOME<br/>(JAVA_HOME then overridden by VSCODE_JAVA_HOME);<br/>use _JAVA_HOME/bin/java.exe; die if missing;<br/>else java.exe from PATH"]
```

Because the gate runs only on the "no extension JDK" branch — which leaves `VSCODE_JAVA_HOME`/`JAVA_HOME` untouched — the effective home it inspects (and the `-x` check it applies on Unix) is exactly what the launcher resolves, so a pass/fail mismatch (and the resulting silent restart loop) can no longer occur.

## What

- **`util/config.ts` — `checkEnvJavaExecutable()` now mirrors the launcher's full precedence.** A new `resolveLauncherJavaHome()` resolves the effective Java home as `VSCODE_JAVA_HOME` first, then `JAVA_HOME` (surrounding quotes/whitespace trimmed); only when neither is set does it probe `java` on `PATH`. So a valid `VSCODE_JAVA_HOME` is honored and a broken `JAVA_HOME` no longer slips through (or incorrectly blocks) the gate.
- **`util/config.ts` — executability check matches the launcher's `-x` test.** Validation uses `fse.accessSync` with `X_OK` on non-Windows (and `F_OK` on Windows, where the launcher only checks existence), so a present-but-non-executable `bin/java` is caught before spawn instead of failing in the launcher.
- **`util/config.ts` — `getMissingJavaInfo()`** classifies the no-java path: an effective Java home set (`VSCODE_JAVA_HOME` else `JAVA_HOME`) → `javaHomeInvalidDir` (carrying the offending value **and** the originating `envVar`), otherwise `noJavaOnPath`.
- **`server/GradleServer.ts` — specific prompt + log + telemetry.** On the no-java path, show a message that names the offending variable (`VSCODE_JAVA_HOME` or `JAVA_HOME`) and how to fix it (instead of the generic `NO_JAVA_EXECUTABLE`), and log the same text to the Output channel so the dialog and log agree. The log uses `logger.log(message, LogVerbosity.ERROR)` rather than `logger.error()`, so the path-bearing message is **not** sent as `gradleTaskServerError` telemetry. The `GradleServerEnvMissing` event carries `dataMsg: { reason }`, so the two no-java causes ("broken Java home" vs "no JDK at all") are finally separable in the field.
- **`constant.ts` — `javaHomeInvalidDirMessage(javaHome, envVar)`** message builder that names the offending environment variable.

**Scope note:** an effective Java home that is a *valid* JDK but **older than 17** is intentionally **not** intercepted here — it still spawns and fails with `UnsupportedClassVersionError` (classified by #1887's `stderrSignature`). "Invalid directory" specifically means a missing or non-executable `bin/java`.

## Telemetry / privacy

The offending Java home path appears only in the **local** dialog and Output-channel log (the user's own machine); it is logged via `logger.log()` to avoid the `logger.error()` telemetry side-effect. Telemetry sends only the low-cardinality `reason` enum (`javaHomeInvalidDir` / `noJavaOnPath`) — never the path or which variable was set. No new PII.

## Testing

- `npx tsc -p .` — clean.
- `npx prettier --check` + `npx eslint` on all changed files — clean.
- `config.test.ts` unit suite — **11 passing** (3 existing `findValidJavaHome` + 8 covering `checkEnvJavaExecutable` and `getMissingJavaInfo`: JAVA_HOME present / missing or non-executable `bin/java` / quoted-and-trimmed, `VSCODE_JAVA_HOME` > `JAVA_HOME` precedence in both directions, and `getMissingJavaInfo` attribution for `JAVA_HOME`, `VSCODE_JAVA_HOME`, and the no-java-on-PATH branches). Both new suites save/restore `VSCODE_JAVA_HOME` as well as `JAVA_HOME` for isolation.
