### PR TITLE
Fix: added some null pointer dereference checks

### DIFF
--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -689,6 +689,11 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
         }
 
         IPath sourceOutputPath = ResourceUtils.filePathFromURI(Utils.getUriWithoutQuery(outputUri).toString());
+        if (sourceOutputPath == null) {
+            JavaLanguageServerPlugin.logError("Cannot process Gradle Build Server output path "
+                    + outputUri + " because it is not a file URI.");
+            return null;
+        }
         File outputDirectory = sourceOutputPath.toFile();
         if (!outputDirectory.exists()) {
             outputDirectory.mkdirs();

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -861,6 +861,12 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
                 }
                 MavenDependencyModule mavenDependencyModule =
                         JSONUtility.toModel(module.getData(), MavenDependencyModule.class);
+                if (mavenDependencyModule == null) {
+                    JavaLanguageServerPlugin.logError("Cannot process Gradle Build Server Maven dependency "
+                            + module.getName() + ":" + module.getVersion()
+                            + " because its Maven metadata is missing or invalid.");
+                    continue;
+                }
                 List<MavenDependencyModuleArtifact> artifacts = mavenDependencyModule.getArtifacts();
                 if (artifacts == null) {
                     continue;

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -783,6 +783,11 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
             }
 
             JvmBuildTargetEx rawJvmTarget = JSONUtility.toModel(buildTarget.getData(), JvmBuildTargetEx.class);
+            if (rawJvmTarget == null) {
+                JavaLanguageServerPlugin.logError("Cannot process Gradle Build Server JVM target "
+                        + buildTarget.getId() + " because its JVM metadata is missing or invalid.");
+                continue;
+            }
             if (StringUtils.isNotBlank(rawJvmTarget.getJavaHome()) && StringUtils.isBlank(jvmTarget.getJavaHome())) {
                 jvmTarget.setJavaHome(rawJvmTarget.getJavaHome());
             }

--- a/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
+++ b/extension/jdtls.ext/com.microsoft.gradle.bs.importer/src/com/microsoft/gradle/bs/importer/GradleBuildServerBuildSupport.java
@@ -524,9 +524,14 @@ public class GradleBuildServerBuildSupport implements IBuildSupport {
         for (BuildTargetIdentifier dependency : projectDependencies) {
             URI uri = Utils.getUriWithoutQuery(dependency.getUri());
             IProject dependencyProject = ProjectUtils.getProjectFromUri(uri.toString());
+            if (dependencyProject == null) {
+                JavaLanguageServerPlugin.logError("Cannot add Gradle Build Server project dependency "
+                        + dependency.getUri() + " to project " + project.getName()
+                        + " because no matching workspace project was found.");
+                continue;
+            }
             String projectName = dependencyProject.getName();
-            if (dependencyProject != null && !Objects.equals(project, dependencyProject) &&
-                    !projectEntryMap.containsKey(projectName)) {
+            if (!Objects.equals(project, dependencyProject) && !projectEntryMap.containsKey(projectName)) {
                 projectEntryMap.put(projectName, JavaCore.newProjectEntry(
                     dependencyProject.getFullPath(),
                     ClasspathEntry.NO_ACCESS_RULES,


### PR DESCRIPTION
These changes harden the GradleBuildServerBuildSupport class against four null-dereference scenarios:
- Skip project dependencies that do not map to an Eclipse workspace project.
- Reject non-file output URIs when conversion produces no filesystem path.
- Skip JVM build targets with missing or invalid decoded metadata.
- Skip Maven dependencies with missing or invalid decoded metadata.
Each case writes a meaningful log message containing relevant identifiers before safely continuing or returning.