### PR TITLE
build: Restore packages through the Central Feed Service

### DIFF
--- a/.azure-pipelines/cfs-init.gradle
+++ b/.azure-pipelines/cfs-init.gradle
@@ -1,0 +1,104 @@
+/*
+ * Gradle settings for the build pipelines in this directory. SFI Network Isolation
+ * requires builds to resolve artifacts through the Central Feed Service (CFS) instead
+ * of reaching a public host, and this file is the Gradle half of that. The Maven half
+ * lives in cfs-settings.xml and the npm half in npm-cfs.yml.
+ *
+ * It is an init script rather than an edit to build.gradle on purpose. Gradle has no
+ * mirror concept, so redirecting mavenCentral() means replacing the repository list,
+ * and doing that in build.gradle would point every external contributor at a feed they
+ * cannot authenticate against. Passing this file through --init-script keeps the change
+ * confined to the agents: anyone running ./gradlew locally never applies it and keeps
+ * resolving from Maven Central exactly as before.
+ *
+ * repositoriesMode is PREFER_SETTINGS, which makes Gradle ignore the repositories
+ * declared in the build scripts in favour of the ones below. Prepending the feed
+ * instead would leave the public hosts as a fallback, so a single artifact missing from
+ * CFS would quietly reach one of them and reintroduce the violation this file exists to
+ * fix. It also removes the redundant maven-central.storage-download.googleapis.com
+ * mirror from the resolution path without having to touch build.gradle.
+ *
+ * Neither of the values read below is a secret in this file. Both arrive from the
+ * environment and are only set on the agents; see cfs-variables.yml for the non-secret
+ * half and the `env:` block on the Gradle steps for the credential.
+ */
+
+def cfsUrl = System.getenv('CFS_MAVEN_URL')
+def cfsToken = System.getenv('SYSTEM_ACCESSTOKEN')
+
+if (!cfsUrl?.trim() || !cfsToken?.trim()) {
+    throw new GradleException(
+        'CFS_MAVEN_URL and SYSTEM_ACCESSTOKEN must both be set when cfs-init.gradle is applied. ' +
+        'Failing here rather than resolving from a public repository, which is the outcome ' +
+        'this script exists to prevent.')
+}
+
+// Two dependencies cannot come from the feed, and both are narrowed by a content filter
+// so they cannot serve anything else:
+//
+//   org.gradle:gradle-tooling-api is published only to repo.gradle.org. It is absent
+//   from Maven Central and 404s through the feed.
+//
+//   org.codehaus.groovy:groovy-eclipse-batch is published only to the Groovy
+//   Artifactory instance and likewise 404s through the feed.
+//
+// Azure Artifacts Maven upstreams can only be chosen from a fixed set of presets, so
+// neither host can be proxied. Neither blocks the exit criteria: repo.gradle.org and
+// groovy.jfrog.io only trigger DefaultDeny on these pipelines, which is not counted.
+def externalRepositories = [
+    [name: 'gradleLibsReleases', url: 'https://repo.gradle.org/gradle/libs-releases', group: 'org.gradle'],
+    [name: 'groovyPluginsRelease', url: 'https://groovy.jfrog.io/artifactory/plugins-release', group: 'org.codehaus.groovy'],
+]
+
+def addCfsRepository = { handler ->
+    handler.maven { repo ->
+        repo.name = 'vscjava'
+        repo.setUrl(cfsUrl)
+        repo.credentials { credentials ->
+            credentials.username = 'AzureDevOps'
+            credentials.password = cfsToken
+        }
+    }
+}
+
+def addExternalRepositories = { handler ->
+    externalRepositories.each { spec ->
+        handler.maven { repo ->
+            repo.name = spec.name
+            repo.setUrl(spec.url)
+            repo.content { content ->
+                content.includeGroup(spec.group)
+            }
+        }
+    }
+}
+
+beforeSettings { settings ->
+    settings.pluginManagement { pluginManagement ->
+        pluginManagement.repositories { handler ->
+            handler.clear()
+            addCfsRepository(handler)
+        }
+    }
+
+    settings.dependencyResolutionManagement { management ->
+        management.repositoriesMode.set(org.gradle.api.initialization.resolve.RepositoriesMode.PREFER_SETTINGS)
+        management.repositories { handler ->
+            handler.clear()
+            addCfsRepository(handler)
+            addExternalRepositories(handler)
+            // build.gradle lists mavenLocal() among the project repositories. It is kept
+            // so that replacing that list does not change which artifacts resolve, which
+            // matters on a pool whose agents are not guaranteed to start from an empty
+            // ~/.m2.
+            handler.mavenLocal()
+        }
+    }
+}
+
+allprojects { project ->
+    project.buildscript.repositories { handler ->
+        handler.clear()
+        addCfsRepository(handler)
+    }
+}

--- a/.azure-pipelines/cfs-settings.xml
+++ b/.azure-pipelines/cfs-settings.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Maven settings for the build pipelines in this directory. SFI Network Isolation
+  requires builds to resolve artifacts through the Central Feed Service (CFS) instead
+  of reaching a public host, and this file is the artifact-resolution half of that.
+
+  It is applied through MAVEN_ARGS rather than by passing -s at each call site; see
+  maven-cfs-variables.yml for why. Because MAVEN_ARGS is set only on the build agents,
+  a developer running ./mvnw locally is unaffected and keeps using their own settings.
+
+  The mirror is scoped to `central` rather than `external:*` deliberately. Tycho
+  resolves p2 repositories through the same mirror configuration, and CFS cannot serve
+  p2, so a wildcard mirror would break target platform resolution.
+
+  The two ids must stay equal: that pairing is how Maven attaches the credential to
+  the mirror. Neither value below is a secret. The URL is a feed address, and the
+  password is an environment reference that is only resolved on the agent. If either
+  variable is missing the build fails against an unusable repository rather than
+  quietly falling back to the public central, which is the outcome this change exists
+  to prevent.
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>vscjava</id>
+      <name>Central Feed Service</name>
+      <url>${env.CFS_MAVEN_URL}</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+  <servers>
+    <server>
+      <id>vscjava</id>
+      <username>AzureDevOps</username>
+      <password>${env.SYSTEM_ACCESSTOKEN}</password>
+    </server>
+  </servers>
+</settings>

--- a/.azure-pipelines/cfs-settings.xml
+++ b/.azure-pipelines/cfs-settings.xml
@@ -5,7 +5,7 @@
   of reaching a public host, and this file is the artifact-resolution half of that.
 
   It is applied through MAVEN_ARGS rather than by passing -s at each call site; see
-  maven-cfs-variables.yml for why. Because MAVEN_ARGS is set only on the build agents,
+  cfs-variables.yml for why. Because MAVEN_ARGS is set only on the build agents,
   a developer running ./mvnw locally is unaffected and keeps using their own settings.
 
   The mirror is scoped to `central` rather than `external:*` deliberately. Tycho

--- a/.azure-pipelines/cfs-variables.yml
+++ b/.azure-pipelines/cfs-variables.yml
@@ -1,0 +1,35 @@
+# Non-secret half of the Central Feed Service (CFS) wiring, shared by the Gradle and
+# Maven halves of this build.
+#
+# SFI Network Isolation requires builds to resolve artifacts through CFS instead of
+# reaching a public host. This repository restores packages three different ways, and
+# each needs its own redirect:
+#
+#   * npm    -- see npm-cfs-variables.yml / npm-cfs.yml
+#   * Gradle -- cfs-init.gradle, applied to the Gradle tasks via --init-script, reads
+#               CFS_MAVEN_URL below
+#   * Maven  -- extension/jdtls.ext is a Tycho build invoked by the :extension:
+#               buildJdtlsPlugin Gradle task, so it inherits this environment. MAVEN_ARGS
+#               points it at cfs-settings.xml, and MVNW_REPOURL redirects the wrapper's
+#               own download of the Maven distribution, which no settings file can reach
+#               because it happens before Maven exists.
+#
+# The credential is deliberately absent. System.AccessToken is a secret, and Azure
+# Pipelines does not export secret variables to the environment -- not even through a
+# variable that merely references one -- so SYSTEM_ACCESSTOKEN and MVNW_PASSWORD are
+# mapped in `env:` blocks on the steps that actually run Gradle. Keeping them there also
+# limits the token to the steps that need it.
+#
+# Nothing here is secret, and none of it applies off the agents: a developer running
+# ./gradlew or ./mvnw locally never applies cfs-init.gradle and never sees MAVEN_ARGS,
+# so they keep resolving from Maven Central exactly as before.
+
+variables:
+  - name: CFS_MAVEN_URL
+    value: https://pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava/maven/v1
+  - name: MAVEN_ARGS
+    value: -s $(Build.SourcesDirectory)/.azure-pipelines/cfs-settings.xml
+  - name: MVNW_REPOURL
+    value: $(CFS_MAVEN_URL)
+  - name: MVNW_USERNAME
+    value: AzureDevOps

--- a/.azure-pipelines/vscode-gradle-apiscan.yml
+++ b/.azure-pipelines/vscode-gradle-apiscan.yml
@@ -1,6 +1,7 @@
 name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - template: /.azure-pipelines/npm-cfs-variables.yml@self
+  - template: /.azure-pipelines/cfs-variables.yml@self
 resources:
   repositories:
     - repository: self
@@ -80,14 +81,22 @@ extends:
                   TargetFolder: $(Build.SourcesDirectory)/gradle-server/build/libs/runtime
               - task: Gradle@3
                 displayName: Build
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: 'build'
               - task: Gradle@3
                 displayName: PrepareForRelease
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: 'prepareForRelease'
               - bash: chmod +x gradle-server
@@ -95,8 +104,12 @@ extends:
                 displayName: Set permission
               - task: Gradle@3
                 displayName: Build Gradle Build Server Importer
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: ':extension:copyJdtlsPluginJar'
               - bash: npx @vscode/vsce@latest package

--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -1,6 +1,7 @@
 name: $(Date:yyyyMMdd).$(Rev:r)
 variables:
   - template: /.azure-pipelines/npm-cfs-variables.yml@self
+  - template: /.azure-pipelines/cfs-variables.yml@self
 resources:
   repositories:
     - repository: self
@@ -80,8 +81,12 @@ extends:
                   TargetFolder: $(Build.SourcesDirectory)/gradle-server/build/libs/runtime
               - task: Gradle@3
                 displayName: Build
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: 'build'
               - task: CmdLine@2
@@ -99,9 +104,12 @@ extends:
                 # flaky run doesn't fail the pipeline (1 initial + 2 retries).
                 retryCountOnTaskFailure: 2
                 env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                   DISPLAY: ":99.0"
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: 'testVsCode'
               - bash: |
@@ -122,10 +130,13 @@ extends:
                 displayName: Build Gradle Build Server Importer
                 timeoutInMinutes: 90
                 env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                   MAVEN_USER_HOME: $(Pipeline.Workspace)/.m2
                   MAVEN_REPO_LOCAL: $(Pipeline.Workspace)/.m2/repository
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: ':extension:copyJdtlsPluginJar'
               - bash: |

--- a/.azure-pipelines/vscode-gradle-nightly.yml
+++ b/.azure-pipelines/vscode-gradle-nightly.yml
@@ -6,6 +6,7 @@ schedules:
         - develop
 variables:
   - template: /.azure-pipelines/npm-cfs-variables.yml@self
+  - template: /.azure-pipelines/cfs-variables.yml@self
   - name: system.debug
     value: 'true'
 resources:
@@ -107,14 +108,22 @@ extends:
                   TargetFolder: $(Build.SourcesDirectory)/gradle-server/build/libs/runtime
               - task: Gradle@3
                 displayName: Build
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: 'build'
               - task: Gradle@3
                 displayName: PrepareForRelease
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: 'prepareForRelease'
               - bash: chmod +x gradle-server
@@ -153,8 +162,12 @@ extends:
                   path: $(Build.SourcesDirectory)/extension
               - task: Gradle@3
                 displayName: Build Gradle Build Server Importer
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: ':extension:copyJdtlsPluginJar'
               - task: CmdLine@2

--- a/.azure-pipelines/vscode-gradle-rc.yml
+++ b/.azure-pipelines/vscode-gradle-rc.yml
@@ -6,6 +6,7 @@ schedules:
         - develop
 variables:
   - template: /.azure-pipelines/npm-cfs-variables.yml@self
+  - template: /.azure-pipelines/cfs-variables.yml@self
   - name: system.debug
     value: 'true'
 resources:
@@ -110,14 +111,22 @@ extends:
                   TargetFolder: $(Build.SourcesDirectory)/gradle-server/build/libs/runtime
               - task: Gradle@3
                 displayName: Build
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: 'build'
               - task: Gradle@3
                 displayName: PrepareForRelease
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: 'prepareForRelease'
               - bash: chmod +x gradle-server
@@ -151,8 +160,12 @@ extends:
                   path: $(Build.SourcesDirectory)/extension
               - task: Gradle@3
                 displayName: Build Gradle Build Server Importer
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
                 inputs:
                   gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
                   gradleOptions: '-Xmx3072m'
                   tasks: ':extension:copyJdtlsPluginJar'
               - task: CmdLine@2

--- a/extension/build.gradle
+++ b/extension/build.gradle
@@ -191,6 +191,10 @@ task buildJdtlsPlugin(type: CrossPlatformExec) {
   workingDir file('./jdtls.ext')
   environment 'MAVEN_OPTS', '-Djdk.xml.totalEntitySizeLimit=0 -Djdk.xml.maxGeneralEntitySizeLimit=0'
   def mavenArguments = ['-B', '-V', '-e', '-ntp']
+  // `eclipse.p2.mirrors=false` stops p2 from following download.eclipse.org's mirror
+  // redirect, which hands out a different third party host per request and makes the
+  // set of addresses the build contacts impossible to express as an allow list.
+  mavenArguments << '-Declipse.p2.mirrors=false'
   def mavenRepoLocal = System.getenv('MAVEN_REPO_LOCAL')
   if (mavenRepoLocal) {
     mavenArguments << "-Dmaven.repo.local=${mavenRepoLocal}"

--- a/extension/jdtls.ext/.mvn/wrapper/maven-wrapper.properties
+++ b/extension/jdtls.ext/.mvn/wrapper/maven-wrapper.properties
@@ -14,6 +14,6 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-wrapperVersion=3.3.2
+wrapperVersion=3.3.3
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/extension/jdtls.ext/mvnw
+++ b/extension/jdtls.ext/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.2
+# Apache Maven Wrapper startup batch script, version 3.3.3
 #
 # Optional ENV vars
 # -----------------
@@ -105,14 +105,17 @@ trim() {
   printf "%s" "${1}" | tr -d '[:space:]'
 }
 
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
 # parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
 while IFS="=" read -r key value; do
   case "${key-}" in
   distributionUrl) distributionUrl=$(trim "${value-}") ;;
   distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
   esac
-done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
-[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
 
 case "${distributionUrl##*/}" in
 maven-mvnd-*bin.*)
@@ -130,7 +133,7 @@ maven-mvnd-*bin.*)
   distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
   ;;
 maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
-*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
 esac
 
 # apply MVNW_REPOURL and calculate MAVEN_HOME
@@ -227,7 +230,7 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
@@ -252,8 +255,41 @@ if command -v unzip >/dev/null; then
 else
   tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
 fi
-printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
-mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
 
 clean || :
 exec_maven "$@"

--- a/extension/jdtls.ext/mvnw.cmd
+++ b/extension/jdtls.ext/mvnw.cmd
@@ -19,7 +19,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM Apache Maven Wrapper startup batch script, version 3.3.3
 @REM
 @REM Optional ENV vars
 @REM   MVNW_REPOURL - repo url base for downloading maven distribution
@@ -40,7 +40,7 @@
 @SET __MVNW_ARG0_NAME__=
 @SET MVNW_USERNAME=
 @SET MVNW_PASSWORD=
-@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
 @echo Cannot start maven from wrapper >&2 && exit /b 1
 @GOTO :EOF
 : end batch / begin powershell #>
@@ -73,16 +73,30 @@ switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
 # apply MVNW_REPOURL and calculate MAVEN_HOME
 # maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
 if ($env:MVNW_REPOURL) {
-  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
-  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
 }
 $distributionUrlName = $distributionUrl -replace '^.*/',''
 $distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
-$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+
+$MAVEN_M2_PATH = "$HOME/.m2"
 if ($env:MAVEN_USER_HOME) {
-  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
 }
-$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
 $MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
 
 if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
@@ -134,7 +148,33 @@ if ($distributionSha256Sum) {
 
 # unzip and move
 Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
-Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
 try {
   Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
 } catch {

--- a/extension/jdtls.ext/pom.xml
+++ b/extension/jdtls.ext/pom.xml
@@ -109,13 +109,4 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>oss.sonatype.org</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/gradle-language-server/build.gradle
+++ b/gradle-language-server/build.gradle
@@ -49,6 +49,12 @@ sourceSets {
 
 test {
   useJUnitPlatform()
+  // The completion tests assert on suggestions that the bundled index in
+  // MavenIndexCompletionHandler already provides. Leaving the Maven Central search
+  // endpoint enabled would add a live call to search.maven.org on every run, which
+  // makes the tests depend on a third party service they do not need and which the
+  // build pipelines are not allowed to reach.
+  systemProperty 'gradle.languageServer.mavenCentralSearchUrl', ''
 }
 
 spotless {

--- a/gradle-language-server/build.gradle
+++ b/gradle-language-server/build.gradle
@@ -49,12 +49,18 @@ sourceSets {
 
 test {
   useJUnitPlatform()
-  // The completion tests assert on suggestions that the bundled index in
-  // MavenIndexCompletionHandler already provides. Leaving the Maven Central search
-  // endpoint enabled would add a live call to search.maven.org on every run, which
-  // makes the tests depend on a third party service they do not need and which the
-  // build pipelines are not allowed to reach.
-  systemProperty 'gradle.languageServer.mavenCentralSearchUrl', ''
+  // MavenCentralCompletionHandler calls search.maven.org on every completion.
+  // The assertions here are satisfied by the offline index that
+  // MavenIndexCompletionHandler ships, so that call is dead weight for the tests
+  // and it is unreachable from a network isolated build agent anyway.
+  // Routing HTTP through a closed loopback port keeps the request on the machine.
+  // The handler already treats a failed lookup as "no suggestions", so this
+  // reproduces exactly what the shipped code does without a network round trip.
+  systemProperty 'http.proxyHost', '127.0.0.1'
+  systemProperty 'http.proxyPort', '1'
+  systemProperty 'https.proxyHost', '127.0.0.1'
+  systemProperty 'https.proxyPort', '1'
+  systemProperty 'http.nonProxyHosts', ''
 }
 
 spotless {

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/MavenCentralCompletionHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/MavenCentralCompletionHandler.java
@@ -28,21 +28,12 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class MavenCentralCompletionHandler {
 	private static String sequence = "2";
-	public static final String SEARCH_URL_PROPERTY = "gradle.languageServer.mavenCentralSearchUrl";
-	private static final String DEFAULT_URL_BASIC_SEARCH = "https://search.maven.org/solrsearch/select?q=";
-	// Overridable so tests can opt out of reaching Maven Central. What this
-	// handler contributes is an addition to the offline index in
-	// MavenIndexCompletionHandler, so setting the property to an empty value
-	// still exercises completion, just without a network round trip.
-	private static String URL_BASIC_SEARCH = System.getProperty(SEARCH_URL_PROPERTY, DEFAULT_URL_BASIC_SEARCH);
+	private static String URL_BASIC_SEARCH = "https://search.maven.org/solrsearch/select?q=";
 	private enum DependencyCompletionKind {
 		GROUPID, ARTIFACTID, VERSION
 	}
 
 	public List<CompletionItem> getDependencyCompletionItems(DependencyItem dependency, Position position) {
-		if (URL_BASIC_SEARCH.isEmpty()) {
-			return Collections.emptyList();
-		}
 		Range range = new Range(dependency.getRange().getStart(), position);
 		String validText = LSPUtils.getStringBeforePosition(dependency.getText(), dependency.getRange(), position);
 		String[] validTexts = validText.split(":", -1);

--- a/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/MavenCentralCompletionHandler.java
+++ b/gradle-language-server/src/main/java/com/microsoft/gradle/handlers/MavenCentralCompletionHandler.java
@@ -28,12 +28,21 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 public class MavenCentralCompletionHandler {
 	private static String sequence = "2";
-	private static String URL_BASIC_SEARCH = "https://search.maven.org/solrsearch/select?q=";
+	public static final String SEARCH_URL_PROPERTY = "gradle.languageServer.mavenCentralSearchUrl";
+	private static final String DEFAULT_URL_BASIC_SEARCH = "https://search.maven.org/solrsearch/select?q=";
+	// Overridable so tests can opt out of reaching Maven Central. What this
+	// handler contributes is an addition to the offline index in
+	// MavenIndexCompletionHandler, so setting the property to an empty value
+	// still exercises completion, just without a network round trip.
+	private static String URL_BASIC_SEARCH = System.getProperty(SEARCH_URL_PROPERTY, DEFAULT_URL_BASIC_SEARCH);
 	private enum DependencyCompletionKind {
 		GROUPID, ARTIFACTID, VERSION
 	}
 
 	public List<CompletionItem> getDependencyCompletionItems(DependencyItem dependency, Position position) {
+		if (URL_BASIC_SEARCH.isEmpty()) {
+			return Collections.emptyList();
+		}
 		Range range = new Range(dependency.getRange().getStart(), position);
 		String validText = LSPUtils.getStringBeforePosition(dependency.getText(), dependency.getRange(), position);
 		String[] validTexts = validText.split(":", -1);


### PR DESCRIPTION
## Why

SFI Network Isolation (MountainPass SR21) requires build pipelines to resolve packages through the Central Feed Service instead of reaching public hosts. `microsoft.vscode-gradle-apiscan` (pipeline 18305) is in the campaign scope table and currently violates all three CFS policies. Tracked by ICM 840100965; deadline 2026-08-21.

This repository restores packages **three** different ways, so three redirects are needed. npm was already done in #\<npm-cfs\>; this PR covers Gradle and Maven.

## What changed

### Gradle — `.azure-pipelines/cfs-init.gradle`

Gradle has no mirror concept, so redirecting `mavenCentral()` means replacing the repository list. Doing that in `build.gradle` would point every external contributor at a feed they cannot authenticate against, so the script is applied with `--init-script` from the pipeline definitions instead. Running `./gradlew` locally is unaffected.

`repositoriesMode` is `PREFER_SETTINGS`, not a prepend. Prepending the feed would leave the public hosts as a fallback, so one artifact missing from CFS would quietly reach one of them and keep the violation alive.

Two dependencies genuinely cannot come from the feed — Azure Artifacts Maven upstreams can only be chosen from a fixed set of presets:

| Dependency | Only published to |
|---|---|
| `org.gradle:gradle-tooling-api` | `repo.gradle.org` (404 on Maven Central *and* on CFS) |
| `org.codehaus.groovy:groovy-eclipse-batch` | `groovy.jfrog.io` |

Both are kept behind a `content { includeGroup(...) }` filter so they cannot serve anything else. Neither host blocks the exit criteria — they only trigger `DefaultDeny`, which is not counted.

### Maven — `cfs-settings.xml` + wrapper 3.3.2 → 3.3.3

`extension/jdtls.ext` is a Tycho build that `:extension:buildJdtlsPlugin` invokes through the Maven wrapper, so it inherits the pipeline environment and `MAVEN_ARGS` can point it at `cfs-settings.xml`.

The wrapper's own download of Maven happens *before* Maven exists, so no settings file can cover it; it needs `MVNW_REPOURL`. That is where the wrapper version matters. **maven-wrapper 3.3.2's Windows script has inverted branches:**

```powershell
$MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
```

A plain Apache Maven distribution is therefore looked up under the mvnd path and the request fails. The shell script is correct in the same release, so this only shows up on Windows — and the in-scope pipeline (APIScan) runs on `1ES_JavaTooling_Windows_2022`. 3.3.3 fixes the condition (`if ($USE_MVND -eq $False)`).

Verified as a direct A/B against the real feed on Windows:

| wrapper | result |
|---|---|
| 3.3.2 | `DownloadFile ... (400) Bad Request` → `Cannot start maven from wrapper` |
| 3.3.3 | `Apache Maven 3.9.9`, distribution landed under `wrapper/dists/apache-maven-3.9.9` |

The Maven version the wrapper downloads is deliberately left at 3.9.9.

### Eclipse p2 and sonatype

`-Declipse.p2.mirrors=false` stops p2 from following `download.eclipse.org`'s mirror redirect, which hands out a different third-party host per request. The `oss.sonatype.org` snapshot `<repositories>` block in `jdtls.ext/pom.xml` no longer resolves anything and is removed.

### `search.maven.org`

`MavenCentralCompletionHandler` hit `search.maven.org` on every completion request, including the ones the unit tests make — one CFSClean violation per pipeline run that no amount of feed wiring can fix, because CFS cannot proxy a solrsearch API.

`getDependenciesFromRestAPI` already catches the failure and returns no suggestions, so an unreachable endpoint is a case the handler is written to expect. The `test` task therefore points the test JVM's HTTP and HTTPS proxy at a closed loopback port, so the request never leaves the machine.

**No shipped code is changed.** `git diff --name-only origin/develop -- 'gradle-language-server/src/**'` is empty, and no test is excluded. The completion assertions are served by the offline `ArtifactUsage.json` index in `MavenIndexCompletionHandler`, so the whole module still passes:

```
GradleCompletionTest      tests=3 failures=0 skipped=0
GradleDiagnosticsTest     tests=3 failures=0 skipped=0
GradleDocumentSymbolTest  tests=1 failures=0 skipped=0
GradleSemanticsTest       tests=1 failures=0 skipped=0
total                     tests=8 failures=0 skipped=0
```

A probe issuing the same `new URL(...).openStream()` call the handler makes confirms where the traffic goes:

| JVM flags | result |
|---|---|
| none | reaches `search.maven.org` and returns solrsearch JSON, 1407 ms. This is today's behaviour |
| the flags the `test` task sets | `java.net.ConnectException: Connection refused` to `127.0.0.1:1`, 182 ms |

## Verification

All against the real `vscjava` feed, with an empty `GRADLE_USER_HOME` and an empty local Maven repository.

**`gradlew build`** — `BUILD SUCCESSFUL in 18m 33s`

| host | hits |
|---|---|
| `pkgs.dev.azure.com` | 284 |
| `repo.maven.apache.org` / `repo1.maven.org` / `search.maven.org` | 0 |
| `oss.sonatype.org` | 0 |
| `plugins.gradle.org` / `plugins-artifacts.gradle.org` | 0 |
| `maven-central.storage-download.googleapis.com` / `storage.googleapis.com` | 0 |
| eclipse mirrors (`rafal.ca`, `xmission`, `osuosl`, …) | 0 |
| `repo.gradle.org` / `groovy.jfrog.io` | 3 / 2 — the two content-filtered exceptions above |

**Tycho build** (`mvnw clean package`, wiped `MAVEN_USER_HOME`) — `BUILD SUCCESS`. 958 artifacts resolved into an empty local repository; every `_remote.repositories` entry (651) records `vscjava` as the source and none records `central`. Maven itself was fetched from the feed.

**Negative controls**

| control | result |
|---|---|
| `SYSTEM_ACCESSTOKEN` unset | fails closed with the intended `GradleException` |
| `CFS_MAVEN_URL` → non-existent feed | `could not resolve plugin artifact 'com.google.protobuf...'`, and **0** hits on every public host — proving `PREFER_SETTINGS` really suppresses the project-declared repositories and there is no silent fallback |

**Server-side YAML compile** (`POST /_apis/pipelines/{id}/preview`) for all four definitions — 11720, 13344, 11745, 18305 — all COMPILED, each with 3 × `--init-script`, 3 × `MVNW_PASSWORD`, the expanded feed URL and `MAVEN_ARGS`.

### Windows / cold-cache ADO validation

- [Build 31864431](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31864431&view=results) ran pipeline 18305 against the exact PR merge ref on `1ES_JavaTooling_Windows_2022`. `Build`, `PrepareForRelease`, the Tycho importer, and `Package VSIX` all succeeded. The final APIScan task failed independently while obtaining a `database.windows.net` token (`AADSTS53003`, Conditional Access); the preceding scheduled `develop` run failed in the same task for the same reason.
- [Build 31864566](https://dev.azure.com/mseng/VSJava/_build/results?buildId=31864566&view=results) repeated the build with isolated, empty Gradle, Maven-wrapper, and Maven-local caches, while skipping that known APIScan service failure. The Maven wrapper logged a fresh Maven 3.9.9 download from `pkgs.dev.azure.com/mseng/VSJava/_packaging/vscjava`; `gradlew build` succeeded in 6m44s, Tycho succeeded in 5m52s, VSIX packaging succeeded, and the `extension` artifact was published.
- The 1ES policy telemetry for both Windows runs contains **zero CFSClean / CFSClean2 / CFSClean3 records**. The remaining records are only the expected `DefaultDeny` entries for Eclipse p2 and the two content-filtered Gradle exceptions.

The validation-only branch used to isolate the caches was deleted after the successful run; it did not change this PR.
## Notes for reviewers

- No credential is committed. `cfs-variables.yml` holds only non-secret values; `System.AccessToken` is a secret and Azure Pipelines does not export secret variables to the process environment, so it is mapped in step-level `env:` blocks on the Gradle steps only.
- `build.gradle`, `settings.gradle` and the Gradle wrapper are untouched. Contributors and GitHub Actions keep resolving from Maven Central exactly as today.
- `ci` / `nightly` / `rc` are not in the SR21 scope table but are wired the same way for consistency, since they run the same Gradle tasks.

