### PR TITLE
fix: respect disabled nested project discovery

### DIFF
--- a/extension/src/stores/RootProjectsStore.ts
+++ b/extension/src/stores/RootProjectsStore.ts
@@ -90,8 +90,7 @@ export class RootProjectsStore extends StoreMap<string, RootProject> {
             if (hasRootGradleMarker) {
                 this.setRootProjectFolder(rootProject);
             }
-            const shouldDiscoverNestedProjects =
-                configNestedFolders === true || (!Array.isArray(configNestedFolders) && !hasRootGradleMarker);
+            const shouldDiscoverNestedProjects = configNestedFolders === true;
             const gradleProjectFoldersOutsideRoot = getGradleProjectFoldersOutsideRoot(
                 configNestedFolders,
                 shouldDiscoverNestedProjects ? await getGradleProjectFolders() : [],

--- a/extension/src/test/integration/nested-projects/extension.test.ts
+++ b/extension/src/test/integration/nested-projects/extension.test.ts
@@ -46,16 +46,9 @@ describe(getSuiteName("Extension"), () => {
 
     describe("Task provider", () => {
         describe("With nestedProjects disabled and a non-Gradle workspace root", () => {
-            let tasks: vscode.Task[] | undefined;
-
-            beforeEach(async () => {
-                tasks = await fetchTasksUntilLoaded(["helloGroovyDefault", "helloKotlinDefault", "helloGroovyCustom"]);
-            });
-
-            it("should load standalone nested Gradle project tasks", async () => {
-                assert.ok(tasks!.find(({ name }) => name === "helloGroovyDefault"));
-                assert.ok(tasks!.find(({ name }) => name === "helloKotlinDefault"));
-                assert.ok(tasks!.find(({ name }) => name === "helloGroovyCustom"));
+            it("should not load nested Gradle project tasks", async () => {
+                const tasks = await vscode.tasks.fetchTasks({ type: "gradle" });
+                assert.strictEqual(tasks.length, 0);
             });
         });
 

--- a/extension/src/test/integration/nested-projects/extension.test.ts
+++ b/extension/src/test/integration/nested-projects/extension.test.ts
@@ -47,8 +47,14 @@ describe(getSuiteName("Extension"), () => {
     describe("Task provider", () => {
         describe("With nestedProjects disabled and a non-Gradle workspace root", () => {
             it("should not load nested Gradle project tasks", async () => {
-                const tasks = await vscode.tasks.fetchTasks({ type: "gradle" });
-                assert.strictEqual(tasks.length, 0);
+                const nestedTaskNames = ["helloGroovyDefault", "helloKotlinDefault", "helloGroovyCustom"];
+                for (let i = 0; i < 5; i++) {
+                    const tasks = await vscode.tasks.fetchTasks({ type: "gradle" });
+                    assert.ok(nestedTaskNames.every((name) => !tasks.some((task) => task.name === name)));
+                    if (i < 4) {
+                        await sleep(5 * 1000);
+                    }
+                }
             });
         });
 

--- a/extension/src/test/unit/RootProjectsStore.test.ts
+++ b/extension/src/test/unit/RootProjectsStore.test.ts
@@ -10,38 +10,26 @@ describe("RootProjectsStore", () => {
         sinon.restore();
     });
 
-    it("discovers standalone nested projects when the workspace root is not a Gradle project", async () => {
+    it("does not scan for nested projects when the workspace root is not a Gradle project and nestedProjects is disabled", async () => {
         const workspaceFolder = {
             index: 0,
             name: "workspace",
             uri: vscode.Uri.file(path.join("workspace")),
         };
-        const nestedProjectFolder = path.join(workspaceFolder.uri.fsPath, "nested-gradle-project");
-        const nestedBuildFile = vscode.Uri.file(path.join(nestedProjectFolder, "build.gradle"));
 
         sinon.stub(vscode.workspace, "workspaceFolders").value([workspaceFolder]);
         sinon.stub(vscode.workspace, "getWorkspaceFolder").returns(workspaceFolder);
         sinon.stub(vscode.workspace, "getConfiguration").returns({
             get: sinon.stub().withArgs("nestedProjects", false).returns(false),
         } as unknown as vscode.WorkspaceConfiguration);
-        sinon.stub(vscode.workspace, "findFiles").callsFake((include) => {
-            if (include === "**/{settings.gradle,settings.gradle.kts}") {
-                return Promise.resolve([]);
-            }
-            if (include === "**/{build.gradle,build.gradle.kts}") {
-                return Promise.resolve([nestedBuildFile]);
-            }
-            return Promise.resolve([]);
-        });
-        sinon.stub(fs, "existsSync").callsFake((filePath) => filePath === nestedBuildFile.fsPath);
+        const findFilesStub = sinon.stub(vscode.workspace, "findFiles").returns(Promise.resolve([]));
+        sinon.stub(fs, "existsSync").returns(false);
 
         const store = new RootProjectsStore();
         const projectRoots = await store.getProjectRoots();
 
-        assert.deepStrictEqual(
-            projectRoots.map((project) => project.getProjectUri().fsPath),
-            [nestedProjectFolder]
-        );
+        assert.deepStrictEqual(projectRoots, []);
+        assert.strictEqual(findFilesStub.called, false);
     });
 
     it("does not scan for nested projects when the workspace root is a Gradle project and nestedProjects is disabled", async () => {


### PR DESCRIPTION
## Summary
- respect `gradle.nestedProjects: false` for non-Gradle workspace roots
- retain standalone nested build discovery when explicitly enabled
- update unit and integration coverage

Fixes #1905