### PR TITLE
Report a delegated test run as finished exactly once

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildClient.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildClient.java
@@ -49,6 +49,7 @@ import ch.epfl.scala.bsp4j.TaskDataKind;
 import ch.epfl.scala.bsp4j.TaskFinishParams;
 import ch.epfl.scala.bsp4j.TaskProgressParams;
 import ch.epfl.scala.bsp4j.TaskStartParams;
+import ch.epfl.scala.bsp4j.TestReport;
 import ch.epfl.scala.bsp4j.extended.TestFinishEx;
 import ch.epfl.scala.bsp4j.extended.TestName;
 import ch.epfl.scala.bsp4j.extended.TestStartEx;
@@ -244,13 +245,32 @@ public class GradleBuildClient implements BuildClient {
                 Arrays.asList(testParts, testStatus.getValue(), null, testFinishEx.getStackTrace()))); // TODO: test duration is missing
         } else if (Objects.equals(params.getDataKind(), TaskDataKind.TEST_REPORT)) {
             lsClient.sendNotification(new ExecuteCommandParams("java.gradle.buildServer.onDidFinishTestRun",
-                    Arrays.asList(params.getStatus().getValue(), params.getMessage())));
+                    Arrays.asList(params.getStatus().getValue(), params.getMessage(), getOriginId(params))));
         } else {
             Either<String, Integer> id = Either.forLeft(params.getTaskId().getId());
             WorkDoneProgressEnd workDoneProgressEnd = new WorkDoneProgressEnd();
             workDoneProgressEnd.setMessage(StringUtils.isBlank(params.getMessage()) ? BUILD_SERVER_TASK :
                     BUILD_SERVER_TASK + " - " + params.getMessage());
             lsClient.notifyProgress(new ProgressParams(id, Either.forLeft(workDoneProgressEnd)));
+        }
+    }
+
+    /**
+     * The id the client attached to the test request this report belongs to, or
+     * {@code null} when the build server did not echo one back.
+     *
+     * <p>The client uses it to tell a report for the run it is waiting on from a
+     * report for a run that has already ended.</p>
+     */
+    private String getOriginId(TaskFinishParams params) {
+        if (params.getData() == null) {
+            return null;
+        }
+        try {
+            TestReport testReport = JSONUtility.toModel(params.getData(), TestReport.class);
+            return testReport == null ? null : testReport.getOriginId();
+        } catch (Exception e) {
+            return null;
         }
     }
 

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/handler/GradleDelegateCommandHandler.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/handler/GradleDelegateCommandHandler.java
@@ -23,6 +23,7 @@ import ch.epfl.scala.bsp4j.BuildTargetTag;
 import ch.epfl.scala.bsp4j.ScalaTestSuiteSelection;
 import ch.epfl.scala.bsp4j.ScalaTestSuites;
 import ch.epfl.scala.bsp4j.TestParams;
+import ch.epfl.scala.bsp4j.TestResult;
 
 public class GradleDelegateCommandHandler implements IDelegateCommandHandler {
 
@@ -60,6 +61,7 @@ public class GradleDelegateCommandHandler implements IDelegateCommandHandler {
                     btIds = btIds.subList(0, 1);
                 }
                 TestParams testParams = new TestParams(btIds);
+                testParams.setOriginId(getOriginId(arguments));
                 testParams.setDataKind("scala-test-suites-selection");
                 testParams.setArguments(getArguments(arguments));
                 List<ScalaTestSuiteSelection> testSelections = new LinkedList<>();
@@ -76,12 +78,31 @@ public class GradleDelegateCommandHandler implements IDelegateCommandHandler {
                     getEnvVarPairs(arguments)
                 );
                 testParams.setData(scalaTestSuites);
-                buildServerConnection.buildTargetTest(testParams);
-                return null;
+                // Waiting for the result rather than dispatching and returning is what makes
+                // the end of this request the end of the run. The build server only reports a
+                // run as finished once it has actually started one, so a Gradle version it
+                // cannot drive, a dropped connection or a target with nothing to run would
+                // otherwise leave the client waiting for a report that never comes. It also
+                // keeps any per-run file the client passed in, such as an init script, alive
+                // until Gradle has actually read it.
+                TestResult testResult = buildServerConnection.buildTargetTest(testParams).join();
+                return testResult.getStatusCode().getValue();
             default:
                 break;
         }
         throw new UnsupportedOperationException("The command: " + commandId + "is not supported.");
+    }
+
+    /**
+     * The client's identifier for this test request. The build server echoes it back
+     * on the test report, which is how the client tells a report for the run it is
+     * waiting on from a report for a run that has already ended.
+     */
+    private String getOriginId(List<Object> arguments) {
+        if (arguments.size() < 6 || arguments.get(5) == null) {
+            return null;
+        }
+        return (String) arguments.get(5);
     }
 
     private List<String> getArguments(List<Object> arguments) {

--- a/extension/src/bs/BuildServerController.ts
+++ b/extension/src/bs/BuildServerController.ts
@@ -88,8 +88,8 @@ export class BuildServerController implements Disposable {
             }),
             commands.registerCommand(
                 "java.gradle.buildServer.onDidFinishTestRun",
-                (status: number, message?: string) => {
-                    this.gradleTestRunner?.finishTestRun(status, message);
+                (status: number, message?: string, originId?: string) => {
+                    this.gradleTestRunner?.finishTestRun(status, message, originId);
                 }
             ),
             commands.registerCommand(

--- a/extension/src/bs/GradleTestRunner.ts
+++ b/extension/src/bs/GradleTestRunner.ts
@@ -14,11 +14,26 @@ import { waitOnTcp } from "../util";
 import * as os from "os";
 import * as path from "path";
 
+/** Build server status codes, as reported by BSP's `StatusCode`. */
+const STATUS_CODE_OK = 1;
+const STATUS_CODE_ERROR = 2;
+const STATUS_CODE_CANCELLED = 3;
+
+interface ActiveRun {
+    readonly id: number;
+    readonly originId: string;
+    reported: boolean;
+}
+
 export class GradleTestRunner implements TestRunner {
     private readonly _onDidChangeTestItemStatus = new vscode.EventEmitter<TestItemStatusChangeEvent>();
     private readonly _onDidFinishTestRun = new vscode.EventEmitter<TestFinishEvent>();
     private testRunnerApi: any;
     private bspContext: IRunTestContext | undefined;
+    /** Resolves once the run in flight has been reported as finished. See {@link launch}. */
+    private runChain: Promise<void> = Promise.resolve();
+    private activeRun: ActiveRun | undefined;
+    private runCounter = 0;
 
     public onDidChangeTestItemStatus: vscode.Event<TestItemStatusChangeEvent> = this._onDidChangeTestItemStatus.event;
     public onDidFinishTestRun: vscode.Event<TestFinishEvent> = this._onDidFinishTestRun.event;
@@ -27,16 +42,92 @@ export class GradleTestRunner implements TestRunner {
         this.testRunnerApi = testRunnerApi;
     }
 
+    /**
+     * Runs one test run, once every run requested before it has finished.
+     *
+     * Test results and completion arrive from the build server through
+     * extension-wide commands that carry no run identity, and are resolved
+     * against the single run this class tracks. Two overlapping runs would
+     * therefore report into each other's test items, so runs are queued instead
+     * of interleaved.
+     */
     public async launch(context: IRunTestContext): Promise<void> {
+        const predecessor = this.runChain;
+        const current = predecessor.then(
+            () => this.runQueued(context),
+            () => this.runQueued(context)
+        );
+        // The queue has to survive a failed run, otherwise one failure would block
+        // every run after it.
+        this.runChain = current.catch(() => undefined);
+        return current;
+    }
+
+    private async runQueued(context: IRunTestContext): Promise<void> {
+        const runId = this.beginRun(context);
         try {
-            await this.launchWithBsp(context);
-        } catch (error) {
-            if (!isBspUnavailableError(error)) {
-                this.finishTestRun(-1, getErrorMessage(error));
+            if (context.cancellationToken?.isCancellationRequested) {
+                // Cancelled while queued behind an earlier run, so nothing was launched.
+                this.reportFinished(runId, STATUS_CODE_CANCELLED);
                 return;
             }
-            await this.launchXmlFallback(context);
+            const statusCode = await this.doLaunch(context);
+            // The build server reports a run as finished only once it has actually
+            // started one, so a request that ends without a report still has to end
+            // the run. Reporting is idempotent, so the build server's own report wins
+            // whenever it arrives.
+            this.reportFinished(runId, statusCode);
+        } catch (error) {
+            this.reportFinished(runId, STATUS_CODE_ERROR, getErrorMessage(error));
+        } finally {
+            this.endRun(runId);
         }
+    }
+
+    private async doLaunch(context: IRunTestContext): Promise<number> {
+        try {
+            return await this.launchWithBsp(context);
+        } catch (error) {
+            if (!isBspUnavailableError(error)) {
+                throw error;
+            }
+            await this.launchXmlFallback(context);
+            return STATUS_CODE_OK;
+        }
+    }
+
+    private beginRun(context: IRunTestContext): number {
+        const id = ++this.runCounter;
+        this.activeRun = { id, originId: `vscode-gradle-test-${id}-${Date.now()}`, reported: false };
+        this.bspContext = context;
+        return id;
+    }
+
+    private endRun(id: number): void {
+        if (this.activeRun?.id === id) {
+            this.activeRun = undefined;
+            // Reports that arrive after a run has ended belong to nothing, and
+            // {@link updateTestItem} drops them for want of a context to resolve against.
+            this.bspContext = undefined;
+        }
+    }
+
+    /**
+     * Reports a run as finished, at most once.
+     *
+     * The build server's report and the end of the request race each other, and a
+     * report belonging to a run that has already ended must never close the run
+     * that replaced it.
+     */
+    private reportFinished(id: number, statusCode: number, message?: string): void {
+        if (this.activeRun?.id !== id || this.activeRun.reported) {
+            return;
+        }
+        this.activeRun.reported = true;
+        this._onDidFinishTestRun.fire({
+            statusCode,
+            message,
+        });
     }
 
     public updateTestItem(
@@ -66,8 +157,7 @@ export class GradleTestRunner implements TestRunner {
         });
     }
 
-    private async launchWithBsp(context: IRunTestContext): Promise<void> {
-        this.bspContext = context;
+    private async launchWithBsp(context: IRunTestContext): Promise<number> {
         const tests: Map<string, string[]> = new Map();
         context.testItems.forEach((testItem) => {
             const id = testItem.id;
@@ -97,20 +187,26 @@ export class GradleTestRunner implements TestRunner {
         }
 
         try {
-            await vscode.commands.executeCommand(
+            // The debugger has to be attached while the run is in flight: the request
+            // below now completes only once the tests are over, and the test JVM is
+            // waiting on the debug port until something connects to it.
+            const request = vscode.commands.executeCommand<number | null>(
                 "java.execute.workspaceCommand",
                 "java.gradle.delegateTest",
                 context.projectName,
                 JSON.stringify([...tests]),
                 args,
                 vmArgs,
-                env
+                env,
+                this.activeRun?.originId
             );
             if (isDebug) {
                 this.startJavaDebug(context, debugPort).catch((err) => {
                     console.error("[gradle-test] Failed to attach debugger:", err);
                 });
             }
+            const statusCode = await request;
+            return typeof statusCode === "number" ? statusCode : STATUS_CODE_OK;
         } finally {
             if (testInitScriptPath) {
                 try {
@@ -376,11 +472,16 @@ export class GradleTestRunner implements TestRunner {
         pending.clear();
     }
 
-    public finishTestRun(statusCode: number, message?: string): void {
-        this._onDidFinishTestRun.fire({
-            statusCode,
-            message,
-        });
+    public finishTestRun(statusCode: number, message?: string, originId?: string): void {
+        if (!this.activeRun) {
+            return;
+        }
+        if (originId && originId !== this.activeRun.originId) {
+            // A report for a run that has already ended. Closing the run that replaced
+            // it would report someone else's result and cut its tests short.
+            return;
+        }
+        this.reportFinished(this.activeRun.id, statusCode, message);
     }
 
     private filterStackTrace(stackTrace: string): string {

--- a/extension/src/java-test-runner.api.ts
+++ b/extension/src/java-test-runner.api.ts
@@ -210,6 +210,16 @@ export interface IRunTestContext {
      * The configuration for this test run.
      */
     testConfig?: IExecutionConfig;
+
+    /**
+     * Cancelled when the user cancels the test run. Absent on hosts released
+     * before this member existed, where {@link testRun}'s own token is the
+     * closest equivalent.
+     *
+     * A runner must observe this and must still report the run as finished
+     * afterwards, so a cancelled run releases whatever the runner serializes on.
+     */
+    cancellationToken?: vscode.CancellationToken;
 }
 
 /**

--- a/extension/src/test/unit/GradleTestRunner.test.ts
+++ b/extension/src/test/unit/GradleTestRunner.test.ts
@@ -189,9 +189,134 @@ describe(getSuiteName("Gradle test runner XML fallback"), () => {
         );
 
         assert.strictEqual(client.runBuild.called, false);
-        assert.strictEqual(finishStatus, -1);
+        assert.strictEqual(finishStatus, 2);
     });
 });
+
+describe(getSuiteName("Gradle test runner run lifecycle"), () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it("finishes the run when the build server never reports a result", async () => {
+        // A Gradle version the build server cannot drive, a dropped connection or a
+        // target with nothing to run all end the request without any test report.
+        sinon.stub(vscode.commands, "executeCommand").resolves(2);
+        const testRunnerApi = buildTestRunnerApi();
+        const runner = new GradleTestRunner(testRunnerApi, buildClient());
+        const finishes = captureFinishEvents(runner);
+
+        await runner.launch(buildRunContext(testRunnerApi, [singleTestItem()]));
+
+        assert.deepStrictEqual(finishes, [{ statusCode: 2, message: undefined }]);
+    });
+
+    it("prefers the build server's own report over the end of the request", async () => {
+        const testRunnerApi = buildTestRunnerApi();
+        const runner = new GradleTestRunner(testRunnerApi, buildClient());
+        const finishes = captureFinishEvents(runner);
+        sinon.stub(vscode.commands, "executeCommand").callsFake(async (...args: any[]) => {
+            runner.finishTestRun(2, "3 tests failed", args[7]);
+            return 1;
+        });
+
+        await runner.launch(buildRunContext(testRunnerApi, [singleTestItem()]));
+
+        assert.deepStrictEqual(finishes, [{ statusCode: 2, message: "3 tests failed" }]);
+    });
+
+    it("ignores a report belonging to a run that already ended", async () => {
+        const testRunnerApi = buildTestRunnerApi();
+        const runner = new GradleTestRunner(testRunnerApi, buildClient());
+        sinon.stub(vscode.commands, "executeCommand").resolves(1);
+        await runner.launch(buildRunContext(testRunnerApi, [singleTestItem()]));
+
+        const finishes = captureFinishEvents(runner);
+        let staleReportDelivered = false;
+        sinon.restore();
+        sinon.stub(vscode.commands, "executeCommand").callsFake(async () => {
+            // The previous run's report, arriving while its successor is in flight.
+            runner.finishTestRun(2, "stale", "vscode-gradle-test-stale");
+            staleReportDelivered = true;
+            return 1;
+        });
+
+        await runner.launch(buildRunContext(testRunnerApi, [singleTestItem()]));
+
+        assert.strictEqual(staleReportDelivered, true);
+        assert.deepStrictEqual(finishes, [{ statusCode: 1, message: undefined }]);
+    });
+
+    it("runs one test run at a time", async () => {
+        const testRunnerApi = buildTestRunnerApi();
+        const runner = new GradleTestRunner(testRunnerApi, buildClient());
+        let inFlight = 0;
+        let overlapped = false;
+        sinon.stub(vscode.commands, "executeCommand").callsFake(async () => {
+            overlapped = overlapped || ++inFlight > 1;
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            inFlight--;
+            return 1;
+        });
+
+        await Promise.all([
+            runner.launch(buildRunContext(testRunnerApi, [singleTestItem()])),
+            runner.launch(buildRunContext(testRunnerApi, [singleTestItem()])),
+        ]);
+
+        assert.strictEqual(overlapped, false);
+    });
+
+    it("does not launch a run that was cancelled while queued", async () => {
+        const testRunnerApi = buildTestRunnerApi();
+        const runner = new GradleTestRunner(testRunnerApi, buildClient());
+        const executeCommand = sinon.stub(vscode.commands, "executeCommand").resolves(1);
+        const context = buildRunContext(testRunnerApi, [singleTestItem()]);
+        context.cancellationToken = { isCancellationRequested: true } as vscode.CancellationToken;
+        const finishes = captureFinishEvents(runner);
+
+        await runner.launch(context);
+
+        assert.strictEqual(executeCommand.called, false);
+        // The run still has to be reported, otherwise the queue never advances.
+        assert.deepStrictEqual(finishes, [{ statusCode: 3, message: undefined }]);
+    });
+
+    it("keeps the queue moving after a run fails", async () => {
+        const testRunnerApi = buildTestRunnerApi();
+        const runner = new GradleTestRunner(testRunnerApi, buildClient());
+        const executeCommand = sinon.stub(vscode.commands, "executeCommand");
+        executeCommand.onFirstCall().rejects(new Error("Gradle test execution failed"));
+        executeCommand.onSecondCall().resolves(1);
+        const finishes = captureFinishEvents(runner);
+
+        await runner.launch(buildRunContext(testRunnerApi, [singleTestItem()]));
+        await runner.launch(buildRunContext(testRunnerApi, [singleTestItem()]));
+
+        assert.strictEqual(finishes.length, 2);
+        assert.strictEqual(finishes[0].statusCode, 2);
+        assert.strictEqual(finishes[1].statusCode, 1);
+    });
+});
+
+function singleTestItem(): { id: string; parts: TestIdParts } {
+    return {
+        id: "method",
+        parts: {
+            project: "demo",
+            class: "com.example.AppTest",
+            invocations: ["shouldPass"],
+        },
+    };
+}
+
+function captureFinishEvents(runner: GradleTestRunner): Array<{ statusCode: number; message?: string }> {
+    const finishes: Array<{ statusCode: number; message?: string }> = [];
+    runner.onDidFinishTestRun((event) => {
+        finishes.push({ statusCode: event.statusCode, message: event.message });
+    });
+    return finishes;
+}
 
 function stubBspUnavailable(): void {
     sinon


### PR DESCRIPTION
## Why

A delegated test run could never end.

`GradleDelegateCommandHandler` dispatched `buildTarget/test` and returned immediately, so completion could only reach the client as a `TEST_REPORT` notification. The build server sends that report only once it has actually started a test run, and several paths end the request before that ever happens:

- a Gradle version it cannot drive (`< 2.6`, or `< 3.5` with environment variables) — it logs an error and returns without constructing a `TestReportReporter`
- a `GradleConnectionException` / `IllegalStateException` from the outer connection
- a target with nothing to run

In all of these the client is left waiting for a report that never comes: the spinner never stops and the test run stays pending until the window is reloaded.

Two more problems sit next to it:

- **Overlapping runs cross-report.** Results arrive through extension-wide commands (`java.gradle.buildServer.onDidChangeTestItemStatus` / `onDidFinishTestRun`) that carry no run identity, and are resolved against the single `bspContext` the runner tracks. A second run started while the first is in flight reports into the first one's test items.
- **The init script is deleted while Gradle still needs it.** For debug runs, `launchWithBsp` writes a per-run init script and removes it in a `finally` around the delegate command. Because the command returned on dispatch, the removal raced Gradle actually reading the script.

## What

**Wait for the result.** `GradleDelegateCommandHandler` now joins `buildTargetTest` and returns the BSP status code. The end of the request becomes the authoritative end of the run, so a missing report degrades to a finished run instead of one that never ends. This also keeps the init script alive for the whole run — the debugger is now attached *while* the request is in flight, since the test JVM waits on the debug port for the duration of the run.

**Report exactly once.** `reportFinished` is idempotent, so the build server's own report still wins whenever it arrives, and the request completing is only a backstop.

**Queue runs.** `launch` chains onto the previous run and resolves on completion rather than dispatch. The chain survives a failed run, so one failure cannot block everything after it. A run cancelled while queued is reported without being launched, so the queue still advances.

**Correlate reports with an origin id.** The client attaches one to the test request; the build server already echoes it back on `TestReport`, so `GradleBuildClient` forwards it with the notification. A report belonging to a run that has already ended can no longer close the run that replaced it. Reports without an origin id are still accepted, so nothing regresses against an older build server.

## Notes

- `IRunTestContext.cancellationToken` is added to the mirrored `java-test-runner.api.ts`. It is optional: hosts released before it exists do not set it.
- Status codes on the new paths use BSP's `StatusCode` values, matching what the notification path already sends. The XML fallback keeps its existing codes.

## Testing

- `extension` unit suite: 117 passing, including 6 new cases covering a missing report, report precedence, a stale report arriving during the next run, serialization, cancel-while-queued, and queue recovery after a failure.
- `jdtls.ext` builds clean (`mvn clean package`).
- `tsc`, `eslint` and `prettier` clean.
