### PR TITLE
fix(transport): reject in-flight requests on pipe close; add cancellation, large-output & BSP coverage

### DIFF
--- a/extension/src/bs/BspProxy.ts
+++ b/extension/src/bs/BspProxy.ts
@@ -58,38 +58,7 @@ export class BspProxy {
         if (!importerConnection || !buildServerConnection) {
             return;
         }
-        importerConnection.onRequest((method, params) => {
-            if (params !== null) {
-                return buildServerConnection.sendRequest(method, params);
-            }
-            return buildServerConnection.sendRequest(method);
-        });
-
-        buildServerConnection.onNotification((method, params) => {
-            if (params !== null) {
-                return importerConnection.sendNotification(method, params);
-            }
-            importerConnection.sendNotification(method);
-        });
-        importerConnection.onError(([error]) => {
-            this.logger.error(`Error on importerConnection: ${error.message}`);
-            sendInfo("", {
-                kind: "bspProxy-importerConnectionError",
-                message: error.message,
-                proxyErrorStack: error.stack ? error.stack.toString() : "",
-            });
-            // TODO: Implement more specific error handling logic here
-        });
-
-        buildServerConnection.onError(([error]) => {
-            this.logger.error(`Error on buildServerConnection: ${error.message}`);
-            sendInfo("", {
-                kind: "bspProxy-buildServerConnectionError",
-                message: error.message,
-                proxyErrorStack: error.stack ? error.stack.toString() : "",
-            });
-            // TODO: Implement more specific error handling logic here
-        });
+        forwardBspMessages(importerConnection, buildServerConnection, this.logger);
     }
     public setBuildServerStarted(started: boolean): void {
         this.buildServerStart = started;
@@ -104,4 +73,48 @@ export class BspProxy {
         }
         this.logger.info("Build Server connection closed");
     }
+}
+
+/**
+ * Wires bidirectional JSON-RPC forwarding between the JDT LS importer connection
+ * and the build server connection: importer requests are proxied to the build
+ * server (and its reply returned), and build server notifications are proxied
+ * back to the importer. Extracted from {@link BspProxy} so the forwarding
+ * contract can be unit tested without standing up real named pipes.
+ */
+export function forwardBspMessages(
+    importerConnection: rpc.MessageConnection,
+    buildServerConnection: rpc.MessageConnection,
+    logger: Logger
+): void {
+    importerConnection.onRequest((method, params) => {
+        if (params !== null) {
+            return buildServerConnection.sendRequest(method, params);
+        }
+        return buildServerConnection.sendRequest(method);
+    });
+
+    buildServerConnection.onNotification((method, params) => {
+        if (params !== null) {
+            return importerConnection.sendNotification(method, params);
+        }
+        importerConnection.sendNotification(method);
+    });
+    importerConnection.onError(([error]) => {
+        logger.error(`Error on importerConnection: ${error.message}`);
+        sendInfo("", {
+            kind: "bspProxy-importerConnectionError",
+            message: error.message,
+            proxyErrorStack: error.stack ? error.stack.toString() : "",
+        });
+    });
+
+    buildServerConnection.onError(([error]) => {
+        logger.error(`Error on buildServerConnection: ${error.message}`);
+        sendInfo("", {
+            kind: "bspProxy-buildServerConnectionError",
+            message: error.message,
+            proxyErrorStack: error.stack ? error.stack.toString() : "",
+        });
+    });
 }

--- a/extension/src/bs/BspProxy.ts
+++ b/extension/src/bs/BspProxy.ts
@@ -88,14 +88,17 @@ export function forwardBspMessages(
     logger: Logger
 ): void {
     importerConnection.onRequest((method, params) => {
-        if (params !== null) {
+        // `params` is `undefined` (not `null`) for a no-params request; forwarding
+        // it verbatim would serialize `params: [null]` instead of omitting params
+        // and change the wire shape, so treat both as "no params".
+        if (params !== null && params !== undefined) {
             return buildServerConnection.sendRequest(method, params);
         }
         return buildServerConnection.sendRequest(method);
     });
 
     buildServerConnection.onNotification((method, params) => {
-        if (params !== null) {
+        if (params !== null && params !== undefined) {
             return importerConnection.sendNotification(method, params);
         }
         importerConnection.sendNotification(method);

--- a/extension/src/test/integration/gradle/extension.test.ts
+++ b/extension/src/test/integration/gradle/extension.test.ts
@@ -136,6 +136,35 @@ describe(getSuiteName("Extension"), () => {
             await api.runTask(runTaskOpts);
             assert.ok(hasMessage);
         });
+
+        it("should stream large task output over the pipe without truncation", async () => {
+            assert.ok(extension);
+            const api = extension.exports as ExtensionApi;
+            const lineCount = 10000;
+            let buffer = "";
+            const runTaskOpts: RunTaskOpts = {
+                projectFolder: fixturePath.fsPath,
+                taskName: "printLots",
+                showOutputColors: false,
+                onOutput: (output: Output): void => {
+                    buffer += new util.TextDecoder("utf-8").decode(output.getOutputBytes_asU8());
+                },
+            };
+            await api.runTask(runTaskOpts);
+
+            // Concatenating every streamed chunk must reconstruct the byte stream
+            // exactly: all lines present, none dropped by backpressure, tail intact.
+            const matches = buffer.match(/printLots-line-\d+/g) || [];
+            assert.strictEqual(
+                matches.length,
+                lineCount,
+                `expected ${lineCount} streamed output lines, received ${matches.length}`
+            );
+            assert.ok(
+                buffer.includes(`printLots-line-${lineCount - 1}`),
+                "the final streamed output line must not be truncated"
+            );
+        });
     });
 
     describe("Task cancellation", () => {

--- a/extension/src/test/integration/gradle/extension.test.ts
+++ b/extension/src/test/integration/gradle/extension.test.ts
@@ -138,6 +138,71 @@ describe(getSuiteName("Extension"), () => {
         });
     });
 
+    describe("Task cancellation", () => {
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it("should cancel a running task over the pipe transport", async () => {
+            assert.ok(extension);
+            const api = extension.exports as ExtensionApi;
+            const loggerAppendLineSpy = sinon.spy(extension.exports.getLogger(), "appendLine");
+
+            let started = false;
+            let finished = false;
+            const cancellationKey = "integration-test-cancel-longRunning";
+            const runOpts: RunTaskOpts = {
+                projectFolder: fixturePath.fsPath,
+                taskName: "longRunning",
+                showOutputColors: false,
+                cancellationKey,
+                onOutput: (output: Output): void => {
+                    const message = new util.TextDecoder("utf-8").decode(output.getOutputBytes_asU8());
+                    if (message.includes("longRunning started")) {
+                        started = true;
+                    }
+                    if (message.includes("longRunning finished")) {
+                        finished = true;
+                    }
+                },
+            };
+
+            // Start the task but do not await completion — we want to cancel it mid-flight.
+            const runPromise = api.runTask(runOpts);
+
+            // Wait until the task action is actually executing on the server (its
+            // "started" marker has streamed back over the pipe) before cancelling.
+            const startDeadline = Date.now() + 25 * 1000;
+            while (!started && Date.now() < startDeadline) {
+                await sleep(500);
+            }
+            assert.ok(started, "the long-running task should have started before being cancelled");
+
+            // Cancel over the same transport using the matching cancellation key.
+            await api.cancelRunTask({
+                projectFolder: fixturePath.fsPath,
+                taskName: "longRunning",
+                cancellationKey,
+            });
+
+            // The run must settle because the server streams a terminal CANCELLED
+            // reply back over the pipe — not because the task's full sleep elapsed.
+            await runPromise.catch(() => undefined);
+
+            // Transport-level proof: the cancel request reached the server, it
+            // cancelled the build, and the CANCELLED terminal reply travelled back
+            // over the pipe to the client.
+            assert.ok(
+                loggerAppendLineSpy.calledWith(sinon.match("Build cancelled: longRunning")),
+                "expected the server to stream a CANCELLED reply back over the pipe"
+            );
+
+            // Semantic proof: the build was interrupted before completion, so the
+            // task's post-sleep marker must never have streamed back.
+            assert.ok(!finished, "a cancelled task must not run to completion");
+        });
+    });
+
     describe("Reuse terminals config", () => {
         const resetConfig = async (): Promise<void> =>
             await vscode.workspace.getConfiguration("gradle").update("reuseTerminals", "off");

--- a/extension/src/test/integration/gradle/extension.test.ts
+++ b/extension/src/test/integration/gradle/extension.test.ts
@@ -142,12 +142,15 @@ describe(getSuiteName("Extension"), () => {
             const api = extension.exports as ExtensionApi;
             const lineCount = 10000;
             let buffer = "";
+            // Reuse a single decoder across every streamed chunk rather than
+            // allocating one per callback — the 10k-line fixture fires this often.
+            const decoder = new util.TextDecoder("utf-8");
             const runTaskOpts: RunTaskOpts = {
                 projectFolder: fixturePath.fsPath,
                 taskName: "printLots",
                 showOutputColors: false,
                 onOutput: (output: Output): void => {
-                    buffer += new util.TextDecoder("utf-8").decode(output.getOutputBytes_asU8());
+                    buffer += decoder.decode(output.getOutputBytes_asU8());
                 },
             };
             await api.runTask(runTaskOpts);
@@ -198,6 +201,13 @@ describe(getSuiteName("Extension"), () => {
 
             // Start the task but do not await completion — we want to cancel it mid-flight.
             const runPromise = api.runTask(runOpts);
+            // Attach a handler immediately so an early launch failure surfaces as a
+            // settled result here, not as an unhandled rejection during the ~25s wait
+            // for the "started" marker below (which would flake unrelated CI runs).
+            const runSettled = runPromise.then(
+                () => true,
+                () => true
+            );
 
             // Wait until the task action is actually executing on the server (its
             // "started" marker has streamed back over the pipe) before cancelling.
@@ -219,13 +229,7 @@ describe(getSuiteName("Extension"), () => {
             // elapsed. Race against a tight deadline so a cancellation regression
             // fails fast here instead of burning the whole Mocha timeout per matrix leg.
             const settleDeadlineMs = 15 * 1000;
-            const settled = await Promise.race([
-                runPromise.then(
-                    () => true,
-                    () => true
-                ),
-                sleep(settleDeadlineMs).then(() => false),
-            ]);
+            const settled = await Promise.race([runSettled, sleep(settleDeadlineMs).then(() => false)]);
             assert.ok(settled, "the cancelled run must settle promptly over the pipe, not hang");
 
             // Transport-level proof: the cancel request reached the server, it

--- a/extension/src/test/integration/gradle/extension.test.ts
+++ b/extension/src/test/integration/gradle/extension.test.ts
@@ -186,17 +186,22 @@ describe(getSuiteName("Extension"), () => {
             // Reuse a single decoder across streamed chunks, consistent with the
             // large-output test above, rather than allocating one per callback.
             const decoder = new util.TextDecoder("utf-8");
+            // Accumulate decoded output before matching: the server flushes on
+            // ByteBufferOutputStream.flush(), so flush boundaries need not align
+            // with line boundaries and a marker can be split across two chunks.
+            // Searching per-chunk would miss a split marker and flake.
+            let outputSoFar = "";
             const runOpts: RunTaskOpts = {
                 projectFolder: fixturePath.fsPath,
                 taskName: "longRunning",
                 showOutputColors: false,
                 cancellationKey,
                 onOutput: (output: Output): void => {
-                    const message = decoder.decode(output.getOutputBytes_asU8());
-                    if (message.includes("longRunning started")) {
+                    outputSoFar += decoder.decode(output.getOutputBytes_asU8());
+                    if (outputSoFar.includes("longRunning started")) {
                         started = true;
                     }
-                    if (message.includes("longRunning finished")) {
+                    if (outputSoFar.includes("longRunning finished")) {
                         finished = true;
                     }
                 },

--- a/extension/src/test/integration/gradle/extension.test.ts
+++ b/extension/src/test/integration/gradle/extension.test.ts
@@ -183,13 +183,16 @@ describe(getSuiteName("Extension"), () => {
             let started = false;
             let finished = false;
             const cancellationKey = "integration-test-cancel-longRunning";
+            // Reuse a single decoder across streamed chunks, consistent with the
+            // large-output test above, rather than allocating one per callback.
+            const decoder = new util.TextDecoder("utf-8");
             const runOpts: RunTaskOpts = {
                 projectFolder: fixturePath.fsPath,
                 taskName: "longRunning",
                 showOutputColors: false,
                 cancellationKey,
                 onOutput: (output: Output): void => {
-                    const message = new util.TextDecoder("utf-8").decode(output.getOutputBytes_asU8());
+                    const message = decoder.decode(output.getOutputBytes_asU8());
                     if (message.includes("longRunning started")) {
                         started = true;
                     }

--- a/extension/src/test/integration/gradle/extension.test.ts
+++ b/extension/src/test/integration/gradle/extension.test.ts
@@ -214,9 +214,19 @@ describe(getSuiteName("Extension"), () => {
                 cancellationKey,
             });
 
-            // The run must settle because the server streams a terminal CANCELLED
-            // reply back over the pipe — not because the task's full sleep elapsed.
-            await runPromise.catch(() => undefined);
+            // The run must settle promptly because the server streams a terminal
+            // CANCELLED reply back over the pipe — not because the task's full sleep
+            // elapsed. Race against a tight deadline so a cancellation regression
+            // fails fast here instead of burning the whole Mocha timeout per matrix leg.
+            const settleDeadlineMs = 15 * 1000;
+            const settled = await Promise.race([
+                runPromise.then(
+                    () => true,
+                    () => true
+                ),
+                sleep(settleDeadlineMs).then(() => false),
+            ]);
+            assert.ok(settled, "the cancelled run must settle promptly over the pipe, not hang");
 
             // Transport-level proof: the cancel request reached the server, it
             // cancelled the build, and the CANCELLED terminal reply travelled back

--- a/extension/src/test/unit/bs/BspProxy.test.ts
+++ b/extension/src/test/unit/bs/BspProxy.test.ts
@@ -1,0 +1,123 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as assert from "assert";
+import { PassThrough } from "stream";
+import {
+    createMessageConnection,
+    MessageConnection,
+    StreamMessageReader,
+    StreamMessageWriter,
+} from "vscode-jsonrpc/node";
+import { forwardBspMessages } from "../../../bs/BspProxy";
+import { Logger } from "../../../logger";
+import { buildMockOutputChannel } from "../../testUtil";
+
+function suiteName(name: string): string {
+    const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
+    return `${prefix}${name}`;
+}
+
+/**
+ * Wire two `MessageConnection`s back-to-back over in-memory `PassThrough`
+ * streams so both endpoints are live and can exchange real JSON-RPC traffic.
+ */
+function connectionPair(): { a: MessageConnection; b: MessageConnection; dispose: () => void } {
+    const aToB = new PassThrough();
+    const bToA = new PassThrough();
+    const a = createMessageConnection(new StreamMessageReader(bToA), new StreamMessageWriter(aToB));
+    const b = createMessageConnection(new StreamMessageReader(aToB), new StreamMessageWriter(bToA));
+    return {
+        a,
+        b,
+        dispose: (): void => {
+            try {
+                a.dispose();
+            } catch {
+                /* ignore */
+            }
+            try {
+                b.dispose();
+            } catch {
+                /* ignore */
+            }
+            aToB.destroy();
+            bToA.destroy();
+        },
+    };
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate() && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    if (!predicate()) {
+        throw new Error("condition was not met within the timeout");
+    }
+}
+
+describe(suiteName("BspProxy message forwarding"), () => {
+    // The proxy sits between the JDT LS importer and the build server, each of
+    // which connects over its own named pipe. Model that with two connection
+    // pairs: the importer client <-> the proxy's importer-side connection, and
+    // the proxy's build-server-side connection <-> the build server.
+    let importerPair: ReturnType<typeof connectionPair>;
+    let buildServerPair: ReturnType<typeof connectionPair>;
+    let logger: Logger;
+
+    beforeEach(() => {
+        importerPair = connectionPair();
+        buildServerPair = connectionPair();
+        logger = new Logger();
+        logger.setLoggingChannel(buildMockOutputChannel());
+    });
+
+    afterEach(() => {
+        importerPair.dispose();
+        buildServerPair.dispose();
+    });
+
+    function startForwarding(): {
+        importerClient: MessageConnection;
+        buildServer: MessageConnection;
+    } {
+        const importerClient = importerPair.a;
+        const importerConnection = importerPair.b;
+        const buildServerConnection = buildServerPair.a;
+        const buildServer = buildServerPair.b;
+
+        forwardBspMessages(importerConnection, buildServerConnection, logger);
+
+        importerClient.listen();
+        importerConnection.listen();
+        buildServerConnection.listen();
+        buildServer.listen();
+
+        return { importerClient, buildServer };
+    }
+
+    it("forwards importer requests to the build server and returns the reply", async () => {
+        const { importerClient, buildServer } = startForwarding();
+
+        buildServer.onRequest("build/initialize", (params: any) => {
+            return { ok: true, echo: params };
+        });
+
+        const reply = await importerClient.sendRequest("build/initialize", { rootUri: "file:///ws" });
+
+        assert.deepStrictEqual(reply, { ok: true, echo: { rootUri: "file:///ws" } });
+    });
+
+    it("forwards build server notifications back to the importer", async () => {
+        const received: any[] = [];
+        const { buildServer } = startForwarding();
+        const importerClient = importerPair.a;
+        importerClient.onNotification("build/logMessage", (params: any) => {
+            received.push(params);
+        });
+
+        buildServer.sendNotification("build/logMessage", { message: "compiling" });
+
+        await waitFor(() => received.length === 1);
+        assert.deepStrictEqual(received[0], { message: "compiling" });
+    });
+});

--- a/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
+++ b/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
@@ -367,20 +367,5 @@ describe(suiteName("GradleJsonRpcClient transport"), () => {
                 }
             );
         });
-
-        it("rejects an in-flight streaming request when the transport dies mid-build", async () => {
-            // The server never answers, so the runBuild request is still in flight
-            // when the gradle-server socket dies underneath it.
-            const inFlight = client.runBuild(new RunBuildRequest(), () => {
-                /* no stream replies expected */
-            });
-            // Let the request reach the wire, then sever the transport.
-            await new Promise((resolve) => setImmediate(resolve));
-            wired.killTransport();
-
-            // The pending call must settle as a handled rejection rather than
-            // hanging forever or leaking an unhandled write-after-destroy error.
-            await assert.rejects(inFlight);
-        });
     });
 });

--- a/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
+++ b/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
@@ -375,12 +375,31 @@ describe(suiteName("GradleJsonRpcClient transport"), () => {
             // terminated every pending call with a status error rather than
             // leaving it to hang. Holding the request open also avoids the server
             // auto-replying "method not found" onto the torn-down stream.
-            wired.server.onRequest(RUN_BUILD, () => new Promise<never>(() => undefined));
+            let onServerReceived!: () => void;
+            const serverReceived = new Promise<void>((resolve) => {
+                onServerReceived = resolve;
+            });
+            wired.server.onRequest(RUN_BUILD, () => {
+                onServerReceived();
+                return new Promise<never>(() => undefined);
+            });
             const inFlight = client.runBuild(new RunBuildRequest(), () => {
                 /* no stream replies expected */
             });
-            // Let the request reach the wire, then sever the transport.
-            await new Promise((resolve) => setImmediate(resolve));
+
+            // Sever the transport only once the server has provably received the
+            // request, so the call is genuinely pending — a bare setImmediate could
+            // race ahead of delivery and let the test pass without ever exercising
+            // the in-flight-hang path. The timeout guards a handshake that never fires.
+            let handshakeTimer: NodeJS.Timeout | undefined;
+            const handshakeTimeout = new Promise<never>((_, reject) => {
+                handshakeTimer = setTimeout(
+                    () => reject(new Error("server never received the in-flight runBuild request")),
+                    2000
+                );
+            });
+            await Promise.race([serverReceived, handshakeTimeout]);
+            clearTimeout(handshakeTimer);
             wired.killTransport();
 
             // The pending call must settle as a handled rejection rather than

--- a/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
+++ b/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
@@ -367,5 +367,20 @@ describe(suiteName("GradleJsonRpcClient transport"), () => {
                 }
             );
         });
+
+        it("rejects an in-flight streaming request when the transport dies mid-build", async () => {
+            // The server never answers, so the runBuild request is still in flight
+            // when the gradle-server socket dies underneath it.
+            const inFlight = client.runBuild(new RunBuildRequest(), () => {
+                /* no stream replies expected */
+            });
+            // Let the request reach the wire, then sever the transport.
+            await new Promise((resolve) => setImmediate(resolve));
+            wired.killTransport();
+
+            // The pending call must settle as a handled rejection rather than
+            // hanging forever or leaking an unhandled write-after-destroy error.
+            await assert.rejects(inFlight);
+        });
     });
 });

--- a/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
+++ b/extension/src/test/unit/transport/GradleJsonRpcClient.test.ts
@@ -367,5 +367,25 @@ describe(suiteName("GradleJsonRpcClient transport"), () => {
                 }
             );
         });
+
+        it("rejects an in-flight streaming request when the transport dies mid-build", async () => {
+            // The server accepts the request but never answers (mid-build), so the
+            // runBuild call is still in flight when the gradle-server socket dies
+            // underneath it. Parity with the old gRPC transport, whose channel
+            // terminated every pending call with a status error rather than
+            // leaving it to hang. Holding the request open also avoids the server
+            // auto-replying "method not found" onto the torn-down stream.
+            wired.server.onRequest(RUN_BUILD, () => new Promise<never>(() => undefined));
+            const inFlight = client.runBuild(new RunBuildRequest(), () => {
+                /* no stream replies expected */
+            });
+            // Let the request reach the wire, then sever the transport.
+            await new Promise((resolve) => setImmediate(resolve));
+            wired.killTransport();
+
+            // The pending call must settle as a handled rejection rather than
+            // hanging forever or leaking an unhandled write-after-destroy error.
+            await assert.rejects(inFlight);
+        });
     });
 });

--- a/extension/src/transport/jsonrpc/GradleJsonRpcClient.ts
+++ b/extension/src/transport/jsonrpc/GradleJsonRpcClient.ts
@@ -17,7 +17,7 @@ import {
     RunBuildRequest,
 } from "../../proto/gradle_pb";
 import { decodeProto, encodeProto } from "./protoCodec";
-import { toGradleRpcError } from "./JsonRpcErrors";
+import { GradleRpcError, toGradleRpcError } from "./JsonRpcErrors";
 import { nextStreamId } from "./streamId";
 import { GradleRequestParams, GradleResponse, GradleStreamPayload } from "./types";
 
@@ -63,6 +63,7 @@ export class GradleJsonRpcClient implements Disposable {
     private readonly runBuildSinks = new Map<number, StreamSink<RunBuildReply>>();
     private readonly disposables: Disposable[] = [];
     private readonly _onClosed = new Emitter<Error | undefined>();
+    private readonly pendingRejecters = new Set<(err: GradleRpcError) => void>();
     private closed = false;
     private lastError: Error | undefined;
 
@@ -153,6 +154,7 @@ export class GradleJsonRpcClient implements Disposable {
 
     public dispose(): void {
         this.closed = true;
+        this.rejectPending(undefined);
         for (const d of this.disposables) {
             try {
                 d.dispose();
@@ -181,7 +183,52 @@ export class GradleJsonRpcClient implements Disposable {
             return;
         }
         this.closed = true;
+        // Restore the gRPC transport's fail-fast semantics: a connection death
+        // (server exit / peer reset) terminated every in-flight call with a
+        // status error. vscode-jsonrpc leaves pending `sendRequest` promises
+        // unsettled on close, so we reject them explicitly here — otherwise an
+        // in-flight `runBuild`/`getBuild` would hang until the user gives up.
+        this.rejectPending(err);
         this._onClosed.fire(err);
+    }
+
+    /**
+     * Reject every request that is still awaiting a response so callers fail
+     * fast instead of hanging when the transport dies underneath them.
+     */
+    private rejectPending(err: Error | undefined): void {
+        if (this.pendingRejecters.size === 0) {
+            return;
+        }
+        const rpcErr = toGradleRpcError(
+            err ?? new Error("Gradle JSON-RPC connection closed before the request completed.")
+        );
+        // Snapshot before iterating: each request's `finally` mutates the set.
+        const rejecters = Array.from(this.pendingRejecters);
+        this.pendingRejecters.clear();
+        for (const reject of rejecters) {
+            reject(rpcErr);
+        }
+    }
+
+    /**
+     * Race the in-flight `sendRequest` against a connection-close signal so a
+     * transport death rejects the pending promise (see {@link rejectPending}).
+     * The close promise only ever rejects while a request is outstanding, and
+     * `Promise.race` always keeps a handler on it, so no unhandled rejection can
+     * escape once the request settles normally.
+     */
+    private async raceAgainstClose<T>(send: Promise<T>): Promise<T> {
+        let rejecter!: (err: GradleRpcError) => void;
+        const closed = new Promise<never>((_, reject) => {
+            rejecter = reject;
+        });
+        this.pendingRejecters.add(rejecter);
+        try {
+            return await Promise.race([send, closed]);
+        } finally {
+            this.pendingRejecters.delete(rejecter);
+        }
     }
 
     /**
@@ -202,10 +249,12 @@ export class GradleJsonRpcClient implements Disposable {
     ): Promise<TReply | null> {
         this.ensureOpen();
         try {
-            const response = await this.connection.sendRequest(type, {
-                request: encodeProto(request.serializeBinary()),
-                streamId: null,
-            });
+            const response = await this.raceAgainstClose(
+                this.connection.sendRequest(type, {
+                    request: encodeProto(request.serializeBinary()),
+                    streamId: null,
+                })
+            );
             return decodeReply(response, deserialize);
         } catch (err) {
             throw toGradleRpcError(err);
@@ -223,10 +272,12 @@ export class GradleJsonRpcClient implements Disposable {
         const streamId = nextStreamId();
         sinkMap.set(streamId, onReply);
         try {
-            const response = await this.connection.sendRequest(type, {
-                request: encodeProto(request.serializeBinary()),
-                streamId,
-            });
+            const response = await this.raceAgainstClose(
+                this.connection.sendRequest(type, {
+                    request: encodeProto(request.serializeBinary()),
+                    streamId,
+                })
+            );
             return decodeReply(response, deserialize);
         } catch (err) {
             throw toGradleRpcError(err);

--- a/extension/test-fixtures/gradle-groovy-custom-build-file/my-custom-build.gradle
+++ b/extension/test-fixtures/gradle-groovy-custom-build-file/my-custom-build.gradle
@@ -28,3 +28,11 @@ tasks.register("helloGroovyCustom") {
         println 'Hello, World!'
     }
 }
+
+tasks.register("longRunning") {
+    doLast {
+        println 'longRunning started'
+        Thread.sleep(20000)
+        println 'longRunning finished'
+    }
+}

--- a/extension/test-fixtures/gradle-groovy-custom-build-file/my-custom-build.gradle
+++ b/extension/test-fixtures/gradle-groovy-custom-build-file/my-custom-build.gradle
@@ -36,3 +36,11 @@ tasks.register("longRunning") {
         println 'longRunning finished'
     }
 }
+
+tasks.register("printLots") {
+    doLast {
+        for (int i = 0; i < 10000; i++) {
+            println "printLots-line-" + i
+        }
+    }
+}

--- a/extension/test-fixtures/gradle-groovy-default-build-file/build.gradle
+++ b/extension/test-fixtures/gradle-groovy-default-build-file/build.gradle
@@ -28,3 +28,11 @@ tasks.register("helloGroovyDefault") {
         println 'Hello, World!'
     }
 }
+
+tasks.register("longRunning") {
+    doLast {
+        println 'longRunning started'
+        Thread.sleep(20000)
+        println 'longRunning finished'
+    }
+}

--- a/extension/test-fixtures/gradle-groovy-default-build-file/build.gradle
+++ b/extension/test-fixtures/gradle-groovy-default-build-file/build.gradle
@@ -36,3 +36,11 @@ tasks.register("longRunning") {
         println 'longRunning finished'
     }
 }
+
+tasks.register("printLots") {
+    doLast {
+        for (int i = 0; i < 10000; i++) {
+            println "printLots-line-" + i
+        }
+    }
+}

--- a/extension/test-fixtures/gradle-kotlin-default-build-file/build.gradle.kts
+++ b/extension/test-fixtures/gradle-kotlin-default-build-file/build.gradle.kts
@@ -30,3 +30,11 @@ tasks.register("helloProjectProperty") {
         println("Hello, Project Property!" + customProp)
     }
 }
+
+tasks.register("longRunning") {
+    doLast {
+        println("longRunning started")
+        Thread.sleep(20000)
+        println("longRunning finished")
+    }
+}

--- a/extension/test-fixtures/gradle-kotlin-default-build-file/build.gradle.kts
+++ b/extension/test-fixtures/gradle-kotlin-default-build-file/build.gradle.kts
@@ -38,3 +38,11 @@ tasks.register("longRunning") {
         println("longRunning finished")
     }
 }
+
+tasks.register("printLots") {
+    doLast {
+        for (i in 0 until 10000) {
+            println("printLots-line-$i")
+        }
+    }
+}


### PR DESCRIPTION
## Why

The migration from gRPC + loopback to JSON-RPC + pipe transport is heading for a one-shot stable cutover. Reviewing the release readiness, the transport's happy path (task execution + streaming stdout) is exercised end-to-end by the existing `gradle` integration suite on all three OSes, but several transport behaviours had **no coverage**, and one turned out to be a genuine parity regression versus the old gRPC channel:

- **Cancellation** only had unit coverage of the RPC wire contract (`GradleJsonRpcClient.test.ts` round-trip, `CancelBuildCommand` wiring). Nothing verified that cancelling a *running* build actually stops it over the pipe.
- **Large-output / backpressure** streaming was untested — a chunk dropped under backpressure would silently truncate task output.
- **The BSP proxy** message-forwarding path had no unit coverage.
- **In-flight request on connection death**: the old gRPC channel terminated every pending RPC with a status error when the connection died (fail-fast). The pipe migration lost this — `vscode-jsonrpc` leaves a pending `sendRequest` unsettled on stream teardown, so an in-flight `runBuild`/`getBuild` would **hang forever** if `gradle-server` died mid-build. This is a real behaviour regression, not new behaviour.

## What

### Tests
- **Cancellation (integration, 3 fixtures × 3 OSes).** Adds a `longRunning` task (prints a `started` marker, sleeps 20s, prints a `finished` marker) to `gradle-groovy-default-build-file`, `gradle-kotlin-default-build-file`, `gradle-groovy-custom-build-file`, and a `Task cancellation` test that:
  1. starts `longRunning` over the pipe (not awaiting completion);
  2. waits until it is genuinely executing on the server (its `started` output streamed back);
  3. cancels it with a matching `cancellationKey`;
  4. asserts the server streamed a **CANCELLED terminal reply back over the pipe** (`Build cancelled: longRunning` logged) — the full round-trip proof;
  5. asserts the post-sleep `finished` marker **never** streamed back;
  6. asserts the run **settles promptly** after cancel (races against a tight deadline) so a cancellation-hang regression fails fast instead of burning the full Mocha timeout per matrix leg.
- **Large-output / backpressure (integration).** Adds a `printLots` task (10000 lines) and a test that concatenates every streamed chunk and asserts all lines are present and the tail is intact (no truncation under backpressure).
- **BSP proxy (unit).** Extracts `forwardBspMessages()` from `BspProxy` and adds `BspProxy.test.ts` covering request and notification forwarding over a paired connection harness.
- **In-flight drop (unit).** Adds a `GradleJsonRpcClient.test.ts` case asserting an in-flight streaming request rejects when the transport dies mid-build.

### Production fix (parity restoration)
- **`GradleJsonRpcClient`** now tracks in-flight request rejecters and rejects them with a typed `GradleRpcError` when the connection closes (`markClosed`) or is disposed, restoring the old gRPC channel's fail-fast semantics. Without this, an in-flight `runBuild`/`getBuild` hangs indefinitely when the pipe dies mid-build. Behaviour on the happy path is unchanged.

## Validation

- `tsc -p .` — 0 errors
- `prettier --check` + `eslint` — clean
- Full **unit** suite runs locally green (108 passing), including the restored in-flight-drop test and the BSP forwarding tests.
- Fixtures execute `longRunning` and `printLots` locally with cached Gradle 8.5 (`BUILD SUCCESSFUL`).

## Not covered (follow-ups)

Still unaddressed by tests: mid-build reconnection after an abnormal drop (the client now fails fast, but does not attempt to reconnect and resume).
