### PR TITLE
fix(deps): update js-yaml in npm package lockfile

### DIFF
--- a/npm-package/package-lock.json
+++ b/npm-package/package-lock.json
@@ -1041,9 +1041,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -1055,6 +1055,7 @@
           "url": "https://github.com/sponsors/nodeca"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },


### PR DESCRIPTION
## Summary

Fixes the repository's only open Dependabot alert, [HIGH alert 166](https://github.com/microsoft/vscode-gradle/security/dependabot/166), for [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj), a CPU-exhaustion issue when parsing ordered maps in `js-yaml` versions `>=4.0.0 <4.3.1`.

- Updates `js-yaml` from 4.3.0 to 4.3.2 in [`npm-package/package-lock.json`](https://github.com/microsoft/vscode-gradle/blob/49e5e69fc807cbe37eca4ad19fd6d46f884db848/npm-package/package-lock.json), generated with `npm update js-yaml --package-lock-only --ignore-scripts --no-fund`.
- ESLint 8.14.0 and `@eslint/eslintrc` 1.2.2 already permit `^4.1.0`, so no override, manifest, major-version, or runtime change is needed. The lockfile v3 diff is limited to package version/resolved/integrity and npm's MIT license metadata.
- The extension's separate [`extension/package-lock.json`](https://github.com/microsoft/vscode-gradle/blob/49e5e69fc807cbe37eca4ad19fd6d46f884db848/extension/package-lock.json) already uses safe `js-yaml` 4.3.1 and is unchanged. Assertions confirmed every copy in both lockfiles is outside the vulnerable range and the package graph delta contains only this package.

GitHub's full inventory is one open high-severity development-only alert, 119 fixed alerts, and eight auto-dismissed alerts. Alerts remain open for GitHub to close after default-branch merge.

## Validation

Validated with supported Node 18.20.8/npm 10.8.2: `npm ci --no-fund`, the existing ESLint CLI on `index.ts`, `npm ls js-yaml`, and `npm audit --omit=dev` all passed. YAML smoke coverage included merge keys, a 10,000-entry ordered map, and duplicate-key rejection.

With Java 21.0.8, standalone `gradlew buildJars` from `extension` passed. Root `gradlew lint build testVsCode` completed lint, build, Java tests, TypeScript API package compilation, and all 111 extension unit tests. One nested-project task-discovery integration case transiently missed `helloGroovyDefault`; rerunning that existing suite with a fresh profile on VS Code 1.136.1 passed all nine tests, and the remaining no-Gradle suite passed both tests. No code, tests, or timeouts were changed.

A redundant lint run after the build reported Prettier issues only in generated ignored documentation copies produced by `copyDocs`; the initial clean-tree lint passed, and this PR changes none of those docs or source files.

`npm audit --omit=dev` reports zero findings. The full development audit still reports five unchanged findings (three high, two moderate) corresponding to auto-dismissed alerts [83](https://github.com/microsoft/vscode-gradle/security/dependabot/83), [157](https://github.com/microsoft/vscode-gradle/security/dependabot/157), [162](https://github.com/microsoft/vscode-gradle/security/dependabot/162), [48](https://github.com/microsoft/vscode-gradle/security/dependabot/48), [41](https://github.com/microsoft/vscode-gradle/security/dependabot/41), and [29](https://github.com/microsoft/vscode-gradle/security/dependabot/29); no unrelated audit fix is included.