### PR TITLE
Clarify IssueLens cross-repository duplicate triage

### DIFF
--- a/.github/issuelens/duplicates.md
+++ b/.github/issuelens/duplicates.md
@@ -24,9 +24,13 @@ related issues:
 - A candidate in another repository may be the canonical issue when its
   component owns the failing behavior and the technical evidence meets the
   built-in threshold.
-- Do not label a target issue as `duplicate` for a merely related cross-project
-  issue. Require the same error signature, stack signature, or reproduction
-  trigger plus the required supporting evidence.
+- Repository location does not change duplicate classification. When a
+  candidate in any configured repository meets the built-in duplicate evidence
+  threshold, treat the target as a duplicate and apply its existing
+  `duplicate` label.
+- Do not apply `duplicate` to a merely related cross-project issue that does not
+  meet that threshold. Require the same error signature, stack signature, or
+  reproduction trigger plus the required supporting evidence.
 
 ## Component Routing Evidence
 

--- a/.github/llms.md
+++ b/.github/llms.md
@@ -36,4 +36,7 @@ When labeling an issue, follow the rules below per label category:
 - [enhancement]: Primary label for enhancement issues 
 - [documentation]: Primary label for documentation issues 
 - [question]: Primary label for question issues
+- [duplicate]: Apply when a specific issue in this repository or any related
+    repository configured by IssueLens meets the duplicate-detection evidence
+    threshold. A cross-repository canonical issue is still a duplicate.
 - [needs more info]: Apply when the issue lacks sufficient information for proper triage or resolution. Use this label when the issue description is too vague or ambiguous to understand the problem

--- a/.github/workflows/issuelens-issue-triage.yml
+++ b/.github/workflows/issuelens-issue-triage.yml
@@ -7,8 +7,9 @@
 #
 # The hosted agent owns its Key Vault-backed GitHub App identity and mints
 # repository-scoped tokens internally. This repository stores no App private key.
-# The App must be installed on this repository and every related repository that
-# IssueLens is expected to search. Agent endpoint access uses Azure OIDC.
+# The App must be installed on this target repository for labels and comments.
+# Related public repositories can be searched read-only without an App
+# installation. Agent endpoint access uses Azure OIDC.
 
 name: IssueLens issue triage
 
@@ -58,12 +59,7 @@ jobs:
             exit 1
           fi
 
-          input="Triage GitHub issue ${REPO}#${ISSUE}. "
-          input+="Find high-confidence duplicate issues and useful related issues across every repository listed by the configured duplicate-detection policy. "
-          input+="Analyze the likely affected component, probable root cause, and reproduction evidence using the issue, its comments, related issues, and repository code when available; state uncertainty rather than guessing. "
-          input+="Apply appropriate existing labels using the repository's configured labeling policy, including 'duplicate' only when the duplicate evidence threshold is met. "
-          input+="Do not close or assign the issue. After completing the analysis and label writes, use the available GitHub issue-comment tool to post the triage result on the target issue. "
-          input+="The comment must contain concise Markdown sections for summary, duplicates or related issues, likely component and root cause, reproduction or missing information, and labels applied. Include links to supporting GitHub evidence and state uncertainty rather than guessing."
+          input="Triage GitHub issue ${REPO}#${ISSUE}. Find duplicates and related issues using the repository's configured scope, analyze the likely component and root cause, and apply appropriate existing labels. Do not assign or close the issue. Post one helpful comment to the reporter with your findings and practical next steps."
 
           payload=$(jq -cn --arg input "$input" '{input:$input}')
 


### PR DESCRIPTION
## Summary

- explicitly allow a qualifying issue in any configured Java tooling repository to be the canonical duplicate
- add the existing `duplicate` label to `.github/llms.md`, including cross-repository duplicate matches
- simplify the workflow input to user-level outcomes and explicitly disable assignment
- request one helpful reporter-facing comment without embedding internal prompt policy in the workflow
- document that public sibling repositories can be searched read-only without an IssueLens App installation

## Why

The IssueLens rerun for #1667 found a strong match in `redhat-developer/vscode-java#4176`, but inferred that `duplicate` should not be applied because the canonical issue was in another repository. No IssueLens core rule requires same-repository duplicates. The ambiguity came from the target policy's phrase “merely related cross-project issue” combined with the absence of `duplicate` from `.github/llms.md`.

This change makes repository location irrelevant when the normal duplicate evidence threshold is met. Merely related issues still do not qualify.

## Validation

- parsed `.github/issuelens.yml` with the production IssueLens parser
- verified all six configured Java tooling repositories remain in duplicate scope
- verified workflow input says not to assign or close the issue
- verified workflow requests one reporter-facing support comment
- `git diff --check` passes

After merge, manually rerun `IssueLens issue triage` for issue #1667 to validate the corrected label decision.