### PR TITLE
build: release 3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the "vscode-gradle" extension will be documented in this 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.18.0
+## What's Changed
+* feat - Discover nested Gradle build files in https://github.com/microsoft/vscode-gradle/pull/1889
+* enhancement - Migrate the Gradle task transport from gRPC to JSON-RPC over a named pipe (Windows) / Unix domain socket (macOS/Linux) in https://github.com/microsoft/vscode-gradle/pull/1863, https://github.com/microsoft/vscode-gradle/pull/1864, https://github.com/microsoft/vscode-gradle/pull/1875
+* enhancement - Load Gradle project dependencies lazily, resolving dependency nodes on expansion in https://github.com/microsoft/vscode-gradle/pull/1831
+* enhancement - Add an XML fallback for Gradle test delegation when BSP delegation is unavailable in https://github.com/microsoft/vscode-gradle/pull/1810
+* fix - Reject in-flight requests when the pipe connection closes, restoring fail-fast parity in https://github.com/microsoft/vscode-gradle/pull/1891
+* fix - Self-heal the JSON-RPC transport with keepalive and bounded auto-restart in https://github.com/microsoft/vscode-gradle/pull/1873
+* fix - Reconnect the task transport without a JVM exit in https://github.com/microsoft/vscode-gradle/pull/1879
+* fix - Prevent gradle-server crashes and add transport disconnect telemetry in https://github.com/microsoft/vscode-gradle/pull/1885
+* fix - Handle JSON-RPC connection death in https://github.com/microsoft/vscode-gradle/pull/1870
+* fix - Surface unexpected Gradle server exits with an actionable notification in https://github.com/microsoft/vscode-gradle/pull/1826
+* fix - Surface a clear prompt when JAVA_HOME points at an invalid directory in https://github.com/microsoft/vscode-gradle/pull/1888
+* fix - Recover from a spurious gRPC CANCELLED on the first Refresh in https://github.com/microsoft/vscode-gradle/pull/1832
+* fix - Create a fresh terminal per task execution so terminal reuse cannot cancel a re-run in https://github.com/microsoft/vscode-gradle/pull/1820
+* fix - Honor JPMS arg type when aggregating classpath attributes in https://github.com/microsoft/vscode-gradle/pull/1886
+* fix - Skip non-classpath artifacts in the BSP importer in https://github.com/microsoft/vscode-gradle/pull/1871
+* fix - Update protobuf-java and guava to address CVEs in https://github.com/microsoft/vscode-gradle/pull/1811
+* fix - Bump brace-expansion to 5.0.6 to address CVE-2026-45149 in https://github.com/microsoft/vscode-gradle/pull/1869
+
 ## 3.17.3
 ## What's Changed
 * perf - Batch BSP calls during import to reduce round-trips from ~4400 to 6 in https://github.com/microsoft/vscode-gradle/pull/1791

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-gradle",
-  "version": "3.17.3",
+  "version": "3.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-gradle",
-      "version": "3.17.3",
+      "version": "3.18.0",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "await-lock": "^2.2.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-gradle",
   "displayName": "Gradle for Java",
   "description": "Manage Gradle Projects, run Gradle tasks and provide better Gradle file authoring experience in VS Code",
-  "version": "3.17.3",
+  "version": "3.18.0",
   "private": true,
   "publisher": "vscjava",
   "aiKey": "b4aae7d0-c65b-4819-92bf-1d2f537ae7ce",


### PR DESCRIPTION
## Why

Cuts a new minor release, **3.18.0**, off the latest `develop`. The headline of this release is the completion of the task-transport migration from **gRPC + TCP loopback** to **JSON-RPC over a named pipe (Windows) / Unix domain socket (macOS/Linux)** — the full chain tracked in #1860 is now shipped, hardened, and covered by parity tests.

## What

- Bumps `extension/package.json` (and `package-lock.json`) `3.17.3` → `3.18.0`.
- Adds the `## 3.18.0` section to `CHANGELOG.md`, following the existing release format.

### Highlights folded into the changelog

**Transport migration (the theme of this release)**
- Replace the gRPC + loopback task server with JSON-RPC over pipe/UDS (#1875, #1863, #1864)
- Reject in-flight requests when the pipe closes, restoring gRPC's fail-fast parity (#1891)
- Self-heal the transport with keepalive + bounded auto-restart, reconnect without a JVM exit, and handle connection death (#1873, #1879, #1870)
- Prevent gradle-server crashes and add transport disconnect telemetry (#1885)

**Other enhancements**
- Discover nested Gradle build files (#1889)
- Load Gradle dependencies lazily (#1831)

**Notable fixes**
- Clear prompt when `JAVA_HOME` points at an invalid directory (#1888)
- Honor JPMS arg type when aggregating classpath attributes (#1886)
- Fresh terminal per task execution (#1820), decouple test delegation from BSP import (#1810)
- Security: update protobuf-java/guava and bump brace-expansion for CVEs (#1811, #1869)

## Notes

- The changelog omits pure dependency bumps (dependabot), CI-only changes, and internal migration cleanup (dead gRPC removal, proto renames), consistent with prior release entries. Happy to fold any of those in if you'd prefer a fuller list.
- `extension/CHANGELOG.md` is a generated/ignored copy, so only the tracked root `CHANGELOG.md` is edited here.
