### PR TITLE
Add IssueLens issue triage

### DIFF
--- a/.github/issuelens.yml
+++ b/.github/issuelens.yml
@@ -1,0 +1,7 @@
+version: 1
+
+instructions:
+  duplicate_detection:
+    path: .github/issuelens/duplicates.md
+  labeling:
+    path: .github/llms.md

--- a/.github/issuelens/duplicates.md
+++ b/.github/issuelens/duplicates.md
@@ -1,0 +1,47 @@
+# Java Tooling Duplicate Detection Policy
+
+Apply the built-in IssueLens duplicate evidence thresholds. Search the target
+repository and all related Java tooling repositories below for duplicate and
+related issues:
+
+- `redhat-developer/vscode-java` — Java language support, navigation,
+  completion, refactoring, snippets, and Java project import.
+- `microsoft/vscode-java-debug` — Java debugging.
+- `microsoft/vscode-java-test` — JUnit and TestNG test running and debugging.
+- `microsoft/vscode-maven` — Maven project scaffolding and goals.
+- `microsoft/vscode-gradle` — Gradle tasks, dependencies, build-file authoring,
+  and extension integration.
+- `microsoft/build-server-for-gradle` — Gradle Build Server project import and
+  synchronization.
+
+## Scope Rules
+
+- Search open and closed issues in every repository above.
+- Select repositories from the affected feature evidence. When ownership is
+  ambiguous, search all six repositories.
+- Report every repository that could not be searched. Do not claim the full
+  Java tooling scope was clear when any configured repository was inaccessible.
+- A candidate in another repository may be the canonical issue when its
+  component owns the failing behavior and the technical evidence meets the
+  built-in threshold.
+- Do not label a target issue as `duplicate` for a merely related cross-project
+  issue. Require the same error signature, stack signature, or reproduction
+  trigger plus the required supporting evidence.
+
+## Component Routing Evidence
+
+- Navigation, completion, refactoring, snippets, Java language diagnostics, or
+  Java project model behavior usually belongs to `redhat-developer/vscode-java`.
+- Launch, attach, breakpoints, stepping, debug console, or Java debug adapter
+  behavior usually belongs to `microsoft/vscode-java-debug`.
+- Test discovery, Test Explorer, JUnit, TestNG, or test result behavior usually
+  belongs to `microsoft/vscode-java-test`.
+- Maven Explorer, archetypes, POM handling, or Maven goal execution usually
+  belongs to `microsoft/vscode-maven`.
+- Gradle Tasks UI, Gradle dependencies, build-file editing, or extension-side
+  Gradle behavior usually belongs to `microsoft/vscode-gradle`.
+- BSP connection, Gradle Build Server synchronization, or BSP-based Gradle
+  project import usually belongs to `microsoft/build-server-for-gradle`.
+
+Cross-project ownership guidance is supporting evidence only. It does not by
+itself establish a duplicate.

--- a/.github/workflows/issuelens-issue-triage.yml
+++ b/.github/workflows/issuelens-issue-triage.yml
@@ -1,0 +1,184 @@
+# IssueLens labels new issues and publishes its triage analysis as a bot comment.
+# Repository-specific labeling guidance is configured in .github/issuelens.yml.
+#
+# Required repository or organization configuration:
+#   Variable: ISSUELENS_APP_ID
+#   Secrets:  ISSUELENS_APP_PRIVATE_KEY, AZURE_CLIENT_ID, AZURE_TENANT_ID,
+#             AZURE_SUBSCRIPTION_ID, ISSUELENS_AGENT_URL,
+#             ISSUELENS_AGENT_SCOPE
+
+name: IssueLens issue triage
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Issue number to triage
+        required: true
+        type: string
+
+run-name: >-
+  IssueLens triage for #${{ github.event.issue.number || inputs.issue_number }}
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: issuelens-triage-${{ github.event.issue.number || inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.ISSUELENS_APP_ID }}
+          private-key: ${{ secrets.ISSUELENS_APP_PRIVATE_KEY }}
+          permission-contents: read
+          permission-issues: write
+
+      - name: Azure login (OIDC) for the agent endpoint
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Invoke IssueLens agent
+        env:
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number || inputs.issue_number }}
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          AGENT_URL: ${{ secrets.ISSUELENS_AGENT_URL }}
+          AGENT_SCOPE: ${{ secrets.ISSUELENS_AGENT_SCOPE }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "$ISSUE" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Issue number must be a positive integer." >&2
+            exit 1
+          fi
+
+          input="Triage GitHub issue ${REPO}#${ISSUE}. "
+          input+="Find high-confidence duplicate issues and useful related issues across every repository listed by the configured duplicate-detection policy. "
+          input+="Analyze the likely affected component, probable root cause, and reproduction evidence using the issue, its comments, related issues, and repository code when available; state uncertainty rather than guessing. "
+          input+="Apply appropriate existing labels using the repository's configured labeling policy, including 'duplicate' only when the duplicate evidence threshold is met. "
+          input+="Do not close, assign, or comment on the issue. Return concise comment-ready Markdown with sections for summary, duplicates or related issues, likely component and root cause, reproduction or missing information, and labels applied. Include links to supporting GitHub evidence."
+
+          payload=$(ISSUELENS_INPUT="$input" python3 - <<'PY'
+          import json
+          import os
+
+          print(json.dumps({
+              "input": os.environ["ISSUELENS_INPUT"],
+              "github_token": os.environ["GH_APP_TOKEN"],
+          }))
+          PY
+          )
+
+          agent_token=$(az account get-access-token \
+            --scope "$AGENT_SCOPE" \
+            --query accessToken \
+            -o tsv)
+
+          response_file=$(mktemp)
+          if ! curl --fail-with-body -sS -N -X POST "$AGENT_URL" \
+            -H "Authorization: Bearer $agent_token" \
+            -H "Content-Type: application/json" \
+            -d "$payload" \
+            -o "$response_file"; then
+            cat "$response_file" >&2
+            exit 1
+          fi
+
+          triage=$(python3 - "$response_file" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          final_messages = []
+          fallback_messages = []
+          for line in pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+              if not line.startswith("data: "):
+                  continue
+              try:
+                  event = json.loads(line.removeprefix("data: "))
+              except json.JSONDecodeError:
+                  continue
+              if event.get("type") != "assistant.message":
+                  continue
+              data = event.get("data") or {}
+              content = data.get("content")
+              if not isinstance(content, str) or not content:
+                  continue
+              fallback_messages.append(content)
+              if data.get("phase") == "final_answer":
+                  final_messages.append(content)
+
+          messages = final_messages or fallback_messages
+          if messages:
+              print(messages[-1], end="")
+          PY
+          )
+
+          if [ -z "$triage" ]; then
+            echo "IssueLens returned no final triage message." >&2
+            exit 1
+          fi
+
+          printf '%s\n' "$triage" > "$RUNNER_TEMP/issuelens-triage.md"
+
+      - name: Publish IssueLens triage comment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number || inputs.issue_number }}
+          BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
+        run: |
+          set -euo pipefail
+
+          marker='<!-- issuelens-triage -->'
+          TRIAGE=$(cat "$RUNNER_TEMP/issuelens-triage.md")
+          comment_body=$(printf '%s\n## IssueLens triage\n\n%s\n' "$marker" "$TRIAGE")
+
+          comments_file=$(mktemp)
+          gh api "repos/${REPO}/issues/${ISSUE}/comments?per_page=100" \
+            > "$comments_file"
+          comment_id=$(python3 - "$comments_file" "$BOT_LOGIN" "$marker" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          comments = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          bot_login = sys.argv[2]
+          marker = sys.argv[3]
+          matches = [
+              comment["id"]
+              for comment in comments
+              if comment.get("user", {}).get("login") == bot_login
+              and comment.get("body", "").startswith(marker)
+          ]
+          if matches:
+              print(matches[-1])
+          PY
+          )
+
+          if [ -n "$comment_id" ]; then
+            gh api \
+              --method PATCH \
+              "repos/${REPO}/issues/comments/${comment_id}" \
+              -f body="$comment_body" \
+              > /dev/null
+          else
+            gh api \
+              --method POST \
+              "repos/${REPO}/issues/${ISSUE}/comments" \
+              -f body="$comment_body" \
+              > /dev/null
+          fi

--- a/.github/workflows/issuelens-issue-triage.yml
+++ b/.github/workflows/issuelens-issue-triage.yml
@@ -69,7 +69,8 @@ jobs:
           input+="Find high-confidence duplicate issues and useful related issues across every repository listed by the configured duplicate-detection policy. "
           input+="Analyze the likely affected component, probable root cause, and reproduction evidence using the issue, its comments, related issues, and repository code when available; state uncertainty rather than guessing. "
           input+="Apply appropriate existing labels using the repository's configured labeling policy, including 'duplicate' only when the duplicate evidence threshold is met. "
-          input+="Do not close, assign, or comment on the issue. Return concise comment-ready Markdown with sections for summary, duplicates or related issues, likely component and root cause, reproduction or missing information, and labels applied. Include links to supporting GitHub evidence."
+          input+="Do not close or assign the issue. After completing the analysis and label writes, use the available GitHub issue-comment tool to post the triage result on the target issue. "
+          input+="The comment must contain concise Markdown sections for summary, duplicates or related issues, likely component and root cause, reproduction or missing information, and labels applied. Include links to supporting GitHub evidence and state uncertainty rather than guessing."
 
           payload=$(ISSUELENS_INPUT="$input" python3 - <<'PY'
           import json
@@ -87,98 +88,7 @@ jobs:
             --query accessToken \
             -o tsv)
 
-          response_file=$(mktemp)
-          if ! curl --fail-with-body -sS -N -X POST "$AGENT_URL" \
+          curl --fail-with-body -sS -N -X POST "$AGENT_URL" \
             -H "Authorization: Bearer $agent_token" \
             -H "Content-Type: application/json" \
-            -d "$payload" \
-            -o "$response_file"; then
-            cat "$response_file" >&2
-            exit 1
-          fi
-
-          triage=$(python3 - "$response_file" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          final_messages = []
-          fallback_messages = []
-          for line in pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
-              if not line.startswith("data: "):
-                  continue
-              try:
-                  event = json.loads(line.removeprefix("data: "))
-              except json.JSONDecodeError:
-                  continue
-              if event.get("type") != "assistant.message":
-                  continue
-              data = event.get("data") or {}
-              content = data.get("content")
-              if not isinstance(content, str) or not content:
-                  continue
-              fallback_messages.append(content)
-              if data.get("phase") == "final_answer":
-                  final_messages.append(content)
-
-          messages = final_messages or fallback_messages
-          if messages:
-              print(messages[-1], end="")
-          PY
-          )
-
-          if [ -z "$triage" ]; then
-            echo "IssueLens returned no final triage message." >&2
-            exit 1
-          fi
-
-          printf '%s\n' "$triage" > "$RUNNER_TEMP/issuelens-triage.md"
-
-      - name: Publish IssueLens triage comment
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REPO: ${{ github.repository }}
-          ISSUE: ${{ github.event.issue.number || inputs.issue_number }}
-          BOT_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
-        run: |
-          set -euo pipefail
-
-          marker='<!-- issuelens-triage -->'
-          TRIAGE=$(cat "$RUNNER_TEMP/issuelens-triage.md")
-          comment_body=$(printf '%s\n## IssueLens triage\n\n%s\n' "$marker" "$TRIAGE")
-
-          comments_file=$(mktemp)
-          gh api "repos/${REPO}/issues/${ISSUE}/comments?per_page=100" \
-            > "$comments_file"
-          comment_id=$(python3 - "$comments_file" "$BOT_LOGIN" "$marker" <<'PY'
-          import json
-          import pathlib
-          import sys
-
-          comments = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
-          bot_login = sys.argv[2]
-          marker = sys.argv[3]
-          matches = [
-              comment["id"]
-              for comment in comments
-              if comment.get("user", {}).get("login") == bot_login
-              and comment.get("body", "").startswith(marker)
-          ]
-          if matches:
-              print(matches[-1])
-          PY
-          )
-
-          if [ -n "$comment_id" ]; then
-            gh api \
-              --method PATCH \
-              "repos/${REPO}/issues/comments/${comment_id}" \
-              -f body="$comment_body" \
-              > /dev/null
-          else
-            gh api \
-              --method POST \
-              "repos/${REPO}/issues/${ISSUE}/comments" \
-              -f body="$comment_body" \
-              > /dev/null
-          fi
+            -d "$payload"

--- a/.github/workflows/issuelens-issue-triage.yml
+++ b/.github/workflows/issuelens-issue-triage.yml
@@ -2,10 +2,13 @@
 # Repository-specific labeling guidance is configured in .github/issuelens.yml.
 #
 # Required repository or organization configuration:
-#   Variable: ISSUELENS_APP_ID
-#   Secrets:  ISSUELENS_APP_PRIVATE_KEY, AZURE_CLIENT_ID, AZURE_TENANT_ID,
-#             AZURE_SUBSCRIPTION_ID, ISSUELENS_AGENT_URL,
-#             ISSUELENS_AGENT_SCOPE
+#   Secrets: AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID,
+#            ISSUELENS_AGENT_URL, ISSUELENS_AGENT_SCOPE
+#
+# The hosted agent owns its Key Vault-backed GitHub App identity and mints
+# repository-scoped tokens internally. This repository stores no App private key.
+# The App must be installed on this repository and every related repository that
+# IssueLens is expected to search. Agent endpoint access uses Azure OIDC.
 
 name: IssueLens issue triage
 
@@ -34,15 +37,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - name: Mint GitHub App installation token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.ISSUELENS_APP_ID }}
-          private-key: ${{ secrets.ISSUELENS_APP_PRIVATE_KEY }}
-          permission-contents: read
-          permission-issues: write
-
       - name: Azure login (OIDC) for the agent endpoint
         uses: azure/login@v3
         with:
@@ -54,7 +48,6 @@ jobs:
         env:
           REPO: ${{ github.repository }}
           ISSUE: ${{ github.event.issue.number || inputs.issue_number }}
-          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
           AGENT_URL: ${{ secrets.ISSUELENS_AGENT_URL }}
           AGENT_SCOPE: ${{ secrets.ISSUELENS_AGENT_SCOPE }}
         run: |
@@ -72,16 +65,7 @@ jobs:
           input+="Do not close or assign the issue. After completing the analysis and label writes, use the available GitHub issue-comment tool to post the triage result on the target issue. "
           input+="The comment must contain concise Markdown sections for summary, duplicates or related issues, likely component and root cause, reproduction or missing information, and labels applied. Include links to supporting GitHub evidence and state uncertainty rather than guessing."
 
-          payload=$(ISSUELENS_INPUT="$input" python3 - <<'PY'
-          import json
-          import os
-
-          print(json.dumps({
-              "input": os.environ["ISSUELENS_INPUT"],
-              "github_token": os.environ["GH_APP_TOKEN"],
-          }))
-          PY
-          )
+          payload=$(jq -cn --arg input "$input" '{input:$input}')
 
           agent_token=$(az account get-access-token \
             --scope "$AGENT_SCOPE" \

--- a/.github/workflows/triage-agent.yml
+++ b/.github/workflows/triage-agent.yml
@@ -1,7 +1,7 @@
-name: AI Triage
+name: Legacy AI Triage (manual)
 on:
-  issues:
-    types: [opened]
+  # Automatic issue triage is handled by issuelens-issue-triage.yml. Keep this
+  # workflow dispatch entry for manual fallback and triage-all-open-issues.yml.
   workflow_dispatch:
     inputs:
       issue_number:


### PR DESCRIPTION
## Summary

- enable IssueLens for opened, reopened, and manually selected issues
- reuse `.github/llms.md` as the repository labeling policy
- search for duplicate and related issues across the Java tooling repositories named in `.github/issuelens/duplicates.md`
- let IssueLens apply existing labels and post its triage analysis as the IssueLens App bot
- keep the previous Azure Function triage workflow available as a manual fallback while removing its automatic issue-open trigger

## Implementation

The workflow authenticates only to the Foundry agent endpoint through Azure OIDC and sends one token-free `{ "input": ... }` invocation. It does not store the IssueLens App private key, mint an installation token, parse the agent's SSE output, or post the issue comment itself.

IssueLens version 21 owns the App credentials through Azure Key Vault. Each agent session starts the bundled GitHub MCP server, resolves the App installation for each explicit repository, and mints short-lived tokens restricted to that repository and the minimum tool permissions. Target issue reads, labels, and comments are therefore attributed to the IssueLens App bot.

Configured related repositories are searched through the same App-backed MCP tools. The IssueLens App must be installed on each related repository that the policy expects the agent to search; inaccessible repositories are reported and are never used for writes.

## Required setup

- install the IssueLens GitHub App on `microsoft/vscode-gradle`
- install the App on each related Java tooling repository that IssueLens should search

## Validation

- parsed `.github/issuelens.yml` with the production IssueLens parser
- removed `actions/create-github-app-token` and the `github_token` invocation field
- confirmed the workflow now contains only OIDC login and one structured agent invocation
- deployed IssueLens version 21 with the session-owned GitHub App MCP server
- smoke-tested version 21 through the token-free invocations protocol and confirmed an App-backed repository read
- all existing PR checks were passing before this workflow update
- `git diff --check` passes