### PR TITLE
build: validate dependency updates through CFS

### DIFF
--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -6,7 +6,7 @@ resources:
   repositories:
     - repository: self
       type: git
-      ref: refs/heads/main
+      ref: refs/heads/develop
     - repository: 1esPipelines
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
@@ -15,6 +15,37 @@ trigger:
   branches:
     include:
       - develop
+pr:
+  branches:
+    include:
+      - develop
+  paths:
+    include:
+      - build.gradle
+      - settings.gradle
+      - gradlew
+      - gradlew.bat
+      - gradle/wrapper/**
+      - gradle-server/build.gradle
+      - gradle-plugin/build.gradle
+      - gradle-plugin-api/build.gradle
+      - gradle-language-server/build.gradle
+      - extension/build.gradle
+      - extension/package.json
+      - extension/package-lock.json
+      - extension/jdtls.ext/**/pom.xml
+      - extension/jdtls.ext/.mvn/wrapper/maven-wrapper.properties
+      - extension/jdtls.ext/mvnw
+      - extension/jdtls.ext/mvnw.cmd
+      - npm-package/build.gradle
+      - npm-package/package.json
+      - npm-package/package-lock.json
+      - .azure-pipelines/vscode-gradle-ci.yml
+      - .azure-pipelines/npm-cfs.yml
+      - .azure-pipelines/npm-cfs-variables.yml
+      - .azure-pipelines/cfs-init.gradle
+      - .azure-pipelines/cfs-settings.xml
+      - .azure-pipelines/cfs-variables.yml
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
@@ -30,8 +61,53 @@ extends:
     stages:
       - stage: Build
         jobs:
+          - job: CFSValidation
+            displayName: Validate dependencies from CFS
+            condition: eq(variables['Build.Reason'], 'PullRequest')
+            steps:
+              - checkout: self
+                fetchTags: false
+              - task: JavaToolInstaller@0
+                displayName: Use Java 21
+                inputs:
+                  versionSpec: '21'
+                  jdkArchitectureOption: 'x64'
+                  jdkSourceOption: 'PreInstalled'
+              - task: NodeTool@0
+                displayName: Use Node 20.x
+                inputs:
+                  versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
+              - script: npm ci --ignore-scripts --prefer-online --cache "$(Agent.TempDirectory)/npm-cache"
+                displayName: Validate extension npm dependencies from CFS
+                workingDirectory: $(Build.SourcesDirectory)/extension
+              - script: npm ci --ignore-scripts --prefer-online --cache "$(Agent.TempDirectory)/npm-cache"
+                displayName: Validate npm package dependencies from CFS
+                workingDirectory: $(Build.SourcesDirectory)/npm-package
+              - task: Gradle@3
+                displayName: Validate Gradle dependencies from CFS
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
+                inputs:
+                  gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle --refresh-dependencies'
+                  gradleOptions: '-Xmx3072m'
+                  tasks: ':gradle-server:dependencies :gradle-plugin:dependencies :gradle-plugin-api:dependencies :gradle-language-server:dependencies :extension:dependencies :npm-package:dependencies'
+              - task: Gradle@3
+                displayName: Validate Maven dependencies from CFS
+                env:
+                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  MVNW_PASSWORD: $(System.AccessToken)
+                  MAVEN_REPO_LOCAL: $(Agent.TempDirectory)/m2/repository
+                inputs:
+                  gradleWrapperFile: 'gradlew'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
+                  gradleOptions: '-Xmx3072m'
+                  tasks: ':extension:buildJdtlsPlugin'
           - job: Job_1
             displayName: VSCode-Gradle-CI
+            condition: ne(variables['Build.Reason'], 'PullRequest')
             templateContext:
               outputs:
                 - output: pipelineArtifact

--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -34,6 +34,7 @@ pr:
       - extension/package.json
       - extension/package-lock.json
       - extension/jdtls.ext/**/pom.xml
+      - extension/jdtls.ext/com.microsoft.gradle.bs.importer.target/com.microsoft.gradle.bs.importer.tp.target
       - extension/jdtls.ext/.mvn/wrapper/maven-wrapper.properties
       - extension/jdtls.ext/mvnw
       - extension/jdtls.ext/mvnw.cmd

--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -90,21 +90,26 @@ extends:
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                   MVNW_PASSWORD: $(System.AccessToken)
+                  GRADLE_USER_HOME: $(Agent.TempDirectory)/gradle
+                  MAVEN_USER_HOME: $(Agent.TempDirectory)/m2
+                  MAVEN_REPO_LOCAL: $(Agent.TempDirectory)/m2/repository
                 inputs:
                   gradleWrapperFile: 'gradlew'
                   options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle --refresh-dependencies'
-                  gradleOptions: '-Xmx3072m'
+                  gradleOptions: '-Xmx3072m -Dmaven.repo.local=$(Agent.TempDirectory)/m2/repository'
                   tasks: ':gradle-server:dependencies :gradle-plugin:dependencies :gradle-plugin-api:dependencies :gradle-language-server:dependencies :extension:dependencies :npm-package:dependencies'
               - task: Gradle@3
                 displayName: Validate Maven dependencies from CFS
                 env:
                   SYSTEM_ACCESSTOKEN: $(System.AccessToken)
                   MVNW_PASSWORD: $(System.AccessToken)
+                  GRADLE_USER_HOME: $(Agent.TempDirectory)/gradle
+                  MAVEN_USER_HOME: $(Agent.TempDirectory)/m2
                   MAVEN_REPO_LOCAL: $(Agent.TempDirectory)/m2/repository
                 inputs:
                   gradleWrapperFile: 'gradlew'
-                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle'
-                  gradleOptions: '-Xmx3072m'
+                  options: '--init-script $(Build.SourcesDirectory)/.azure-pipelines/cfs-init.gradle --refresh-dependencies'
+                  gradleOptions: '-Xmx3072m -Dmaven.repo.local=$(Agent.TempDirectory)/m2/repository'
                   tasks: ':extension:buildJdtlsPlugin'
           - job: Job_1
             displayName: VSCode-Gradle-CI

--- a/.azure-pipelines/vscode-gradle-ci.yml
+++ b/.azure-pipelines/vscode-gradle-ci.yml
@@ -31,6 +31,7 @@ pr:
       - gradle-plugin-api/build.gradle
       - gradle-language-server/build.gradle
       - extension/build.gradle
+      - extension/.npmrc
       - extension/package.json
       - extension/package-lock.json
       - extension/jdtls.ext/**/pom.xml
@@ -39,6 +40,7 @@ pr:
       - extension/jdtls.ext/mvnw
       - extension/jdtls.ext/mvnw.cmd
       - npm-package/build.gradle
+      - npm-package/.npmrc
       - npm-package/package.json
       - npm-package/package-lock.json
       - .azure-pipelines/vscode-gradle-ci.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    # CI restores packages from the Central Feed Service, which withholds
-    # upstream versions until they are roughly a week old (measured at ~6.8
-    # days; both the packument entry and the tarball return 404 before then).
-    # Dependabot's built-in cooldown is only 3 days, so bumps otherwise land in
-    # a window where the feed 404s and the build fails. 10 days leaves margin
-    # in case the feed's ingestion lag drifts.
-    cooldown:
-      default-days: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:


### PR DESCRIPTION
## Summary
- remove scheduled npm Dependabot version updates while keeping grouped GitHub Actions updates
- add a PR-only CFS validation job for the extension and npm package lockfiles
- validate Gradle dependency resolution and the existing Tycho/Maven build through CFS
- keep the existing full build, tests, VSIX packaging, and artifact publication for non-PR runs
- trigger the CFS gate only when dependency inputs or CFS pipeline configuration changes

## Why
The ADO build restores packages through CFS, where newly published upstream versions may not be available immediately. The current Dependabot PR can therefore pass GitHub Actions but fail the ADO build with a CFS 404. A dedicated PR gate checks actual feed availability before merge without running the full extension build.

## ADO
Updated [`microsoft.vscode-gradle.CI`](https://dev.azure.com/mseng/VSJava/_build?definitionId=11720) to use `develop`, the `microsoft (7)` GitHub connection, and automatic PR validation without requiring an `/azp run` comment.

There is no NuGet manifest in this repository. The gate covers the actual CFS consumers here: npm, Gradle dependency resolution, and Maven/Tycho.