### PR TITLE
ci: route ADO pipeline npm restore through CFS feed

### DIFF
--- a/.azure-pipelines/npm-cfs-variables.yml
+++ b/.azure-pipelines/npm-cfs-variables.yml
@@ -1,0 +1,28 @@
+# Variables required to route npm package restore through the Central Feed Service
+# (CFS). Consumed by every pipeline in this directory alongside the npm-cfs.yml steps
+# template, which is where these values are actually applied.
+#
+# Both are declared here rather than in each pipeline so the feed URL exists in
+# exactly one place.
+#
+# npm_config_registry is not redundant with the registry written into the generated
+# .npmrc. This repository commits project level .npmrc files -- extension/.npmrc and
+# npm-package/.npmrc -- that pin registry=https://registry.npmjs.org/ so that outside
+# contributors are unaffected by whatever registry their own environment configures.
+# npm resolves configuration in the order cli > environment > project .npmrc >
+# user .npmrc, so a registry supplied only through the user config is silently
+# outranked by those committed files and restore falls back to the public registry.
+# An environment variable outranks every .npmrc file, so it is the only way to
+# redirect these builds without modifying the working tree.
+#
+# npm matches npm_config_* environment variables case insensitively, so the
+# uppercased form that Azure Pipelines exports applies to every step on every OS.
+# That matters here because most package restore is driven by Gradle rather than by
+# a task -- the `npmInstall` tasks in extension/build.gradle and npm-package/build.gradle
+# shell out to `npm install` and inherit the agent environment.
+
+variables:
+  - name: npm_config_registry
+    value: https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc

--- a/.azure-pipelines/npm-cfs.yml
+++ b/.azure-pipelines/npm-cfs.yml
@@ -1,0 +1,53 @@
+# Single source of truth for routing npm package restore through the Central Feed
+# Service (CFS), as required by SFI Network Isolation. Every build pipeline in this
+# directory consumes this template, so the feed URL is declared exactly once.
+#
+# The .npmrc is generated at build time into the agent temp directory rather than
+# being committed to the repository, so that:
+#   * open source contributors and the GitHub Actions workflows keep restoring from
+#     the public npm registry -- npm rewrites the host of every `resolved` URL in
+#     package-lock.json to the configured registry, so a single lockfile serves both;
+#   * the credential that NpmAuthenticate injects never lands inside the workspace;
+#   * the configuration does not depend on the repository being checked out, so
+#     release jobs consuming a prebuilt artifact work the same way as build jobs.
+#
+# Pipelines consuming this template must also declare the pipeline level variable
+#   npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
+# npm matches npm_config_* environment variables case insensitively, so the
+# uppercased form that Azure Pipelines exports applies to every step on every OS.
+# That matters here because most package restore is driven by Gradle rather than by
+# a task -- the `npmInstall` tasks in extension/build.gradle and npm-package/build.gradle
+# shell out to `npm install`, and inherit the agent environment.
+#
+# The file is written with `npm config set` rather than a shell redirect because the
+# pipelines span both Linux (1ES_JavaTooling_Ubuntu-2004) and Windows
+# (1ES_JavaTooling_Windows_2022) pools. `script:` maps to CmdLine@2, which runs on
+# both, and the npm invocation itself is shell agnostic. PowerShell@2 is avoided
+# because it resolves `pwsh` before `powershell` and hard fails when neither is on
+# PATH, which is not guaranteed on a custom Linux image.
+#
+# This template must run after the Node install task, and before any step that
+# restores packages -- including `npx`, which resolves downloads through the
+# configured registry.
+#
+# Consumers must reference this file as `/.azure-pipelines/npm-cfs.yml@self`. A
+# relative path is resolved against the file doing the including, which for these
+# pipelines is the 1ES extends template in another repository, so the unqualified
+# form is looked up in 1ESPipelineTemplates and fails YAML compilation.
+
+parameters:
+  - name: npmrcPath
+    type: string
+    default: $(Agent.TempDirectory)/.npmrc
+
+steps:
+  - script: npm config set registry https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/ --location=user --userconfig="${{ parameters.npmrcPath }}"
+    displayName: Configure CFS npm registry
+
+  # Appends `//pkgs.dev.azure.com/.../registry/:_authToken=<token>` for every registry
+  # it finds in the file above. `always-auth` is deliberately not written: it is not
+  # read by this task and is rejected outright by the npm 10 shipped with Node 20.
+  - task: NpmAuthenticate@0
+    displayName: Authenticate to CFS feed
+    inputs:
+      workingFile: ${{ parameters.npmrcPath }}

--- a/.azure-pipelines/npm-cfs.yml
+++ b/.azure-pipelines/npm-cfs.yml
@@ -1,23 +1,24 @@
-# Single source of truth for routing npm package restore through the Central Feed
-# Service (CFS), as required by SFI Network Isolation. Every build pipeline in this
-# directory consumes this template, so the feed URL is declared exactly once.
+# Routes npm package restore through the Central Feed Service (CFS), as required by
+# SFI Network Isolation. Consumed by every build pipeline in this directory.
+#
+# Pipelines must also include the companion variables template:
+#   variables:
+#     - template: /.azure-pipelines/npm-cfs-variables.yml@self
+# which declares the feed URL and the generated .npmrc path. The redirect itself is
+# carried by the npm_config_registry environment variable that template exports; see
+# its header for why the generated .npmrc alone is not enough in this repository.
 #
 # The .npmrc is generated at build time into the agent temp directory rather than
-# being committed to the repository, so that:
+# being committed, so that:
 #   * open source contributors and the GitHub Actions workflows keep restoring from
-#     the public npm registry -- npm rewrites the host of every `resolved` URL in
-#     package-lock.json to the configured registry, so a single lockfile serves both;
+#     the public npm registry;
 #   * the credential that NpmAuthenticate injects never lands inside the workspace;
 #   * the configuration does not depend on the repository being checked out, so
 #     release jobs consuming a prebuilt artifact work the same way as build jobs.
 #
-# Pipelines consuming this template must also declare the pipeline level variable
-#   npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
-# npm matches npm_config_* environment variables case insensitively, so the
-# uppercased form that Azure Pipelines exports applies to every step on every OS.
-# That matters here because most package restore is driven by Gradle rather than by
-# a task -- the `npmInstall` tasks in extension/build.gradle and npm-package/build.gradle
-# shell out to `npm install`, and inherit the agent environment.
+# The registry is still written into that file because NpmAuthenticate discovers the
+# registries to authenticate by reading it. npm then takes the URL from the
+# environment and the matching credential from this file.
 #
 # The file is written with `npm config set` rather than a shell redirect because the
 # pipelines span both Linux (1ES_JavaTooling_Ubuntu-2004) and Windows
@@ -35,13 +36,8 @@
 # pipelines is the 1ES extends template in another repository, so the unqualified
 # form is looked up in 1ESPipelineTemplates and fails YAML compilation.
 
-parameters:
-  - name: npmrcPath
-    type: string
-    default: $(Agent.TempDirectory)/.npmrc
-
 steps:
-  - script: npm config set registry https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/ --location=user --userconfig="${{ parameters.npmrcPath }}"
+  - script: npm config set registry $(npm_config_registry) --location=user --userconfig="$(npm_config_userconfig)"
     displayName: Configure CFS npm registry
 
   # Appends `//pkgs.dev.azure.com/.../registry/:_authToken=<token>` for every registry
@@ -50,4 +46,15 @@ steps:
   - task: NpmAuthenticate@0
     displayName: Authenticate to CFS feed
     inputs:
-      workingFile: ${{ parameters.npmrcPath }}
+      workingFile: $(npm_config_userconfig)
+
+  # Restore silently falling back to the public registry is the failure mode this
+  # whole template exists to prevent, and it leaves no trace in the build log, so it
+  # is asserted rather than assumed. The check runs from the directory that actually
+  # restores packages, because that is where a project level .npmrc would apply.
+  # Written in node, which the preceding Node install task guarantees, to avoid
+  # shell differences between the Linux and Windows pools.
+  - script: |
+      node -e "const fs=require('fs'),cp=require('child_process');const dir=fs.existsSync('extension/package.json')?'extension':'.';const r=cp.execSync('npm config get registry',{cwd:dir}).toString().trim();console.log('npm registry in '+dir+' -> '+r);if(!r.startsWith('https://pkgs.dev.azure.com/')){console.error('##vso[task.logissue type=error]npm is not configured against the CFS feed');process.exit(1);}"
+    displayName: Verify CFS npm registry
+    workingDirectory: $(Build.SourcesDirectory)

--- a/.azure-pipelines/release/release-nightly.yml
+++ b/.azure-pipelines/release/release-nightly.yml
@@ -9,8 +9,7 @@ parameters:
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/release/release-nightly.yml
+++ b/.azure-pipelines/release/release-nightly.yml
@@ -9,6 +9,8 @@ parameters:
 variables:
   - name: Codeql.Enabled
     value: true
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -52,6 +54,7 @@ extends:
                 displayName: 'Use Node.js 20.x'
                 inputs:
                   version: '20.x'
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - bash: 'npm install -g @vscode/vsce'
                 displayName: 'Bash Script'
 

--- a/.azure-pipelines/release/release-rc.yml
+++ b/.azure-pipelines/release/release-rc.yml
@@ -3,8 +3,7 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/release/release-rc.yml
+++ b/.azure-pipelines/release/release-rc.yml
@@ -3,6 +3,8 @@ name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - name: Codeql.Enabled
     value: true
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -41,6 +43,7 @@ extends:
                 displayName: 'Use Node.js 20.x'
                 inputs:
                   version: '20.x'
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - bash: 'npm install -g @vscode/vsce'
                 displayName: 'Bash Script'
 

--- a/.azure-pipelines/vscode-gradle-apiscan.yml
+++ b/.azure-pipelines/vscode-gradle-apiscan.yml
@@ -1,4 +1,7 @@
 name: $(Date:yyyyMMdd).$(Rev:r)
+variables:
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -48,6 +51,7 @@ extends:
                 displayName: Install Node 20.x
                 inputs:
                   versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - task: DownloadPipelineArtifact@2
                 displayName: 'Download Build Server Artifacts'
                 inputs:

--- a/.azure-pipelines/vscode-gradle-apiscan.yml
+++ b/.azure-pipelines/vscode-gradle-apiscan.yml
@@ -1,7 +1,6 @@
 name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -1,4 +1,7 @@
 name: $(Date:yyyyMMdd).$(Rev:r)
+variables:
+  - name: npm_config_userconfig
+    value: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -48,6 +51,7 @@ extends:
                 displayName: Install Node 20.x
                 inputs:
                   versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - task: DownloadPipelineArtifact@2
                 displayName: 'Download Build Server Artifacts'
                 inputs:

--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -1,7 +1,6 @@
 name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
-  - name: npm_config_userconfig
-    value: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/vscode-gradle-nightly.yml
+++ b/.azure-pipelines/vscode-gradle-nightly.yml
@@ -5,8 +5,9 @@ schedules:
       include:
         - develop
 variables:
-  system.debug: true
-  npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
+  - name: system.debug
+    value: 'true'
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/vscode-gradle-nightly.yml
+++ b/.azure-pipelines/vscode-gradle-nightly.yml
@@ -6,6 +6,7 @@ schedules:
         - develop
 variables:
   system.debug: true
+  npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -65,6 +66,7 @@ extends:
                 displayName: Install Node 20.x
                 inputs:
                   versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - task: MicroBuildSigningPlugin@4
                 displayName: 'Install Signing Plugin'
                 inputs:

--- a/.azure-pipelines/vscode-gradle-rc.yml
+++ b/.azure-pipelines/vscode-gradle-rc.yml
@@ -5,8 +5,9 @@ schedules:
       include:
         - develop
 variables:
-  system.debug: true
-  npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
+  - template: /.azure-pipelines/npm-cfs-variables.yml@self
+  - name: system.debug
+    value: 'true'
 resources:
   repositories:
     - repository: self

--- a/.azure-pipelines/vscode-gradle-rc.yml
+++ b/.azure-pipelines/vscode-gradle-rc.yml
@@ -6,6 +6,7 @@ schedules:
         - develop
 variables:
   system.debug: true
+  npm_config_userconfig: $(Agent.TempDirectory)/.npmrc
 resources:
   repositories:
     - repository: self
@@ -69,6 +70,7 @@ extends:
                 displayName: Install Node 20.x
                 inputs:
                   versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
               - task: MicroBuildSigningPlugin@4
                 displayName: 'Install Signing Plugin'
                 inputs:


### PR DESCRIPTION
Routes npm package restore in the six Azure DevOps pipelines through the Central Feed Service (CFS) feed `mseng/VSJava/vscjava`, as required by SFI Network Isolation.

Starts from microsoft/vscode-java-pack#1708 (the CFS routing) and microsoft/vscode-java-pack#1711 (the template path fix), applied together so this repo never lands the broken intermediate state. One additional change is needed here that vscode-java-pack did not require -- see [Why npm_config_registry](#why-npm_config_registry).

## What changed

Two new templates under `.azure-pipelines/`:

* `npm-cfs-variables.yml` declares the feed URL and the generated `.npmrc` path, so the URL exists in exactly one place.
* `npm-cfs.yml` writes the `.npmrc` into `$(Agent.TempDirectory)`, runs `NpmAuthenticate@0` against it, and then asserts the effective registry.

Each of the six pipelines includes the variables template and, immediately after its Node install task, the steps template:

```yaml
variables:
  - template: /.azure-pipelines/npm-cfs-variables.yml@self
```
```yaml
- template: /.azure-pipelines/npm-cfs.yml@self
```

No task was swapped and no `npm`/`npx` invocation changed. Unlike vscode-java-pack, package restore here is driven by Gradle rather than by `Npm@1` -- the `npmInstall` tasks in `extension/build.gradle` and `npm-package/build.gradle` shell out to `npm install` and inherit the agent environment. `package.json` and `package-lock.json` are untouched.

## Why npm_config_registry

The first run of this PR (build 31830818) restored 589 + 129 packages with no error, yet the `vscjava` feed had cached **nothing** -- restore had silently fallen back to `registry.npmjs.org`.

This repository commits project level `.npmrc` files, `extension/.npmrc` and `npm-package/.npmrc`, both pinning `registry=https://registry.npmjs.org/` so contributors are unaffected by whatever registry their own environment configures. npm resolves configuration in the order

```
cli > environment > project .npmrc > user .npmrc > global > builtin > default
```

so a registry supplied only through the generated user config is outranked by those committed files. Reproduced against npm 10.9.3:

| config | effective registry |
| --- | --- |
| generated user `.npmrc` only | `https://registry.npmjs.org/` |
| plus `npm_config_registry` env var | `https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/npm/registry/` |

An environment variable outranks every `.npmrc` file, so `npm_config_registry` carries the redirect and the committed files stay untouched. The registry is still written into the generated `.npmrc` because that is how `NpmAuthenticate@0` discovers which registries to authenticate; npm then takes the URL from the environment and the matching credential from that file.

Because this failure mode is silent, the template now ends with a `Verify CFS npm registry` step that reads the effective registry from the directory that actually restores and fails the build if it is not the CFS feed.

## Why the template path is absolute

All six pipelines pass their steps into an `extends` template in another repository. A relative template path is resolved against the file doing the including, which is the 1ES template, not the pipeline -- so a bare `npm-cfs.yml` is looked up in `1ESPipelineTemplates` and fails YAML compilation for every pipeline. Hence `/.azure-pipelines/npm-cfs.yml@self`, per the [template documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/templates?view=azure-devops#store-templates-in-other-repositories).

## Why the .npmrc is generated instead of committed

This is a public repository. A committed `.npmrc` pointing at an internal feed would break outside contributors and `.github/workflows/main.yml`, which runs on `ubuntu-latest` with no Azure credentials. Generating it into the agent temp directory keeps the workspace clean and keeps the injected credential out of the checked out sources. One lockfile serves both audiences: every `resolved` URL in `package-lock.json` points at `registry.npmjs.org`, and npm replaces that host with the configured registry.

## Verification

Compiled through the Azure DevOps `previewRun` API (no builds queued) against `develop` and against this branch:

| Pipeline | Definition | `develop` | this branch |
| --- | --- | --- | --- |
| `vscode-gradle-ci.yml` | 11720 | compiles | compiles |
| `vscode-gradle-rc.yml` | 11745 | compiles | compiles |
| `vscode-gradle-nightly.yml` | 13344 | compiles | compiles |
| `vscode-gradle-apiscan.yml` | 18305 | compiles | compiles |
| `release/release-nightly.yml` | 21136 | compiles | compiles |
| `release/release-rc.yml` | 21546 | compiles | compiles |

The expanded YAML places the steps in the required order, on both the Linux (`1ES_JavaTooling_Ubuntu-2004`) and Windows (`1ES_JavaTooling_Windows_2022`) pools:

```
1. npm_config_registry + npm_config_userconfig variables
2. NodeTool@0 / UseNode@1
3. npm config set registry ... --userconfig=...
4. NpmAuthenticate@0
5. Verify CFS npm registry
6. Gradle build / npm install / npx ...
```

Feed authentication was checked rather than left to the first run. All six definitions use `projectCollection` job authorization, so the token belongs to `Project Collection Build Service (mseng)` -- that identity holds `contributor` on the `vscjava` feed, alongside the VSJava project build service. The feed's `npmjs` upstream is enabled and healthy, so packages are cached on demand with no periodic maintenance.

## Notes

`networkIsolationPolicy` is deliberately not set here. Specifying it in YAML replaces the full set of non required policies, so declaring `CFSClean` without also naming the current base policy would block everything. That should be enabled separately.

Out of scope, and not npm package feeds, but worth confirming against the CFSClean endpoint list: `NodeTool@0`/`UseNode@1` fetch Node from nodejs.org on a tool cache miss, `APIScan@2` resolves `toolVersion: Latest`, MicroBuild signing restores from the internal `MicroBuildToolset` NuGet feed, and this repo additionally restores Gradle and Maven dependencies.
