### PR TITLE
Preserve GRADLE_SERVER_OPTS for Gradle server

### DIFF
--- a/extension/src/server/serverUtil.ts
+++ b/extension/src/server/serverUtil.ts
@@ -20,6 +20,10 @@ export function quoteArg(arg: string): string {
     return `"${arg}"`;
 }
 
+export function appendGradleServerOpts(existingOpts: string | undefined, requiredOpts: string): string {
+    return existingOpts ? `${existingOpts} ${requiredOpts}` : requiredOpts;
+}
+
 export async function getGradleServerEnv(): Promise<ProcessEnv | undefined> {
     const javaHome = getRedHatJavaEmbeddedJRE() || (await findValidJavaHome());
     const env = { ...process.env };
@@ -31,10 +35,12 @@ export async function getGradleServerEnv(): Promise<ProcessEnv | undefined> {
         return undefined;
     }
     if (env["DEBUG_GRADLE_SERVER"] === "true") {
-        env.GRADLE_SERVER_OPTS =
-            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8089 " + GRADLE_SERVER_BASE_JVM_OPTS;
+        env.GRADLE_SERVER_OPTS = appendGradleServerOpts(
+            env.GRADLE_SERVER_OPTS,
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8089 " + GRADLE_SERVER_BASE_JVM_OPTS
+        );
     } else {
-        env.GRADLE_SERVER_OPTS = GRADLE_SERVER_BASE_JVM_OPTS;
+        env.GRADLE_SERVER_OPTS = appendGradleServerOpts(env.GRADLE_SERVER_OPTS, GRADLE_SERVER_BASE_JVM_OPTS);
     }
     return env;
 }

--- a/extension/src/test/unit/serverUtil.test.ts
+++ b/extension/src/test/unit/serverUtil.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as assert from "assert";
+import { GRADLE_SERVER_BASE_JVM_OPTS } from "../../constant";
+import { appendGradleServerOpts } from "../../server/serverUtil";
+
+function suiteName(name: string): string {
+    const prefix = process.env.SUITE_NAME ? `${process.env.SUITE_NAME} - ` : "";
+    return `${prefix}${name}`;
+}
+
+describe(suiteName("appendGradleServerOpts"), () => {
+    it("uses the required opts when no user opts are configured", () => {
+        assert.strictEqual(appendGradleServerOpts(undefined, GRADLE_SERVER_BASE_JVM_OPTS), GRADLE_SERVER_BASE_JVM_OPTS);
+    });
+
+    it("preserves user opts before the required server opts", () => {
+        const userOpts = "-Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort=8888";
+
+        assert.strictEqual(
+            appendGradleServerOpts(userOpts, GRADLE_SERVER_BASE_JVM_OPTS),
+            `${userOpts} ${GRADLE_SERVER_BASE_JVM_OPTS}`
+        );
+    });
+
+    it("preserves user opts before debug and required server opts", () => {
+        const userOpts = "-Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort=8888";
+        const debugOpts =
+            "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=8089 " + GRADLE_SERVER_BASE_JVM_OPTS;
+
+        assert.strictEqual(appendGradleServerOpts(userOpts, debugOpts), `${userOpts} ${debugOpts}`);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #1604.

This preserves user-provided `GRADLE_SERVER_OPTS` when constructing the Gradle server environment, then appends the extension-required JVM options. The same merge path is used for normal startup and `DEBUG_GRADLE_SERVER=true`.

## Validation

- `npm run compile:test`
- `npx prettier --check src/server/serverUtil.ts src/test/unit/serverUtil.test.ts`
- `npx eslint src/server/serverUtil.ts src/test/unit/serverUtil.test.ts --ext .ts`
- `git diff --check`
- `npm run compile`
- `npm test` was attempted. The first unit pass reached `112 passing`; after building `dist`, the rerun reached the unit suite but failed in existing `SafeSocketMessageWriter` transport timing coverage (`expected the framed message to arrive`). The new `appendGradleServerOpts` tests passed in both harness runs.
